### PR TITLE
fix: support generic custom endpoint verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added support for generic OpenAI-compatible custom verifiers via `HERMES_VAULT_VERIFY_URL_<SERVICE>` environment variables. Normalizes service names (replacing hyphens, dots, and spaces with underscores, and uppercasing) to form the environment variable name (e.g. `HERMES_VAULT_VERIFY_URL_DEEPSEEK`). Performs bearer-authenticated requests and sanitizes error reasons and transport exceptions for safety.
+
 ## 0.9.0 -- Profile, Verifier, and MCP Expansion
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ hermes-vault oauth providers
 ### Verifier plugin architecture
 v0.9.0 introduces a modular, file-based YAML verifier plugin system (under `src/hermes_vault/verifiers/`). This allows operators to define custom validation checks for new services and register them via entry points, while fully maintaining backward compatibility with built-in verifiers.
 
+Additionally, you can configure generic custom OpenAI-compatible verifiers via environment variables without creating plugins. Setting `HERMES_VAULT_VERIFY_URL_<SERVICE>` (with `<SERVICE>` normalising hyphens, dots, and spaces to underscores and converting to uppercase, e.g. `HERMES_VAULT_VERIFY_URL_DEEPSEEK`) will trigger a GET request to that URL using the credential as the bearer token (`Authorization: Bearer <secret>`).
+
 ### Multi-vault profile support
 Enables complete profile isolation via CLI flags like `--profile work` and `--profile personal`. Each profile manages its own isolated SQLite database, custom policies, OAuth registries, and verifier plugins. Pending OAuth states are scoped to prevent token pollution, and profile contexts propagate properly across worker threads (including MCP and local dashboard launches). Profiles support dedicated passphrases via environment variables like `HERMES_VAULT_PASSPHRASE_PROFILE`.
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -563,6 +563,19 @@ Keep `vault.db` and `master_key_salt.bin` together in backup procedures. A verif
 - Point it at an operator-validated authenticated GET endpoint that returns `200` for valid credentials and `401` or `403` for invalid ones
 - If you are testing an OpenAI-compatible MiniMax deployment, `/v1/models` is a candidate endpoint to validate, not an assumed contract
 
+### Custom OpenAI-Compatible Endpoints Verification
+
+Hermes Vault supports a generic, environment-driven OpenAI-compatible verifier for custom or unknown services. 
+
+- Define the environment variable `HERMES_VAULT_VERIFY_URL_<SERVICE>` to specify the verification URL for that service.
+- The service name is normalized: hyphens (`-`), dots (`.`), and spaces (` `) are translated to underscores (`_`), and the name is uppercased.
+  - For service `deepseek` -> `HERMES_VAULT_VERIFY_URL_DEEPSEEK`
+  - For service `fireworks` -> `HERMES_VAULT_VERIFY_URL_FIREWORKS`
+  - For service `custom-provider` -> `HERMES_VAULT_VERIFY_URL_CUSTOM_PROVIDER`
+- The endpoint is expected to be an OpenAI-compatible `/v1/models`-style endpoint.
+- Hermes Vault will send a GET request with the vaulted credential as the bearer token (`Authorization: Bearer <secret>`).
+- **Security Warning**: Ensure that the configured URL is trusted and provider-controlled, as the vault will send the decrypted bearer token to it.
+
 ### "Broker denied access"
 
 - Read the exact denial reason

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -565,7 +565,7 @@ Keep `vault.db` and `master_key_salt.bin` together in backup procedures. A verif
 
 ### Custom OpenAI-Compatible Endpoints Verification
 
-Hermes Vault supports a generic, environment-driven OpenAI-compatible verifier for custom or unknown services. 
+Hermes Vault supports a generic, environment-driven OpenAI-compatible verifier for custom or unknown services.
 
 - Define the environment variable `HERMES_VAULT_VERIFY_URL_<SERVICE>` to specify the verification URL for that service.
 - The service name is normalized: hyphens (`-`), dots (`.`), and spaces (` `) are translated to underscores (`_`), and the name is uppercased.

--- a/src/hermes_vault/verifier.py
+++ b/src/hermes_vault/verifier.py
@@ -259,6 +259,18 @@ class Verifier:
 
         adapter = getattr(self, f"_verify_{service}", None)
         if adapter is None:
+            env_var = f"HERMES_VAULT_VERIFY_URL_{service.replace('-', '_').replace('.', '_').replace(' ', '_').upper()}"
+            url = os.environ.get(env_var)
+            if url:
+                result = self._http_verify(ProviderVerifierConfig(
+                    service=service,
+                    url=url,
+                    headers={"Authorization": f"Bearer {secret}"},
+                ))
+                if result.status_code is not None and result.reason.startswith(f"Provider returned status {result.status_code}:"):
+                    result.reason = f"Provider returned status {result.status_code}."
+                return result
+
             return VerificationResult(
                 service=service,
                 category=VerificationCategory.unknown,

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -304,7 +304,7 @@ def test_plugin_protocol_exports_remain_available() -> None:
 def test_generic_verifier_normalization(monkeypatch) -> None:
     # Test normalization of service names to environment variables
     verifier = Verifier(load_file_plugins=False, load_entry_points=False)
-    
+
     captured_config = []
 
     def fake_http_verify(config):
@@ -343,7 +343,7 @@ def test_generic_verifier_normalization(monkeypatch) -> None:
 def test_generic_verifier_http_success(monkeypatch) -> None:
     import io
     import urllib.request
-    
+
     monkeypatch.setenv("HERMES_VAULT_VERIFY_URL_DEEPSEEK", "https://api.deepseek.com/v1/models")
     verifier = Verifier(load_file_plugins=False, load_entry_points=False)
 
@@ -384,7 +384,7 @@ def test_generic_verifier_http_success(monkeypatch) -> None:
 def test_generic_verifier_http_failures(monkeypatch) -> None:
     import io
     import urllib.request
-    
+
     monkeypatch.setenv("HERMES_VAULT_VERIFY_URL_FIREWORKS", "https://api.fireworks.ai/v1/models")
     verifier = Verifier(load_file_plugins=False, load_entry_points=False)
 
@@ -431,7 +431,7 @@ def test_generic_verifier_http_failures(monkeypatch) -> None:
 
 def test_generic_verifier_transport_failure(monkeypatch) -> None:
     import urllib.request
-    
+
     monkeypatch.setenv("HERMES_VAULT_VERIFY_URL_DEEPSEEK", "https://api.deepseek.com/v1/models")
     verifier = Verifier(load_file_plugins=False, load_entry_points=False)
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -299,3 +299,159 @@ def test_plugin_protocol_exports_remain_available() -> None:
     assert CredentialVerifierPlugin is not None
     assert VerifierContext is not None
     assert ProviderVerifierConfig is not None
+
+
+def test_generic_verifier_normalization(monkeypatch) -> None:
+    # Test normalization of service names to environment variables
+    verifier = Verifier(load_file_plugins=False, load_entry_points=False)
+    
+    captured_config = []
+
+    def fake_http_verify(config):
+        captured_config.append(config)
+        return VerificationResult(
+            service=config.service,
+            category=VerificationCategory.valid,
+            success=True,
+            reason="ok",
+        )
+
+    monkeypatch.setattr(verifier, "_http_verify", fake_http_verify)
+
+    # 1. service with hyphens
+    monkeypatch.setenv("HERMES_VAULT_VERIFY_URL_CUSTOM_PROVIDER", "https://api.custom.invalid/v1/models")
+    result = verifier.verify("custom-provider", "secret-value")
+    assert result.success is True
+    assert captured_config[-1].url == "https://api.custom.invalid/v1/models"
+    assert captured_config[-1].service == "custom-provider"
+
+    # 2. service with dots
+    monkeypatch.setenv("HERMES_VAULT_VERIFY_URL_MY_CUSTOM_PROVIDER", "https://api.dot.invalid/v1/models")
+    result = verifier.verify("my.custom.provider", "secret-value")
+    assert result.success is True
+    assert captured_config[-1].url == "https://api.dot.invalid/v1/models"
+    assert captured_config[-1].service == "my.custom.provider"
+
+    # 3. service with spaces and mixed case
+    monkeypatch.setenv("HERMES_VAULT_VERIFY_URL_MY_SPACE_PROVIDER", "https://api.space.invalid/v1/models")
+    result = verifier.verify("my space provider", "secret-value")
+    assert result.success is True
+    assert captured_config[-1].url == "https://api.space.invalid/v1/models"
+    assert captured_config[-1].service == "my space provider"
+
+
+def test_generic_verifier_http_success(monkeypatch) -> None:
+    import io
+    import urllib.request
+    
+    monkeypatch.setenv("HERMES_VAULT_VERIFY_URL_DEEPSEEK", "https://api.deepseek.com/v1/models")
+    verifier = Verifier(load_file_plugins=False, load_entry_points=False)
+
+    class FakeResponse:
+        def __init__(self, code, body):
+            self.code = code
+            self.body = body
+            self.headers = {}
+        def getcode(self):
+            return self.code
+        def read(self):
+            return self.body
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    captured_req = []
+
+    def fake_urlopen(req, timeout=None):
+        captured_req.append(req)
+        return FakeResponse(200, b'{"models": []}')
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    result = verifier.verify("deepseek", "sentinel-secret-token")
+    assert result.success is True
+    assert result.category is VerificationCategory.valid
+    assert result.status_code == 200
+    assert result.reason == "Credential verified successfully."
+
+    assert len(captured_req) == 1
+    req = captured_req[0]
+    assert req.full_url == "https://api.deepseek.com/v1/models"
+    assert req.get_header("Authorization") == "Bearer sentinel-secret-token"
+
+
+def test_generic_verifier_http_failures(monkeypatch) -> None:
+    import io
+    import urllib.request
+    
+    monkeypatch.setenv("HERMES_VAULT_VERIFY_URL_FIREWORKS", "https://api.fireworks.ai/v1/models")
+    verifier = Verifier(load_file_plugins=False, load_entry_points=False)
+
+    current_status = 401
+    current_body = b"{}"
+
+    def fake_urlopen(req, timeout=None):
+        fp = io.BytesIO(current_body)
+        raise urllib.error.HTTPError(req.full_url, current_status, "HTTP Error", {}, fp)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    # Test 401 -> invalid_or_expired
+    current_status = 401
+    current_body = b'{"error": "Unauthorized"}'
+    result = verifier.verify("fireworks", "token")
+    assert result.success is False
+    assert result.category is VerificationCategory.invalid_or_expired
+    assert result.status_code == 401
+    assert "Unauthorized" not in result.reason
+    assert "token" not in result.reason
+
+    # Test 403 -> permission_scope_issue
+    current_status = 403
+    current_body = b'{"error": "Forbidden"}'
+    result = verifier.verify("fireworks", "token")
+    assert result.success is False
+    assert result.category is VerificationCategory.permission_scope_issue
+    assert result.status_code == 403
+    assert "Forbidden" not in result.reason
+    assert "token" not in result.reason
+
+    # Test 500 -> unknown, body sanitized (not exposed at all)
+    current_status = 500
+    current_body = b'{"error": "internal error", "sensitive_key": "some_value"}'
+    result = verifier.verify("fireworks", "token")
+    assert result.success is False
+    assert result.category is VerificationCategory.unknown
+    assert result.status_code == 500
+    assert result.reason == "Provider returned status 500."
+    assert "sensitive_key" not in result.reason
+    assert "some_value" not in result.reason
+
+
+def test_generic_verifier_transport_failure(monkeypatch) -> None:
+    import urllib.request
+    
+    monkeypatch.setenv("HERMES_VAULT_VERIFY_URL_DEEPSEEK", "https://api.deepseek.com/v1/models")
+    verifier = Verifier(load_file_plugins=False, load_entry_points=False)
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    result = verifier.verify("deepseek", "token")
+    assert result.success is False
+    assert result.category is VerificationCategory.network_failure
+    assert "URLError" in result.reason
+    assert "connection refused" not in result.reason  # sanitized to class name only in reason
+    assert "token" not in result.reason
+
+
+def test_generic_verifier_missing_env_var() -> None:
+    verifier = Verifier(load_file_plugins=False, load_entry_points=False)
+    # Check that without the env var, we fall back to unsupported result
+    result = verifier.verify("deepseek", "token")
+    assert result.success is False
+    assert result.category is VerificationCategory.unknown
+    assert result.reason == "No provider-specific verifier is configured for this service."


### PR DESCRIPTION
Fixes #16

### Summary
Introduces a generic, environment-driven OpenAI-compatible verifier fallback for unknown or custom services. 
When a custom service name (e.g. `deepseek`) has a matching environment variable `HERMES_VAULT_VERIFY_URL_<SERVICE>` (e.g. `HERMES_VAULT_VERIFY_URL_DEEPSEEK`), it will perform a GET request with the vaulted credential mapped as the bearer token (`Authorization: Bearer <secret>`).

### Security Notes
- Ensures that decrypted credentials are never leaked in logs, test outputs, or error details.
- Avoids exposing raw response bodies from custom endpoints to the user (instead returning coarse status code results such as `Provider returned status 500.` without leaking body content).
- Exception tracebacks and details are sanitized to their class name only.
- Added a warning note to operators that configured endpoints must be trusted, as the decrypted token is sent directly to them.

### Tests Run
- Added focused unit tests in `tests/test_verifier.py` validating:
  - Environment variable name normalization (translating hyphens, dots, and spaces to underscores and uppercasing).
  - Successful mock verification (200 OK) with the correct Authorization header format.
  - Failures (401 mapping to `invalid_or_expired`, 403 mapping to `permission_scope_issue`).
  - Safe representation of custom/internal response bodies (500 response body contents are sanitized and not leaked).
  - Transport failure sanitization (URLError details are hidden and class name is reported).
  - Missing environment variable fallback logic (returning "No provider-specific verifier is configured").
- Ran the entire test suite: `585 passed` (all tests pass).

### Example Env Vars
- `HERMES_VAULT_VERIFY_URL_DEEPSEEK=https://api.deepseek.com/v1/models`
- `HERMES_VAULT_VERIFY_URL_FIREWORKS=https://api.fireworks.ai/v1/models`