### PR TITLE
feat(oauth): add device-code login flow

### DIFF
--- a/src/hermes_vault/cli.py
+++ b/src/hermes_vault/cli.py
@@ -2011,15 +2011,16 @@ def oauth_login(
     alias: str = typer.Option("default", "--alias", help="Vault alias for the stored credential."),
     port: int = typer.Option(0, "--port", help="Callback server port. 0 = OS-assigned ephemeral."),
     timeout: int = typer.Option(120, "--timeout", help="Seconds to wait for the OAuth callback before aborting."),
-    no_browser: bool = typer.Option(False, "--no-browser", help="Skip auto-opening browser; print URL instead."),
+    no_browser: bool = typer.Option(False, "--no-browser", help="Skip auto-opening browser; print the browser PKCE URL instead (use `oauth device-login` for device-code auth)."),
     scopes: list[str] = typer.Option(None, "--scope", help="Override requested OAuth scopes (repeatable)."),
 ) -> None:
-    """Log in via OAuth PKCE and store tokens in the vault.
+    """Log in via browser PKCE and store tokens in the vault.
 
     \b
     Examples:
       hermes-vault oauth login google --alias work
       hermes-vault oauth login github --alias personal --no-browser
+      hermes-vault oauth device-login google --alias work
       hermes-vault oauth login google --scope openid --scope email --scope profile
     """
     from hermes_vault.oauth.flow import LoginFlow
@@ -2030,6 +2031,36 @@ def oauth_login(
             port=port,
             timeout=timeout,
             no_browser=no_browser,
+            scopes=list(scopes or []),
+            console=console,
+        )
+        flow.run()
+    except Exception as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+
+@oauth_app.command("device-login")
+def oauth_device_login(
+    ctx: typer.Context,
+    provider: str = typer.Argument(help="OAuth provider name with device-code support (e.g. google, github)."),
+    alias: str = typer.Option("default", "--alias", help="Vault alias for the stored credential."),
+    timeout: int = typer.Option(300, "--timeout", help="Seconds to wait for the device-code authorization before aborting."),
+    scopes: list[str] = typer.Option(None, "--scope", help="Override requested OAuth scopes (repeatable)."),
+) -> None:
+    """Log in via OAuth device-code flow and store tokens in the vault.
+
+    \b
+    Examples:
+      hermes-vault oauth device-login google --alias work
+      hermes-vault oauth device-login github --scope repo --scope read:org
+    """
+    from hermes_vault.oauth.device import DeviceLoginFlow
+    try:
+        flow = DeviceLoginFlow(
+            provider_id=provider,
+            alias=alias,
+            timeout=timeout,
             scopes=list(scopes or []),
             console=console,
         )
@@ -2051,6 +2082,7 @@ def oauth_providers(ctx: typer.Context) -> None:
     table.add_column("Name")
     table.add_column("Requires Client ID")
     table.add_column("Requires Client Secret")
+    table.add_column("Device Code")
     for pid in registry.list_providers():
         p = registry.get(pid)
         if p is None:
@@ -2060,6 +2092,7 @@ def oauth_providers(ctx: typer.Context) -> None:
             p.name,
             "yes" if p.requires_client_id else "no",
             "yes" if p.requires_client_secret else "no",
+            "yes" if p.device_authorization_endpoint else "no",
         )
     console.print(table)
 

--- a/src/hermes_vault/oauth/device.py
+++ b/src/hermes_vault/oauth/device.py
@@ -1,0 +1,190 @@
+"""Device-code OAuth login flow for Hermes Vault."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+from rich.console import Console
+
+from hermes_vault.oauth.errors import (
+    OAuthDeniedError,
+    OAuthMissingClientIdError,
+    OAuthProviderError,
+    OAuthTimeoutError,
+)
+from hermes_vault.oauth.exchange import TokenExchanger
+from hermes_vault.oauth.flow import _store_oauth_tokens
+from hermes_vault.oauth.providers import OAuthProviderRegistry
+from hermes_vault.vault import Vault
+
+
+class DeviceLoginFlow:
+    """Executes a device-code OAuth login flow.
+
+    The flow is explicit and browser-free, so it is safe to use on devices
+    that cannot open a browser or when operators prefer a manual approval step.
+    """
+
+    def __init__(
+        self,
+        provider_id: str,
+        alias: str = "default",
+        timeout: int = 300,
+        scopes: list[str] | None = None,
+        console: Console | None = None,
+        vault: Vault | None = None,
+        mutations=None,
+        registry: OAuthProviderRegistry | None = None,
+        sleep_fn: Callable[[float], None] | None = None,
+        clock_fn: Callable[[], float] | None = None,
+    ) -> None:
+        self.provider_id = provider_id
+        self.alias = alias
+        self.timeout = timeout
+        self.scopes = scopes or []
+        self.console = console or Console()
+        self.vault = vault
+        self.mutations = mutations
+        self._registry = registry
+        self.sleep_fn = sleep_fn or time.sleep
+        self.clock_fn = clock_fn or time.monotonic
+
+    @property
+    def registry(self) -> OAuthProviderRegistry:
+        if self._registry is None:
+            from hermes_vault.config import get_settings
+
+            settings = get_settings()
+            self._registry = OAuthProviderRegistry(
+                settings.runtime_home / "oauth-providers.yaml",
+            )
+        return self._registry
+
+    def run(self) -> None:
+        """Execute the full device-code login flow."""
+        provider = self.registry.get(self.provider_id)
+        if provider is None:
+            known = self.registry.list_providers()
+            raise OAuthProviderError(
+                f"Unknown OAuth provider '{self.provider_id}'. "
+                f"Known providers: {', '.join(known) or 'none'}"
+            )
+
+        if provider.device_authorization_endpoint is None:
+            supported = self.registry.list_device_code_providers()
+            raise OAuthProviderError(
+                f"Provider '{provider.service_id}' does not support device-code login. "
+                f"Supported providers: {', '.join(supported) or 'none'}"
+            )
+
+        client_id, client_secret = self.registry.get_client_credentials(provider)
+        if provider.requires_client_id and not client_id:
+            raise OAuthMissingClientIdError(
+                f"Provider '{provider.service_id}' requires a client_id. "
+                f"Set HERMES_VAULT_OAUTH_{provider.service_id.upper()}_CLIENT_ID."
+            )
+
+        requested_scopes = self.scopes if self.scopes else provider.default_scopes
+        scope_str = provider.scope_separator.join(requested_scopes)
+        exchanger = TokenExchanger(provider)
+
+        with self.console.status("[bold green]Requesting device-code login...", spinner="dots"):
+            device_response = exchanger.request_device_code(
+                client_id=client_id or "",
+                scope=scope_str,
+                client_secret=client_secret,
+                extra_params=getattr(provider, "device_extra_params", None) or None,
+            )
+
+        if device_response.message:
+            self.console.print(device_response.message)
+        else:
+            self.console.print(
+                f"Visit [bold cyan]{device_response.verification_uri}[/bold cyan] and enter code "
+                f"[bold]{device_response.user_code}[/bold]."
+            )
+        if device_response.verification_uri_complete:
+            self.console.print(
+                f"Direct link: {device_response.verification_uri_complete}"
+            )
+        self.console.print(
+            f"Polling every {max(1, device_response.interval)}s for up to {self.timeout}s."
+        )
+
+        poll_interval = max(1, device_response.interval or 5)
+        deadline = self.clock_fn() + self.timeout
+        token_response = None
+
+        while True:
+            if self.clock_fn() >= deadline:
+                raise OAuthTimeoutError(
+                    f"Timed out after {self.timeout}s. Device authorization was not completed."
+                )
+
+            poll_result = exchanger.poll_device_code(
+                device_code=device_response.device_code,
+                client_id=client_id or "",
+                client_secret=client_secret,
+            )
+
+            if poll_result.status == "success":
+                token_response = poll_result.token_response
+                assert token_response is not None
+                break
+
+            if poll_result.status == "authorization_pending":
+                self.console.print("[yellow]Waiting for device authorization...[/yellow]")
+            elif poll_result.status == "slow_down":
+                poll_interval += poll_result.retry_after or 5
+                self.console.print(
+                    f"[yellow]Provider asked us to slow down. Polling every {poll_interval}s.[/yellow]"
+                )
+            elif poll_result.status == "access_denied":
+                raise OAuthDeniedError("Authorization denied by user or provider.")
+            elif poll_result.status == "expired_token":
+                raise OAuthTimeoutError(
+                    "Device code expired before authorization completed."
+                )
+            else:
+                raise OAuthProviderError(
+                    f"Device token polling failed: {poll_result.status} — {poll_result.error_description or ''}"
+                )
+
+            remaining = deadline - self.clock_fn()
+            if remaining <= 0:
+                raise OAuthTimeoutError(
+                    f"Timed out after {self.timeout}s. Device authorization was not completed."
+                )
+            self.sleep_fn(min(poll_interval, remaining))
+
+        if not self.mutations or not self.vault:
+            vault, _policy, _broker, mutations = self._build_services()
+            self.vault = vault
+            self.mutations = mutations
+
+        record = _store_oauth_tokens(
+            provider=provider,
+            alias=self.alias,
+            requested_scopes=requested_scopes,
+            token_response=token_response,
+            vault=self.vault,
+            mutations=self.mutations,
+            console=self.console,
+        )
+
+        msg = (
+            f"Stored OAuth credential [cyan]{record.id}[/cyan] "
+            f"for [bold]{provider.service_id}[/bold] alias '{self.alias}'."
+        )
+        self.console.print(f"[green]{msg}[/green]")
+        if token_response.expires_in:
+            self.console.print(
+                f"[yellow]Access token expires in {token_response.expires_in}s. "
+                f"Run `hermes-vault oauth refresh {provider.service_id} --alias {self.alias}` before expiry.[/yellow]"
+            )
+
+    def _build_services(self) -> tuple:
+        from hermes_vault.cli import build_services
+
+        return build_services(prompt=True)

--- a/src/hermes_vault/oauth/exchange.py
+++ b/src/hermes_vault/oauth/exchange.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any
 
@@ -12,24 +13,16 @@ from hermes_vault.oauth.errors import OAuthNetworkError, OAuthProviderError
 from hermes_vault.oauth.providers import OAuthProvider
 
 
+@dataclass(slots=True)
 class TokenResponse:
     """Response from a successful token exchange."""
 
-    def __init__(
-        self,
-        access_token: str,
-        token_type: str,
-        expires_in: int | None,
-        refresh_token: str | None,
-        scope: str | None,
-        raw: dict[str, Any],
-    ) -> None:
-        self.access_token = access_token
-        self.token_type = token_type
-        self.expires_in = expires_in
-        self.refresh_token = refresh_token
-        self.scope = scope
-        self.raw = raw
+    access_token: str
+    token_type: str
+    expires_in: int | None
+    refresh_token: str | None
+    scope: str | None
+    raw: dict[str, Any]
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> "TokenResponse":
@@ -60,6 +53,31 @@ class TokenResponse:
         if scopes:
             metadata["scopes"] = scopes
         return CredentialSecret(secret=self.access_token, metadata=metadata)
+
+
+@dataclass(slots=True)
+class DeviceAuthorizationResponse:
+    """Response returned by a device-code authorization endpoint."""
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str | None
+    expires_in: int
+    interval: int
+    message: str | None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class DevicePollResult:
+    """Response returned by a device-code token polling request."""
+
+    status: str
+    token_response: TokenResponse | None = None
+    error_description: str | None = None
+    retry_after: int | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
 
 
 class TokenExchanger:
@@ -115,11 +133,7 @@ class TokenExchanger:
         except requests.RequestException as exc:
             raise OAuthNetworkError(f"Token exchange failed: {exc}") from exc
 
-        try:
-            data = resp.json()
-        except Exception:
-            # Some legacy endpoints send URL-encoded text
-            data = _parse_url_encoded_body(resp.text)
+        data = _parse_response_payload(resp)
 
         if "error" in data:
             raise OAuthProviderError(
@@ -137,12 +151,180 @@ class TokenExchanger:
 
         return TokenResponse.from_json(data)
 
+    def request_device_code(
+        self,
+        *,
+        client_id: str,
+        scope: str,
+        client_secret: str | None = None,
+        extra_params: dict[str, str] | None = None,
+    ) -> DeviceAuthorizationResponse:
+        """Request a device/user code from the provider."""
+        if getattr(self.provider, "device_authorization_endpoint", None) is None:
+            raise OAuthProviderError(
+                f"Provider '{self.provider.service_id}' does not support device-code login."
+            )
+
+        payload: dict[str, str] = {
+            "client_id": client_id,
+            "scope": scope,
+        }
+        if client_secret is not None:
+            payload["client_secret"] = client_secret
+        for key, value in (extra_params or {}).items():
+            payload[key] = value
+
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        try:
+            resp = requests.post(
+                str(self.provider.device_authorization_endpoint),
+                data=payload,
+                headers=headers,
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise OAuthNetworkError(f"Device authorization failed: {exc}") from exc
+
+        data = _parse_response_payload(resp)
+        if "error" in data:
+            raise OAuthProviderError(
+                f"Device authorization error: {data.get('error')} — {data.get('error_description', '')}"
+            )
+
+        if not resp.ok:
+            raise OAuthProviderError(
+                f"Device authorization error: HTTP {resp.status_code} — {resp.text}"
+            )
+
+        device_code = data.get("device_code")
+        user_code = data.get("user_code")
+        verification_uri = data.get("verification_uri") or data.get("verification_url")
+        if not device_code or not user_code or not verification_uri:
+            raise OAuthProviderError(
+                "Device authorization response missing required fields"
+            )
+
+        return DeviceAuthorizationResponse(
+            device_code=str(device_code),
+            user_code=str(user_code),
+            verification_uri=str(verification_uri),
+            verification_uri_complete=(
+                str(data.get("verification_uri_complete"))
+                if data.get("verification_uri_complete")
+                else None
+            ),
+            expires_in=_coerce_int(data.get("expires_in"), default=0),
+            interval=_coerce_int(data.get("interval"), default=5),
+            message=str(data.get("message")) if data.get("message") else None,
+            raw=data,
+        )
+
+    def poll_device_code(
+        self,
+        *,
+        device_code: str,
+        client_id: str,
+        client_secret: str | None = None,
+    ) -> DevicePollResult:
+        """Poll the token endpoint using the device-code grant."""
+        payload: dict[str, str] = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": device_code,
+            "client_id": client_id,
+        }
+        if client_secret is not None:
+            payload["client_secret"] = client_secret
+
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        try:
+            resp = requests.post(
+                str(self.provider.token_endpoint),
+                data=payload,
+                headers=headers,
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise OAuthNetworkError(f"Device token polling failed: {exc}") from exc
+
+        data = _parse_response_payload(resp)
+        error = data.get("error")
+        if error == "authorization_pending":
+            return DevicePollResult(
+                status="authorization_pending",
+                error_description=data.get("error_description"),
+                raw=data,
+            )
+        if error == "slow_down":
+            return DevicePollResult(
+                status="slow_down",
+                error_description=data.get("error_description"),
+                retry_after=5,
+                raw=data,
+            )
+        if error == "access_denied":
+            return DevicePollResult(
+                status="access_denied",
+                error_description=data.get("error_description"),
+                raw=data,
+            )
+        if error == "expired_token":
+            return DevicePollResult(
+                status="expired_token",
+                error_description=data.get("error_description"),
+                raw=data,
+            )
+        if error:
+            raise OAuthProviderError(
+                f"Token endpoint error: {error} — {data.get('error_description', '')}"
+            )
+
+        if not resp.ok:
+            raise OAuthProviderError(
+                f"Token endpoint error: HTTP {resp.status_code} — {resp.text}"
+            )
+
+        access_token = data.get("access_token")
+        if not access_token:
+            raise OAuthProviderError("Token endpoint response missing access_token")
+
+        return DevicePollResult(
+            status="success",
+            token_response=TokenResponse.from_json(data),
+            raw=data,
+        )
+
 
 def _parse_url_encoded_body(text: str) -> dict[str, str]:
     """Best-effort parse for URL-encoded responses (e.g., GitHub legacy)."""
     from urllib.parse import parse_qs
+
     result = parse_qs(text.strip())
     return {k: v[0] if len(v) == 1 else " ".join(v) for k, v in result.items()}
+
+
+def _parse_response_payload(resp: requests.Response) -> dict[str, Any]:
+    try:
+        data = resp.json()
+    except Exception:
+        data = _parse_url_encoded_body(resp.text)
+    return data if isinstance(data, dict) else {}
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        if value is None:
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def _parse_scope_list(scope: str | None) -> list[str]:

--- a/src/hermes_vault/oauth/flow.py
+++ b/src/hermes_vault/oauth/flow.py
@@ -9,11 +9,10 @@ from __future__ import annotations
 import urllib.parse
 import webbrowser
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 from rich.console import Console
 
-from hermes_vault.models import CredentialSecret, CredentialStatus
+from hermes_vault.models import CredentialSecret
 from hermes_vault.mutations import OPERATOR_AGENT_ID, VaultMutations
 from hermes_vault.oauth.callback import CallbackServer
 from hermes_vault.oauth.errors import (
@@ -23,12 +22,70 @@ from hermes_vault.oauth.errors import (
     OAuthStateMismatchError,
     OAuthTimeoutError,
 )
-from hermes_vault.oauth.exchange import TokenExchanger
+from hermes_vault.oauth.exchange import TokenExchanger, TokenResponse
 from hermes_vault.oauth.pkce import PKCEGenerator
 from hermes_vault.oauth.providers import OAuthProviderRegistry
 from hermes_vault.oauth.oauth_refresh import refresh_alias_for
 from hermes_vault.oauth.state import StateManager
 from hermes_vault.vault import Vault
+
+
+def _store_oauth_tokens(
+    *,
+    provider,
+    alias: str,
+    requested_scopes: list[str],
+    token_response: TokenResponse,
+    vault: Vault,
+    mutations: VaultMutations,
+    console: Console,
+):
+    """Persist the access token and optional refresh token using the canonical storage shape."""
+    credential_secret = token_response.to_credential_secret(provider)
+    with console.status("[bold green]Storing credential...", spinner="dots"):
+        result_mutation = mutations.add_credential(
+            agent_id=OPERATOR_AGENT_ID,
+            service=provider.service_id,
+            secret=credential_secret.secret,
+            credential_type="oauth_access_token",
+            alias=alias,
+            scopes=requested_scopes,
+            metadata=credential_secret.metadata,
+            replace_existing=True,
+        )
+
+    if not result_mutation.allowed:
+        raise OAuthProviderError(
+            f"Vault refused credential storage: {result_mutation.reason}"
+        )
+
+    record = result_mutation.record
+    assert record is not None
+
+    if token_response.expires_in is not None:
+        expiry = datetime.now(timezone.utc) + timedelta(seconds=token_response.expires_in)
+        vault.set_expiry(record.id, expiry)
+
+    if token_response.refresh_token:
+        refresh_secret = CredentialSecret(
+            secret=token_response.refresh_token,
+            metadata={
+                "associated_access_token_alias": alias,
+                "provider": provider.service_id,
+            },
+        )
+        mutations.add_credential(
+            agent_id=OPERATOR_AGENT_ID,
+            service=provider.service_id,
+            secret=refresh_secret.secret,
+            credential_type="oauth_refresh_token",
+            alias=refresh_alias_for(alias),
+            scopes=requested_scopes,
+            metadata=refresh_secret.metadata,
+            replace_existing=True,
+        )
+
+    return record
 
 
 class LoginFlow:
@@ -142,7 +199,10 @@ class LoginFlow:
                     f"[yellow]Could not open browser automatically. Open this URL:[/yellow]\n{auth_url}"
                 )
         else:
-            self.console.print(f"Open this URL in your browser:\n{auth_url}")
+            self.console.print(
+                f"Open this URL in your browser to continue the browser PKCE flow:\n{auth_url}\n"
+                f"For no-browser device-code login, use `hermes-vault oauth device-login {provider.service_id}`."
+            )
 
         # ── 7. Wait for callback ───────────────────────────────────────────
         with self.console.status("[bold green]Waiting for browser authorization...", spinner="dots"):
@@ -181,56 +241,20 @@ class LoginFlow:
 
         if not self.mutations or not self.vault:
             # CLI mode: build services now
-            vault, policy, _broker, mutations = self._build_services()
+            vault, _policy, _broker, mutations = self._build_services()
             self.vault = vault
             self.mutations = mutations
 
         # ── 10. Store in vault ───────────────────────────────────────────
-        credential_secret = token_response.to_credential_secret(provider)
-        with self.console.status("[bold green]Storing credential...", spinner="dots"):
-            result_mutation = self.mutations.add_credential(
-                agent_id=OPERATOR_AGENT_ID,
-                service=provider.service_id,
-                secret=credential_secret.secret,
-                credential_type="oauth_access_token",
-                alias=self.alias,
-                scopes=requested_scopes,
-                metadata=credential_secret.metadata,
-                replace_existing=True,
-            )
-
-        if not result_mutation.allowed:
-            raise OAuthProviderError(
-                f"Vault refused credential storage: {result_mutation.reason}"
-            )
-
-        record = result_mutation.record
-        assert record is not None
-
-        # Set expiry if provider returned one
-        if token_response.expires_in is not None:
-            expiry = datetime.now(timezone.utc) + timedelta(seconds=token_response.expires_in)
-            self.vault.set_expiry(record.id, expiry)
-
-        # Store refresh token separately at an alias-scoped refresh record
-        if token_response.refresh_token:
-            refresh_secret = CredentialSecret(
-                secret=token_response.refresh_token,
-                metadata={
-                    "associated_access_token_alias": self.alias,
-                    "provider": provider.service_id,
-                },
-            )
-            self.mutations.add_credential(
-                agent_id=OPERATOR_AGENT_ID,
-                service=provider.service_id,
-                secret=refresh_secret.secret,
-                credential_type="oauth_refresh_token",
-                alias=refresh_alias_for(self.alias),
-                scopes=requested_scopes,
-                metadata=refresh_secret.metadata,
-                replace_existing=True,
-            )
+        record = _store_oauth_tokens(
+            provider=provider,
+            alias=self.alias,
+            requested_scopes=requested_scopes,
+            token_response=token_response,
+            vault=self.vault,
+            mutations=self.mutations,
+            console=self.console,
+        )
 
         # ── 11. Success ────────────────────────────────────────────────────
         msg = (

--- a/src/hermes_vault/oauth/providers.py
+++ b/src/hermes_vault/oauth/providers.py
@@ -18,11 +18,13 @@ class OAuthProvider(BaseModel):
     service_id: str
     name: str
     authorization_endpoint: HttpUrl
+    device_authorization_endpoint: HttpUrl | None = None
     token_endpoint: HttpUrl
     default_scopes: list[str] = Field(default_factory=list)
     scope_separator: str = " "
     use_pkce: bool = True
     extra_params: dict[str, str] = Field(default_factory=dict)
+    device_extra_params: dict[str, str] = Field(default_factory=dict)
     requires_client_id: bool = False
     requires_client_secret: bool = False
 
@@ -83,6 +85,14 @@ class OAuthProviderRegistry:
         """Return sorted list of registered provider IDs."""
         return sorted(self._providers.keys())
 
+    def list_device_code_providers(self) -> list[str]:
+        """Return the provider IDs that support device-code login."""
+        return sorted(
+            sid
+            for sid, provider in self._providers.items()
+            if provider.device_authorization_endpoint is not None
+        )
+
     def get_client_credentials(self, provider: OAuthProvider) -> tuple[str | None, str | None]:
         """Read client_id and client_secret from environment variables.
 
@@ -103,6 +113,7 @@ providers:
   google:
     name: "Google"
     authorization_endpoint: "https://accounts.google.com/o/oauth2/v2/auth"
+    device_authorization_endpoint: "https://oauth2.googleapis.com/device/code"
     token_endpoint: "https://oauth2.googleapis.com/token"
     default_scopes:
       - "openid"
@@ -117,6 +128,7 @@ providers:
   github:
     name: "GitHub"
     authorization_endpoint: "https://github.com/login/oauth/authorize"
+    device_authorization_endpoint: "https://github.com/login/device/code"
     token_endpoint: "https://github.com/login/oauth/access_token"
     default_scopes:
       - "repo"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,6 +228,44 @@ def test_maintain_print_systemd(monkeypatch) -> None:
     assert "hermes-vault --no-banner maintain --format json" in result.output
 
 
+def test_oauth_device_login_invokes_device_flow(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeFlow:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run(self):
+            captured["ran"] = True
+
+    monkeypatch.setattr("hermes_vault.oauth.device.DeviceLoginFlow", FakeFlow)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        _hermes_group,
+        ["oauth", "device-login", "google", "--alias", "work", "--scope", "openid", "--scope", "email"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["provider_id"] == "google"
+    assert captured["alias"] == "work"
+    assert captured["timeout"] == 300
+    assert captured["scopes"] == ["openid", "email"]
+    assert captured["ran"] is True
+
+
+def test_oauth_providers_shows_device_code_support(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HERMES_VAULT_HOME", str(tmp_path))
+
+    runner = CliRunner()
+    result = runner.invoke(_hermes_group, ["oauth", "providers"])
+
+    assert result.exit_code == 0
+    assert "Device Code" in result.output
+    assert "google" in result.output
+    assert "github" in result.output
+
+
 def test_oauth_normalize_json_output(monkeypatch) -> None:
     monkeypatch.setattr("hermes_vault.cli.build_services", _fake_build_services())
 

--- a/tests/test_oauth_device.py
+++ b/tests/test_oauth_device.py
@@ -1,0 +1,340 @@
+"""Tests for the explicit OAuth device-code login flow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_vault.models import CredentialRecord, MutationResult
+from hermes_vault.oauth.device import DeviceLoginFlow
+from hermes_vault.oauth.errors import OAuthDeniedError, OAuthProviderError, OAuthTimeoutError
+from hermes_vault.oauth.exchange import DeviceAuthorizationResponse, DevicePollResult, TokenExchanger, TokenResponse
+from hermes_vault.oauth.oauth_refresh import refresh_alias_for
+from hermes_vault.oauth.providers import OAuthProvider, OAuthProviderRegistry
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _FakeRegistry:
+    def __init__(self, provider: OAuthProvider, client_id: str = "test-client-id", client_secret: str | None = None) -> None:
+        self._provider = provider
+        self.get = MagicMock(return_value=provider)
+        self.list_providers = MagicMock(return_value=[provider.service_id])
+        self.list_device_code_providers = MagicMock(
+            return_value=[provider.service_id] if provider.device_authorization_endpoint else []
+        )
+        self.get_client_credentials = MagicMock(return_value=(client_id, client_secret))
+
+
+class _FakeMutations:
+    def __init__(self, record_id: str = "cred-123") -> None:
+        self.record_id = record_id
+        self.calls: list[dict] = []
+
+    def add_credential(self, **kwargs):
+        self.calls.append(kwargs)
+        record = CredentialRecord(
+            id=self.record_id,
+            service=kwargs["service"],
+            alias=kwargs["alias"],
+            credential_type=kwargs["credential_type"],
+            encrypted_payload="encrypted",
+            scopes=kwargs.get("scopes") or [],
+        )
+        return MutationResult(
+            allowed=True,
+            service=kwargs["service"],
+            agent_id=kwargs["agent_id"],
+            action="add_credential",
+            reason="ok",
+            record=record,
+        )
+
+
+class _FakeVault:
+    def __init__(self) -> None:
+        self.set_expiry = MagicMock(return_value=None)
+
+
+@pytest.fixture
+def device_provider() -> OAuthProvider:
+    return OAuthProvider(
+        service_id="google",
+        name="Google",
+        authorization_endpoint="https://accounts.google.com/o/oauth2/v2/auth",
+        device_authorization_endpoint="https://oauth2.googleapis.com/device/code",
+        token_endpoint="https://oauth2.googleapis.com/token",
+        default_scopes=["openid", "email"],
+        requires_client_id=True,
+    )
+
+
+class TestOAuthProviderRegistryDeviceSupport:
+    def test_default_registry_lists_device_code_providers(self, tmp_path: Path) -> None:
+        registry = OAuthProviderRegistry(tmp_path / "providers.yaml")
+
+        providers = registry.list_device_code_providers()
+
+        assert "google" in providers
+        assert "github" in providers
+        assert "openai" not in providers
+
+
+class TestDeviceCodeExchange:
+    def test_request_device_code_builds_payload(self, device_provider: OAuthProvider) -> None:
+        exchanger = TokenExchanger(device_provider)
+        fake_resp = MagicMock()
+        fake_resp.ok = True
+        fake_resp.json.return_value = {
+            "device_code": "dev-123",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://example.com/device",
+            "verification_uri_complete": "https://example.com/device?user_code=ABCD-EFGH",
+            "expires_in": 900,
+            "interval": 5,
+            "message": "Visit the URL and enter the code.",
+        }
+        fake_resp.status_code = 200
+        fake_resp.text = ""
+
+        with patch("hermes_vault.oauth.exchange.requests.post", return_value=fake_resp) as mock_post:
+            response = exchanger.request_device_code(client_id="client-123", scope="openid email")
+
+        assert isinstance(response, DeviceAuthorizationResponse)
+        assert response.device_code == "dev-123"
+        assert response.user_code == "ABCD-EFGH"
+        assert response.verification_uri == "https://example.com/device"
+        assert response.verification_uri_complete == "https://example.com/device?user_code=ABCD-EFGH"
+        assert response.expires_in == 900
+        assert response.interval == 5
+        assert response.message == "Visit the URL and enter the code."
+
+        call_kwargs = mock_post.call_args[1]
+        assert call_kwargs["data"]["client_id"] == "client-123"
+        assert call_kwargs["data"]["scope"] == "openid email"
+        assert "grant_type" not in call_kwargs["data"]
+
+    def test_poll_device_code_parses_pending_slow_down_and_success(self, device_provider: OAuthProvider) -> None:
+        exchanger = TokenExchanger(device_provider)
+        pending_resp = MagicMock()
+        pending_resp.ok = False
+        pending_resp.json.return_value = {"error": "authorization_pending"}
+        pending_resp.status_code = 400
+        pending_resp.text = ""
+
+        slow_resp = MagicMock()
+        slow_resp.ok = False
+        slow_resp.json.return_value = {"error": "slow_down", "error_description": "poll slower"}
+        slow_resp.status_code = 400
+        slow_resp.text = ""
+
+        success_resp = MagicMock()
+        success_resp.ok = True
+        success_resp.json.return_value = {
+            "access_token": "tok",
+            "token_type": "Bearer",
+            "refresh_token": "ref",
+            "scope": "openid email",
+        }
+        success_resp.status_code = 200
+        success_resp.text = ""
+
+        with patch(
+            "hermes_vault.oauth.exchange.requests.post",
+            side_effect=[pending_resp, slow_resp, success_resp],
+        ):
+            pending = exchanger.poll_device_code(device_code="dev-123", client_id="client-123")
+            slow = exchanger.poll_device_code(device_code="dev-123", client_id="client-123")
+            success = exchanger.poll_device_code(device_code="dev-123", client_id="client-123")
+
+        assert pending.status == "authorization_pending"
+        assert slow.status == "slow_down"
+        assert slow.retry_after == 5
+        assert success.status == "success"
+        assert success.token_response is not None
+        assert success.token_response.access_token == "tok"
+
+
+class TestDeviceLoginFlow:
+    def test_device_login_flow_stores_access_and_refresh_tokens(self, device_provider: OAuthProvider) -> None:
+        registry = _FakeRegistry(device_provider)
+        vault = _FakeVault()
+        mutations = _FakeMutations()
+        console = MagicMock()
+        clock = _FakeClock()
+
+        device_auth = DeviceAuthorizationResponse(
+            device_code="dev-123",
+            user_code="ABCD-EFGH",
+            verification_uri="https://example.com/device",
+            verification_uri_complete="https://example.com/device?user_code=ABCD-EFGH",
+            expires_in=900,
+            interval=2,
+            message="Visit the URL and enter the code.",
+            raw={"device_code": "dev-123"},
+        )
+        poll_results = [
+            DevicePollResult(status="authorization_pending", raw={"error": "authorization_pending"}),
+            DevicePollResult(status="slow_down", retry_after=5, raw={"error": "slow_down"}),
+            DevicePollResult(
+                status="success",
+                token_response=TokenResponse(
+                    access_token="atok-123",
+                    token_type="Bearer",
+                    expires_in=3600,
+                    refresh_token="rtok-456",
+                    scope="openid email",
+                    raw={"access_token": "atok-123"},
+                ),
+                raw={"access_token": "atok-123"},
+            ),
+        ]
+
+        with patch("hermes_vault.oauth.device.TokenExchanger.request_device_code", return_value=device_auth) as request_mock, patch(
+            "hermes_vault.oauth.device.TokenExchanger.poll_device_code",
+            side_effect=poll_results,
+        ) as poll_mock:
+            flow = DeviceLoginFlow(
+                provider_id="google",
+                alias="work",
+                timeout=30,
+                vault=vault,
+                mutations=mutations,
+                registry=registry,
+                console=console,
+                sleep_fn=clock.sleep,
+                clock_fn=clock.monotonic,
+            )
+            flow.run()
+
+        request_mock.assert_called_once()
+        assert poll_mock.call_count == 3
+        assert clock.now == pytest.approx(9.0)
+        assert vault.set_expiry.call_count == 1
+        assert len(mutations.calls) == 2
+
+        access_call = mutations.calls[0]
+        assert access_call["credential_type"] == "oauth_access_token"
+        assert access_call["alias"] == "work"
+        assert access_call["scopes"] == ["openid", "email"]
+        assert access_call["metadata"]["provider"] == "google"
+        assert access_call["metadata"]["token_type"] == "Bearer"
+        assert access_call["metadata"]["scopes"] == ["openid", "email"]
+        assert "refresh_token" not in access_call["metadata"]
+        assert "raw_response" not in access_call["metadata"]
+
+        refresh_call = mutations.calls[1]
+        assert refresh_call["credential_type"] == "oauth_refresh_token"
+        assert refresh_call["alias"] == refresh_alias_for("work")
+        assert refresh_call["secret"] == "rtok-456"
+        assert refresh_call["metadata"]["provider"] == "google"
+        assert refresh_call["metadata"]["associated_access_token_alias"] == "work"
+
+    def test_device_login_flow_rejects_unsupported_provider(self) -> None:
+        provider = OAuthProvider(
+            service_id="openai",
+            name="OpenAI",
+            authorization_endpoint="https://auth.openai.com/oauth/authorize",
+            token_endpoint="https://auth.openai.com/oauth/token",
+            default_scopes=["api_access"],
+        )
+        registry = _FakeRegistry(provider)
+        console = MagicMock()
+
+        with pytest.raises(OAuthProviderError) as exc_info:
+            DeviceLoginFlow(
+                provider_id="openai",
+                alias="default",
+                timeout=10,
+                vault=_FakeVault(),
+                mutations=_FakeMutations(),
+                registry=registry,
+                console=console,
+            ).run()
+
+        assert "does not support device-code login" in str(exc_info.value)
+        assert "google" not in str(exc_info.value)
+
+    def test_device_login_flow_access_denied_raises(self, device_provider: OAuthProvider) -> None:
+        registry = _FakeRegistry(device_provider)
+        console = MagicMock()
+
+        device_auth = DeviceAuthorizationResponse(
+            device_code="dev-123",
+            user_code="ABCD-EFGH",
+            verification_uri="https://example.com/device",
+            verification_uri_complete=None,
+            expires_in=900,
+            interval=1,
+            message=None,
+            raw={"device_code": "dev-123"},
+        )
+        poll_results = [
+            DevicePollResult(status="authorization_pending", raw={"error": "authorization_pending"}),
+            DevicePollResult(status="access_denied", error_description="user refused", raw={"error": "access_denied"}),
+        ]
+
+        with patch("hermes_vault.oauth.device.TokenExchanger.request_device_code", return_value=device_auth), patch(
+            "hermes_vault.oauth.device.TokenExchanger.poll_device_code",
+            side_effect=poll_results,
+        ):
+            flow = DeviceLoginFlow(
+                provider_id="google",
+                alias="default",
+                timeout=10,
+                vault=_FakeVault(),
+                mutations=_FakeMutations(),
+                registry=registry,
+                console=console,
+                sleep_fn=lambda _: None,
+                clock_fn=lambda: 0.0,
+            )
+            with pytest.raises(OAuthDeniedError):
+                flow.run()
+
+    def test_device_login_flow_expired_token_raises_timeout(self, device_provider: OAuthProvider) -> None:
+        registry = _FakeRegistry(device_provider)
+        console = MagicMock()
+
+        device_auth = DeviceAuthorizationResponse(
+            device_code="dev-123",
+            user_code="ABCD-EFGH",
+            verification_uri="https://example.com/device",
+            verification_uri_complete=None,
+            expires_in=900,
+            interval=1,
+            message=None,
+            raw={"device_code": "dev-123"},
+        )
+        poll_results = [
+            DevicePollResult(status="expired_token", error_description="expired", raw={"error": "expired_token"}),
+        ]
+
+        with patch("hermes_vault.oauth.device.TokenExchanger.request_device_code", return_value=device_auth), patch(
+            "hermes_vault.oauth.device.TokenExchanger.poll_device_code",
+            side_effect=poll_results,
+        ):
+            flow = DeviceLoginFlow(
+                provider_id="google",
+                alias="default",
+                timeout=10,
+                vault=_FakeVault(),
+                mutations=_FakeMutations(),
+                registry=registry,
+                console=console,
+                sleep_fn=lambda _: None,
+                clock_fn=lambda: 0.0,
+            )
+            with pytest.raises(OAuthTimeoutError):
+                flow.run()


### PR DESCRIPTION
Adds OAuth device-code login for headless environments, with provider metadata, CLI wiring, and tests. Rebased onto current master (docs cleanup commit 6b02b98).