### PR TITLE
v0.15.0 Agent OAuth Freshness: broker/MCP auto-refresh tokens before handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.15.0 -- Agent OAuth Freshness
+
+### Added
+
+- Agent OAuth Freshness: broker/MCP env handoff auto-refreshes near-expiry OAuth tokens before the credential reaches the agent, reducing stale-token failures.
+- New `oauth_refresh` metadata field in `BrokerDecision` surfaced through CLI and MCP responses, enabling agent-visible freshness status.
+- Refresh cooldown of 30 seconds per credential prevents provider rate-limit abuse from repeated handoffs.
+- Sanitized failure handling: expired + unrecoverable OAuth tokens are denied with a clean error — no raw token leakage.
+- Policy gate: live refresh requires the existing `rotate` service action permission; `get_env` alone does not authorize vault mutation.
+- CLI `broker env` JSON output now includes `oauth_refresh` metadata.
+- MCP `get_ephemeral_env` response includes a `metadata` field with `oauth_refresh` status.
+
+### Changed
+
+- Dashboard live refresh remains dry-run-only; live token mutation is CLI-only.
+- Version surfaces now report `0.15.0` in `pyproject.toml`, `src/hermes_vault/__init__.py`, and `src/hermes_vault/mcp_server.py`.
+
+### Verification
+
+- Full test suite: 687 passed, 1 skipped (includes 8 broker, 2 CLI, and 2 MCP OAuth freshness tests, plus policy and audit verification tests).
+
 ## 0.14.0 -- Native Windows + DPAPI Master-Key Protection
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -314,6 +314,28 @@ hermes-vault oauth refresh google --alias work
 hermes-vault oauth providers
 ```
 
+## What's New in 0.15.0 - Agent OAuth Freshness
+
+v0.15.0 introduces **Agent OAuth Freshness**: brokered credentials are automatically refreshed before agent handoff. When an agent requests an ephemeral environment via `broker env` or MCP `get_ephemeral_env`, near-expiry OAuth tokens are silently refreshed using their stored refresh tokens — so the agent never receives a token that's about to fail.
+
+```bash
+hermes-vault broker env google --agent my-agent
+```
+
+- **How it works**: The broker checks OAuth token expiry during `get_ephemeral_env`. Tokens far from expiry pass through untouched with `oauth_refresh: {refreshed: false}`. Near-expiry tokens (within 5 minutes) trigger a live refresh via the `RefreshEngine`. Successfully refreshed tokens return with `oauth_refresh: {refreshed: true}`.
+- **Policy gate**: Live refresh requires the `rotate` service action on the agent's policy v2 entry. `get_env` alone does NOT authorize vault mutation. If an agent lacks `rotate` and the token is hard-expired, the request is denied with a clear policy reason.
+- **Dashboard boundary**: The dashboard OAuth refresh remains dry-run-only. Live token mutation at handoff is exclusive to the CLI and MCP broker paths.
+- **Failure modes**:
+  - **Expired + refresh failure** → denied with clean error, no raw token leakage.
+  - **Near-expiry + refresh failure** → warning returned but existing token still delivered (agent may still succeed).
+- **Refresh cooldown**: 30 seconds per credential prevents provider rate-limit abuse from rapid handoff sequences.
+
+### What changed for operators
+
+- `hermes-vault broker env <service> --agent <agent>` JSON output now includes an `oauth_refresh` metadata field with refresh status.
+- Agents configured in `policy.yaml` need the `rotate` action on services where live OAuth refresh at handoff is expected.
+- MCP `get_ephemeral_env` responses include a `metadata` field with `oauth_refresh`.
+
 ## What's New in 0.14.0 - Native Windows + DPAPI Master-Key Protection
 
 v0.14.0 is the release that makes Windows a first-class runtime instead of a best-effort port. The runtime platform layer is explicit, the Windows guide is real, and DPAPI can wrap the master key at rest when `pywin32` is installed and `HERMES_VAULT_DPAPI=1` is set.

--- a/docs/credential-lifecycle.md
+++ b/docs/credential-lifecycle.md
@@ -24,6 +24,7 @@ v0.13.0 treats this doc as the operator loop behind the release story. The vault
 - Policy v2 determines whether access is allowed based on per-service action permissions
 - Agent-level capabilities gate non-service-scoped actions (list, scan, export, import)
 - Broker prefers ephemeral environment materialization for downstream task execution
+- **v0.15.0: OAuth Freshness at Handoff** — Near-expiry OAuth tokens are automatically refreshed during `get_ephemeral_env` before the credential reaches the agent. The `rotate` permission is required for this live refresh; `get_env` alone does not authorize vault mutation. A 30-second per-credential cooldown prevents provider rate-limit abuse.
 - All broker decisions are recorded in the audit log
 
 ## 4. Verification

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -95,6 +95,34 @@ Once registered, tools are prefixed as `mcp_hermes_vault_*`:
 | `mcp_hermes_vault_oauth_provider_status` | Report provider readiness and safe next commands |
 | `mcp_hermes_vault_oauth_refresh` | Trigger refresh for a stored OAuth token |
 
+### `get_ephemeral_env`
+
+The `get_ephemeral_env` tool materialises ephemeral environment variables for a service. The response now includes a `metadata` field alongside `env`, `ttl_seconds`, and `expires_at`.
+
+**Arguments:**
+- `agent_id` (required unless the server is bound to an allowed-agent set with a configured default) --- Identity for policy enforcement
+- `service` (required) --- Service name
+- `alias` (optional) --- Credential alias, default `default`
+- `ttl_seconds` (optional) --- TTL for the ephemeral environment, default 300
+
+**Response shape:**
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\n  \"env\": {\"OPENAI_API_KEY\": \"sk-...\"},\n  \"ttl_seconds\": 300,\n  \"expires_at\": \"2026-06-15T18:30:00Z\",\n  \"metadata\": {\n    \"oauth_refresh\": {\n      \"refreshed\": false,\n      \"reason\": \"Token is still fresh (expires in 3500s)\"\n    }\n  }\n}"
+    }
+  ]
+}
+```
+
+The `metadata` field may contain `oauth_refresh` with the following structure:
+- `refreshed` (bool or null): `true` if the token was refreshed, `false` if still fresh, `null` for non-OAuth credentials
+- `reason` (string): Human-readable explanation of the refresh decision
+
+When a near-expiry OAuth token is successfully refreshed, `oauth_refresh.refreshed` is `true`. When the token is hard-expired and refresh fails, the request is denied with a policy reason and no raw tokens are exposed.
+
 ## OAuth Tools
 
 ### `oauth_login`

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -571,6 +571,62 @@ hermes-vault oauth refresh google --alias personal
 
 This avoids refresh-token collisions when one operator stores multiple identities for the same provider.
 
+## OAuth Freshness at Handoff
+
+v0.15.0 introduces automatic OAuth token freshness at broker handoff. When an agent requests an ephemeral environment, near-expiry OAuth tokens are refreshed before delivery — reducing stale-token failures in agent workflows.
+
+### What changed for operators
+
+- `hermes-vault broker env <service> --agent <agent>` now includes `oauth_refresh` metadata in its JSON output, showing whether the token was refreshed (`true`), still fresh (`false`), or had no expiry (`null`).
+- Agents that should receive live-refreshed OAuth tokens at handoff need the `rotate` action in their policy v2 entry for that service.
+
+### Policy requirement
+
+Live OAuth refresh requires the existing `rotate` service action. The `get_env` action alone does NOT authorize vault mutation. If an agent only has `get_env` and the OAuth token is hard-expired, the broker denies the request with a clear policy reason.
+
+Example policy entry with refresh permission:
+
+```yaml
+agents:
+  my-agent:
+    services:
+      google:
+        actions: [get_env, rotate]   # rotate needed for live refresh at handoff
+    max_ttl_seconds: 900
+```
+
+### How to verify
+
+Run `hermes-vault broker env <service> --agent <agent>` and inspect the `oauth_refresh` metadata:
+
+```json
+{
+  "allowed": true,
+  "service": "google",
+  "agent_id": "my-agent",
+  "env": { "GOOGLE_API_KEY": "..." },
+  "oauth_refresh": {
+    "refreshed": true,
+    "reason": "Token was expired; successfully refreshed"
+  }
+}
+```
+
+### Failure scenarios
+
+| Scenario | Behavior |
+|----------|----------|
+| Token is far from expiry | Passes through untouched; `oauth_refresh.refreshed = false` |
+| Token near expiry, refresh succeeds | Refreshed token delivered; `oauth_refresh.refreshed = true` |
+| Token hard-expired, refresh fails | Request denied with clean error; `oauth_refresh.refreshed = false` and failure reason |
+| Near-expiry, refresh fails | Warning returned but existing token still delivered (agent may still succeed) |
+| Agent lacks `rotate` permission | Policy denial with reason about missing `rotate` action |
+| Non-OAuth credential | `oauth_refresh.refreshed = null` (no-op) |
+
+### Dashboard boundary
+
+Dashboard OAuth refresh remains dry-run-only. Live token mutation at handoff is exclusive to CLI and MCP broker paths.
+
 ## Backup Verification and Drill
 
 v0.14.0 makes the platform split explicit: `maintain` still covers refresh + health only, but the release also brings Windows-native support and DPAPI-backed master-key protection. Use `policy doctor` for drift diagnosis, then `backup-verify` and `restore --dry-run` to prove recovery before calling the vault fully assured.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -134,6 +134,36 @@ Mitigation: The callback server binds to `127.0.0.1` only and listens on an OS-a
 
 Mitigation: `backup-verify` and `restore --dry-run` prove the archive is structurally valid and decryptable without mutating the live vault. They reduce the chance of discovering a broken backup during recovery, but they do not protect against a lost passphrase, missing salt file, or host compromise after verification.
 
+### OAuth Refresh-at-Handoff Threat Model
+
+v0.15.0 introduces automatic OAuth token refresh at broker/MCP handoff. This adds new threat vectors:
+
+#### Silent vault mutation from a read-looking command
+
+Risk: A `get_ephemeral_env` call looks like a read operation to operators auditing the system, but it can silently mutate the vault by refreshing a near-expiry OAuth token.
+
+Mitigation: Live refresh requires the `rotate` service action permission. An agent with only `get_env` cannot trigger vault mutation. Policy separation ensures read-only grants remain read-only.
+
+#### Provider rate-limit abuse
+
+Risk: Rapid repeated `get_ephemeral_env` calls for the same credential could hammer the provider's token endpoint, triggering rate-limit blocks.
+
+Mitigation: A 30-second per-credential cooldown prevents repeated refresh attempts within a single handoff sequence. The existing exponential backoff in the `RefreshEngine` provides additional protection for retries.
+
+#### Stale token delivery after refresh failure
+
+Risk: When a near-expiry token fails to refresh, the broker could silently deliver a stale token that the agent then fails to use, creating confusing failures.
+
+Mitigation: The broker treats hard-expired tokens as fail-closed: if the token is past expiry and refresh cannot recover it, the request is denied with a clean error. Near-expiry tokens that fail refresh still deliver the existing token with a warning in `oauth_refresh` metadata.
+
+#### Summary
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Vault mutation from read call | Medium | Require `rotate` permission for live refresh |
+| Provider rate-limit abuse | Low | 30s per-credential cooldown + exponential backoff |
+| Stale token delivery | Low | Fail-closed for hard-expired tokens |
+
 ### Residual risks
 
 - Initial login can use browser PKCE or device-code flow for providers that support it. Device-code support removes the local browser requirement, but the operator still has to approve the login in a provider-controlled browser or device prompt.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-vault"
-version = "0.14.0"
+version = "0.15.0"
 description = "Hermes-native local-first credential broker, scanner, and encrypted vault."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/hermes_vault/__init__.py
+++ b/src/hermes_vault/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/src/hermes_vault/broker.py
+++ b/src/hermes_vault/broker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -17,10 +18,22 @@ from hermes_vault.models import (
     VerificationResult,
 )
 from hermes_vault.mutations import VaultMutations
+from hermes_vault.oauth.errors import (
+    OAuthNetworkError,
+    OAuthProviderError,
+    sanitize_oauth_error_detail,
+)
+from hermes_vault.oauth.oauth_refresh import (
+    RefreshTokenExpiredError,
+    RefreshTokenMissingError,
+)
 from hermes_vault.policy import PolicyEngine
 from hermes_vault.service_ids import get_env_var_map, normalize
 from hermes_vault.verifier import Verifier
 from hermes_vault.vault import AmbiguousTargetError, Vault
+
+OAUTH_REFRESH_MARGIN_SECONDS = 300  # 5 minutes
+OAUTH_REFRESH_COOLDOWN_SECONDS = 30  # seconds between refresh attempts
 
 
 def _verification_is_unsupported(result: VerificationResult) -> bool:
@@ -38,13 +51,23 @@ class Broker:
         verifier: Verifier,
         audit: AuditLogger,
         scanner: Any = None,
+        refresh_engine: Any = None,
     ) -> None:
         self.vault = vault
         self.policy = policy
         self.verifier = verifier
         self.audit = audit
         self.scanner = scanner
+        self._refresh_engine = refresh_engine
+        self._refresh_cooldowns: dict[str, float] = {}
         self._mutations = VaultMutations(vault=vault, policy=policy, audit=audit)
+
+    @property
+    def refresh_engine(self):
+        if self._refresh_engine is None:
+            from hermes_vault.oauth.oauth_refresh import RefreshEngine
+            self._refresh_engine = RefreshEngine(vault=self.vault)
+        return self._refresh_engine
 
     def get_credential(self, service: str, purpose: str, agent_id: str) -> BrokerDecision:
         service = normalize(service)
@@ -82,9 +105,35 @@ class Broker:
         secret = self.vault.get_secret(record.id)
         if not secret:
             return self._deny(agent_id, canonical, "get_ephemeral_env", "credential not found in vault", ttl_seconds=effective_ttl)
+        # ── OAuth freshness check ────────────────────────────────────────
+        freshness_result = self._ensure_oauth_freshness(
+            record, canonical, alias, agent_id,
+        )
+        if freshness_result.get("decision") == "deny":
+            deny_meta: dict[str, object] = {}
+            oauth_meta = freshness_result.get("oauth_refresh")
+            if oauth_meta is not None:
+                deny_meta["oauth_refresh"] = oauth_meta
+            return self._deny(
+                agent_id, canonical, "get_ephemeral_env",
+                freshness_result.get("reason", "OAuth refresh failed"),
+                ttl_seconds=effective_ttl,
+                metadata=deny_meta,
+            )
+        if freshness_result.get("re_resolve"):
+            record = self.vault.resolve_credential(canonical, alias=alias)
+            secret = self.vault.get_secret(record.id)
+            if not secret:
+                return self._deny(agent_id, canonical, "get_ephemeral_env", "credential not found after OAuth refresh", ttl_seconds=effective_ttl)
         env_template = get_env_var_map(canonical)
         env = {key: value.format(secret=secret.secret) for key, value in env_template.items()}
         warnings = self._governance_warnings(canonical, alias)
+        metadata: dict[str, object] = {}
+        if warnings:
+            metadata["warnings"] = warnings
+        oauth_meta = freshness_result.get("oauth_refresh")
+        if oauth_meta is not None:
+            metadata["oauth_refresh"] = oauth_meta
         return self._allow(
             agent_id,
             canonical,
@@ -92,8 +141,147 @@ class Broker:
             "ephemeral environment materialization approved",
             ttl_seconds=effective_ttl,
             env=env,
-            metadata={"warnings": warnings} if warnings else {},
+            metadata=metadata,
         )
+
+    def _ensure_oauth_freshness(
+        self,
+        record,
+        service: str,
+        alias: str | None,
+        agent_id: str,
+    ) -> dict[str, object]:
+        """Check whether an OAuth access token needs refreshing and do it.
+
+        Returns a dict with keys:
+          - decision: "pass" | "deny"
+          - re_resolve: bool (if True, caller must re-fetch record + secret)
+          - oauth_refresh: dict with refresh metadata (or None for non-OAuth)
+          - reason: str (for deny cases)
+        """
+        # 1. Non-OAuth credentials pass through untouched
+        if record.credential_type != "oauth_access_token":
+            return {"decision": "pass", "oauth_refresh": None}
+
+        # 2. Token with no expiry — can't determine staleness
+        if record.expiry is None:
+            return {"decision": "pass", "oauth_refresh": {"refreshed": None}}
+
+        # 3. Check if token is near expiry or already expired
+        is_near_expiry = self.refresh_engine.is_expired(
+            record, margin_seconds=OAUTH_REFRESH_MARGIN_SECONDS,
+        )
+
+        if not is_near_expiry:
+            # 4. Token still has plenty of life
+            return {"decision": "pass", "oauth_refresh": {"refreshed": False}}
+
+        # 5. Token is near/at expiry — check rotate permission
+        can_rotate, rotate_reason = self.policy.can(
+            agent_id, service, ServiceAction.rotate,
+        )
+        cooldown_key = f"{service}:{alias or 'default'}"
+
+        if not can_rotate:
+            hard_expired = self.refresh_engine.is_expired(record, margin_seconds=0)
+            self.audit.record(
+                AccessLogRecord(
+                    agent_id=agent_id,
+                    service=service,
+                    action="broker_env_oauth_refresh",
+                    decision=Decision.deny if hard_expired else Decision.allow,
+                    reason=f"OAuth refresh skipped: {rotate_reason}",
+                )
+            )
+            if hard_expired:
+                return {
+                    "decision": "deny",
+                    "reason": f"OAuth refresh denied: {rotate_reason}",
+                    "oauth_refresh": {"refreshed": False, "error": rotate_reason},
+                }
+            return {
+                "decision": "pass",
+                "oauth_refresh": {"refreshed": False, "warning": rotate_reason},
+            }
+
+        # 6. Check cooldown
+        last_attempt = self._refresh_cooldowns.get(cooldown_key, 0.0)
+        if time.time() - last_attempt < OAUTH_REFRESH_COOLDOWN_SECONDS:
+            return {
+                "decision": "pass",
+                "oauth_refresh": {"refreshed": False, "cooldown": True},
+            }
+
+        # 7. Attempt live refresh
+        try:
+            self.refresh_engine.refresh(service, alias=alias or "default", dry_run=False)
+            self._refresh_cooldowns[cooldown_key] = time.time()
+            self.audit.record(
+                AccessLogRecord(
+                    agent_id=agent_id,
+                    service=service,
+                    action="broker_env_oauth_refresh",
+                    decision=Decision.allow,
+                    reason="Token refreshed successfully by broker",
+                )
+            )
+            return {
+                "decision": "pass",
+                "re_resolve": True,
+                "oauth_refresh": {"refreshed": True},
+            }
+        except RefreshTokenMissingError as exc:
+            return self._oauth_refresh_error(
+                record, exc, agent_id, service, cooldown_key,
+            )
+        except RefreshTokenExpiredError as exc:
+            return self._oauth_refresh_error(
+                record, exc, agent_id, service, cooldown_key,
+            )
+        except OAuthProviderError as exc:
+            return self._oauth_refresh_error(
+                record, exc, agent_id, service, cooldown_key,
+            )
+        except OAuthNetworkError as exc:
+            return self._oauth_refresh_error(
+                record, exc, agent_id, service, cooldown_key,
+            )
+        except Exception as exc:
+            return self._oauth_refresh_error(
+                record, exc, agent_id, service, cooldown_key,
+            )
+
+    def _oauth_refresh_error(
+        self,
+        record,
+        exc: Exception,
+        agent_id: str,
+        service: str,
+        cooldown_key: str,
+    ) -> dict[str, object]:
+        """Handle a refresh error: audit, cooldown, and decide pass/deny."""
+        sanitized = sanitize_oauth_error_detail(exc)
+        self._refresh_cooldowns[cooldown_key] = time.time()
+        hard_expired = self.refresh_engine.is_expired(record, margin_seconds=0)
+        self.audit.record(
+            AccessLogRecord(
+                agent_id=agent_id,
+                service=service,
+                action="broker_env_oauth_refresh",
+                decision=Decision.deny if hard_expired else Decision.allow,
+                reason=sanitized,
+            )
+        )
+        if hard_expired:
+            return {
+                "decision": "deny",
+                "reason": sanitized,
+                "oauth_refresh": {"refreshed": False, "error": sanitized},
+            }
+        return {
+            "decision": "pass",
+            "oauth_refresh": {"refreshed": False, "error": sanitized},
+        }
 
     def _governance_warnings(self, service: str, alias: str | None = None) -> list[dict[str, str]]:
         """Build structured governance warnings for a credential request."""
@@ -482,6 +670,7 @@ class Broker:
         action: str,
         reason: str,
         ttl_seconds: int | None = None,
+        metadata: dict[str, object] | None = None,
     ) -> BrokerDecision:
         self.audit.record(
             AccessLogRecord(
@@ -499,4 +688,5 @@ class Broker:
             agent_id=agent_id,
             reason=reason,
             ttl_seconds=ttl_seconds,
+            metadata=metadata or {},
         )

--- a/src/hermes_vault/cli.py
+++ b/src/hermes_vault/cli.py
@@ -1651,9 +1651,9 @@ def broker_env(
     canonical = normalize(service)
     decision = broker.get_ephemeral_env(service=canonical, agent_id=agent, ttl=ttl)
     if not decision.allowed:
-        console.print_json(data=decision.model_dump_json())
+        console.print_json(data=decision.model_dump(mode="json"))
         raise typer.Exit(code=1)
-    console.print_json(data=json.dumps(decision.model_dump(mode="json")))
+    console.print_json(data=decision.model_dump(mode="json"))
 
 
 @broker_app.command("list")

--- a/src/hermes_vault/mcp_server.py
+++ b/src/hermes_vault/mcp_server.py
@@ -529,7 +529,7 @@ _pending_oauth: dict[str, dict[str, Any]] = {}
 
 # ── server ─────────────────────────────────────────────────────────────────────
 
-server = Server("hermes-vault", version="0.14.0")
+server = Server("hermes-vault", version="0.15.0")
 
 
 @server.list_tools()
@@ -746,6 +746,7 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
                 "env": result.env,
                 "ttl_seconds": result.ttl_seconds,
                 "expires_at": expires_at,
+                "metadata": result.metadata,
             }))]
 
         if name == "verify_credential":

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -413,3 +413,63 @@ class TestAuditCLi:
         parsed = json.loads(result.output)
         assert len(parsed) == 1
         assert parsed[0]["timestamp"].startswith("2026-04-20T18:30:00")
+
+
+# ── OAuth refresh audit tests ──────────────────────────────
+
+
+def test_oauth_refresh_audit_action_broker_env_oauth_refresh(tmp_path: Path) -> None:
+    """Audit records from refresh-at-handoff must contain the action 'broker_env_oauth_refresh'."""
+    audit = AuditLogger(tmp_path / "audit.db")
+    audit.initialize()
+    audit.record(
+        _make_record(
+            agent_id="dwight",
+            service="openai",
+            action="broker_env_oauth_refresh",
+            decision=Decision.allow,
+        ).model_copy(
+            update={
+                "metadata": {
+                    "oauth_refresh": {"refreshed": True},
+                }
+            }
+        )
+    )
+
+    results = audit.list_recent(limit=10, action="broker_env_oauth_refresh")
+
+    assert len(results) >= 1
+    assert results[0]["action"] == "broker_env_oauth_refresh"
+    assert results[0]["decision"] == "allow"
+
+
+def test_oauth_refresh_audit_no_raw_token_leakage(tmp_path: Path) -> None:
+    """Audit records from refresh-at-handoff must not contain raw tokens."""
+    audit = AuditLogger(tmp_path / "audit.db")
+    audit.initialize()
+    audit.record(
+        _make_record(
+            agent_id="dwight",
+            service="openai",
+            action="broker_env_oauth_refresh",
+            decision=Decision.deny,
+        ).model_copy(
+            update={
+                "reason": "Token refresh failed: invalid_grant - provider rejected the refresh token",
+                "metadata": {
+                    "oauth_refresh": {"refreshed": False, "error": "invalid_grant"},
+                },
+            }
+        )
+    )
+
+    results = audit.list_recent(limit=10, action="broker_env_oauth_refresh")
+
+    assert len(results) >= 1
+    # The reason should explain the failure without raw token material
+    assert "refresh" in results[0]["reason"].lower()
+    # Verify no raw token values leaked into reason or metadata
+    assert "ya29" not in results[0]["reason"]
+    assert "access_token" not in results[0].get("metadata", {}).get("oauth_refresh", {})
+    assert "old_access" not in results[0]["reason"]

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,19 +1,25 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from hermes_vault.audit import AuditLogger
 from hermes_vault.broker import Broker
 from hermes_vault.models import (
     AgentCapability,
     AgentPolicy,
+    CredentialRecord,
     CredentialStatus,
     PolicyConfig,
     ServiceAction,
     ServicePolicyEntry,
     VerificationCategory,
     VerificationResult,
+    utc_now,
 )
+from hermes_vault.oauth.oauth_refresh import RefreshEngine
+from hermes_vault.oauth.providers import OAuthProviderRegistry
 from hermes_vault.policy import PolicyEngine
 from hermes_vault.vault import Vault
 
@@ -520,3 +526,354 @@ def test_broker_import_allowed_legacy_agent(tmp_path: Path) -> None:
     decision = broker.import_credentials("hermes", backup)
     assert decision.allowed is True
     assert decision.metadata["imported_count"] == 1
+
+
+# ── OAuth freshness helpers (inlined for test independence) ─────────────
+
+
+class MockTokenEndpoint:
+    """A programmable mock token endpoint for refresh flows.
+
+    Usage:
+        endpoint = MockTokenEndpoint(success_tokens={...})
+        with patch("hermes_vault.oauth.oauth_refresh.requests.post", side_effect=endpoint.handler):
+            ...
+    """
+
+    def __init__(
+        self,
+        success_tokens: dict | None = None,
+        error_response: dict | None = None,
+        status_code: int = 200,
+        fail_count: int = 0,
+    ):
+        self.calls: list[dict] = []
+        self.success_tokens = success_tokens or {
+            "access_token": "new_access_token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "new_refresh_token",
+            "scope": "openid email",
+        }
+        self.error_response = error_response
+        self.status_code = status_code
+        self.fail_count = fail_count
+        self._call_count = 0
+
+    def handler(self, url, data=None, headers=None, timeout=None, **kwargs):
+        self._call_count += 1
+        if isinstance(data, dict):
+            parsed = data
+        elif data:
+            parsed = dict(p.split("=", 1) for p in data.split("&"))
+        else:
+            parsed = {}
+        self.calls.append({"url": str(url), "data": parsed})
+
+        mock_resp = MagicMock()
+        if self._call_count <= self.fail_count:
+            from requests import RequestException
+
+            raise RequestException(f"Simulated failure #{self._call_count}")
+
+        if self.error_response:
+            mock_resp.ok = False
+            mock_resp.status_code = self.status_code
+            mock_resp.json.return_value = self.error_response
+            mock_resp.text = str(self.error_response)
+            return mock_resp
+
+        mock_resp.ok = True
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = self.success_tokens
+        mock_resp.text = str(self.success_tokens)
+        return mock_resp
+
+
+def _add_credential(
+    vault: Vault,
+    service: str,
+    secret: str,
+    credential_type: str,
+    alias: str = "default",
+    expiry: datetime | None = None,
+) -> CredentialRecord:
+    rec = vault.add_credential(
+        service=service,
+        secret=secret,
+        credential_type=credential_type,
+        alias=alias,
+        replace_existing=True,
+    )
+    if expiry is not None:
+        vault.set_expiry(rec.id, expiry)
+    return rec
+
+
+def _seed_tokens(
+    vault: Vault,
+    service: str,
+    expiry: datetime | None = None,
+    access_alias: str = "default",
+    refresh_alias: str = "refresh",
+    refresh_secret: str = "old_refresh",
+) -> None:
+    if expiry is None:
+        expiry = utc_now() - timedelta(seconds=10)
+    _add_credential(
+        vault, service, "old_access", "oauth_access_token",
+        alias=access_alias, expiry=expiry,
+    )
+    vault.add_credential(
+        service=service,
+        secret=refresh_secret,
+        credential_type="oauth_refresh_token",
+        alias=refresh_alias,
+        replace_existing=True,
+    )
+
+
+def _make_registry(tmp_path: Path) -> OAuthProviderRegistry:
+    path = tmp_path / "providers.yaml"
+    path.write_text(
+        "providers:\n"
+        "  openai:\n    name: OpenAI\n"
+        "    authorization_endpoint: https://example.com/auth\n"
+        "    token_endpoint: https://example.com/token\n"
+    )
+    return OAuthProviderRegistry(path)
+
+
+def _oauth_policy(actions: list[ServiceAction] | None = None) -> PolicyEngine:
+    if actions is None:
+        actions = [ServiceAction.get_env, ServiceAction.rotate]
+    return PolicyEngine(
+        PolicyConfig(
+            agents={
+                "dwight": AgentPolicy(
+                    services=["openai"],
+                    service_actions={
+                        "openai": ServicePolicyEntry(actions=actions),
+                    },
+                    max_ttl_seconds=900,
+                )
+            }
+        )
+    )
+
+
+# ── OAuth freshness tests ──────────────────────────────────────────────
+
+
+def test_get_ephemeral_env_api_key_unchanged_for_oauth_refresh(tmp_path: Path) -> None:
+    """API-key credentials must produce no oauth_refresh metadata."""
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    vault.add_credential("openai", "sk-sec...7890", "api_key")
+    policy = _oauth_policy()
+    broker = Broker(vault, policy, StubVerifier(), AuditLogger(tmp_path / "vault.db"))
+
+    decision = broker.get_ephemeral_env("openai", "dwight", ttl=900)
+
+    assert decision.allowed is True
+    assert decision.env["OPENAI_API_KEY"] == "sk-sec...7890"
+    # No oauth_refresh metadata for non-OAuth credentials
+    assert "oauth_refresh" not in decision.metadata
+
+
+def test_get_ephemeral_env_oauth_current_token_no_refresh(tmp_path: Path) -> None:
+    """A current (non-expired) OAuth token must be returned as-is."""
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    future = utc_now() + timedelta(seconds=3600)
+    _seed_tokens(vault, "openai", expiry=future)
+    policy = _oauth_policy()
+    broker = Broker(vault, policy, StubVerifier(), AuditLogger(tmp_path / "vault.db"))
+
+    decision = broker.get_ephemeral_env("openai", "dwight", ttl=900, alias="default")
+
+    assert decision.allowed is True
+    assert decision.env["OPENAI_API_KEY"] == "old_access"
+    assert decision.metadata.get("oauth_refresh") == {"refreshed": False}
+
+
+def test_get_ephemeral_env_oauth_expired_refreshes_success(tmp_path: Path) -> None:
+    """An expired OAuth token must be refreshed before handoff."""
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    past = utc_now() - timedelta(seconds=10)
+    _seed_tokens(vault, "openai", expiry=past)
+
+    registry = _make_registry(tmp_path)
+    refresh_engine = RefreshEngine(vault=vault, registry=registry)
+    policy = _oauth_policy()
+    broker = Broker(
+        vault, policy, StubVerifier(), AuditLogger(tmp_path / "vault.db"),
+        refresh_engine=refresh_engine,
+    )
+
+    endpoint = MockTokenEndpoint(success_tokens={
+        "access_token": "fresh_access",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "refresh_token": "fresh_refresh",
+        "scope": "openid",
+    })
+
+    with patch("hermes_vault.oauth.oauth_refresh.requests.post", side_effect=endpoint.handler):
+        decision = broker.get_ephemeral_env("openai", "dwight", ttl=900, alias="default")
+
+    assert decision.allowed is True
+    assert decision.metadata["oauth_refresh"]["refreshed"] is True
+    assert decision.env["OPENAI_API_KEY"] == "fresh_access"
+
+    # Verify the vault was actually updated
+    re_record = vault.resolve_credential("openai", alias="default")
+    re_secret = vault.get_secret(re_record.id)
+    assert re_secret is not None
+    assert re_secret.secret == "fresh_access"
+
+
+def test_get_ephemeral_env_oauth_expired_no_refresh_token_denies(tmp_path: Path) -> None:
+    """Expired OAuth token without a refresh token must be denied with a sanitised reason."""
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    past = utc_now() - timedelta(seconds=10)
+    _add_credential(
+        vault, "openai", "old_access", "oauth_access_token",
+        alias="default", expiry=past,
+    )
+    # Deliberately no refresh token
+
+    registry = _make_registry(tmp_path)
+    refresh_engine = RefreshEngine(vault=vault, registry=registry)
+    policy = _oauth_policy()
+    broker = Broker(
+        vault, policy, StubVerifier(), AuditLogger(tmp_path / "vault.db"),
+        refresh_engine=refresh_engine,
+    )
+
+    decision = broker.get_ephemeral_env("openai", "dwight", ttl=900)
+
+    assert decision.allowed is False
+    assert "refresh token" in decision.reason.lower() or "Refresh token" in decision.reason
+    # Verify it is NOT an OAuthProviderError — should be a clean string
+    assert "OAuthProviderError" not in repr(decision.reason)
+    # No raw token leaked
+    assert "old_access" not in decision.reason
+
+
+def test_get_ephemeral_env_oauth_refresh_fails_token_still_valid_returns_with_warning(tmp_path: Path) -> None:
+    """Near-expiry token with failed refresh should still be returned (still valid)."""
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    near_expiry = utc_now() + timedelta(seconds=120)  # < OAUTH_REFRESH_MARGIN_SECONDS (300)
+    _seed_tokens(vault, "openai", expiry=near_expiry)
+
+    registry = _make_registry(tmp_path)
+    refresh_engine = RefreshEngine(vault=vault, registry=registry)
+    policy = _oauth_policy()
+    broker = Broker(
+        vault, policy, StubVerifier(), AuditLogger(tmp_path / "vault.db"),
+        refresh_engine=refresh_engine,
+    )
+
+    endpoint = MockTokenEndpoint(
+        error_response={"error": "invalid_grant", "error_description": "Token revoked"},
+        status_code=400,
+    )
+
+    with patch("hermes_vault.oauth.oauth_refresh.requests.post", side_effect=endpoint.handler):
+        decision = broker.get_ephemeral_env("openai", "dwight", ttl=900, alias="default")
+
+    assert decision.allowed is True
+    assert decision.metadata["oauth_refresh"]["refreshed"] is False
+    assert "error" in decision.metadata["oauth_refresh"]
+    # Still returns the original token
+    assert decision.env["OPENAI_API_KEY"] == "old_access"
+
+
+def test_get_ephemeral_env_oauth_expired_refresh_fails_denies(tmp_path: Path) -> None:
+    """Expired token whose refresh fails must be denied with sanitised message."""
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    past = utc_now() - timedelta(seconds=10)
+    _seed_tokens(vault, "openai", expiry=past)
+
+    registry = _make_registry(tmp_path)
+    refresh_engine = RefreshEngine(vault=vault, registry=registry)
+    policy = _oauth_policy()
+    broker = Broker(
+        vault, policy, StubVerifier(), AuditLogger(tmp_path / "vault.db"),
+        refresh_engine=refresh_engine,
+    )
+
+    endpoint = MockTokenEndpoint(
+        error_response={"error": "invalid_grant", "error_description": "Token revoked"},
+        status_code=400,
+    )
+
+    with patch("hermes_vault.oauth.oauth_refresh.requests.post", side_effect=endpoint.handler):
+        decision = broker.get_ephemeral_env("openai", "dwight", ttl=900)
+
+    assert decision.allowed is False
+    assert decision.reason  # should have a sanitised reason
+    # No raw token leaked
+    assert "old_access" not in decision.reason
+    assert "raw_response" not in str(decision.metadata)
+
+
+def test_get_ephemeral_env_oauth_refresh_needs_rotate_permission(tmp_path: Path) -> None:
+    """Expired token without rotate permission must be denied, mentioning policy."""
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    past = utc_now() - timedelta(seconds=10)
+    _seed_tokens(vault, "openai", expiry=past)
+
+    # Grant get_env but NOT rotate
+    policy = _oauth_policy(actions=[ServiceAction.get_env])
+
+    registry = _make_registry(tmp_path)
+    refresh_engine = RefreshEngine(vault=vault, registry=registry)
+    broker = Broker(
+        vault, policy, StubVerifier(), AuditLogger(tmp_path / "vault.db"),
+        refresh_engine=refresh_engine,
+    )
+
+    decision = broker.get_ephemeral_env("openai", "dwight", ttl=900, alias="default")
+
+    assert decision.allowed is False
+    assert "rotate" in decision.reason.lower() or "denied" in decision.reason.lower()
+    assert decision.metadata.get("oauth_refresh", {}).get("refreshed") is False
+
+
+def test_get_ephemeral_env_oauth_refresh_cooldown_respected(tmp_path: Path) -> None:
+    """Multiple calls within cooldown must not re-hit the token endpoint."""
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    past = utc_now() - timedelta(seconds=10)
+    _seed_tokens(vault, "openai", expiry=past)
+
+    registry = _make_registry(tmp_path)
+    refresh_engine = RefreshEngine(vault=vault, registry=registry)
+    policy = _oauth_policy()
+    broker = Broker(
+        vault, policy, StubVerifier(), AuditLogger(tmp_path / "vault.db"),
+        refresh_engine=refresh_engine,
+    )
+
+    endpoint = MockTokenEndpoint(success_tokens={
+        "access_token": "cooldown_token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "refresh_token": "cooldown_refresh",
+        "scope": "openid",
+    })
+
+    with patch("hermes_vault.oauth.oauth_refresh.requests.post", side_effect=endpoint.handler):
+        # First call — triggers refresh
+        decision1 = broker.get_ephemeral_env("openai", "dwight", ttl=900, alias="default")
+        assert decision1.allowed is True
+        assert decision1.metadata["oauth_refresh"]["refreshed"] is True
+        assert endpoint.calls is not None
+        first_call_count = len(endpoint.calls)
+
+        # Second call — within cooldown, should NOT trigger refresh
+        decision2 = broker.get_ephemeral_env("openai", "dwight", ttl=900, alias="default")
+        assert decision2.allowed is True
+        # Should have a cooldown indicator OR no additional endpoint calls
+        assert len(endpoint.calls) == first_call_count
+        # The second call should return the already-refreshed token
+        assert decision2.env["OPENAI_API_KEY"] == "cooldown_token"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from hermes_vault import _platform
 from hermes_vault.cli import _dashboard_runtime_warning, _hermes_group, app
-from hermes_vault.models import BrokerDecision, MutationResult
+from hermes_vault.models import BrokerDecision, MutationResult, utc_now
+from hermes_vault.policy import PolicyEngine
 from hermes_vault.vault import Vault
 
 
@@ -1339,3 +1342,119 @@ def _fake_vault():
                 ),
             ]
     return FakeVault()
+
+
+# ── broker env OAuth freshness tests ─────────────────────────────────────
+
+
+def test_broker_env_cli_shows_oauth_refresh_metadata(monkeypatch, tmp_path: Path) -> None:
+    """CLI broker env must include oauth_refresh metadata for current OAuth tokens."""
+    home = tmp_path
+    db_path = home / "vault.db"
+    salt_path = home / "master_key_salt.bin"
+    policy_path = home / "policy.yaml"
+
+    monkeypatch.setenv("HERMES_VAULT_HOME", str(home))
+    monkeypatch.setenv("HERMES_VAULT_PASSPHRASE", "test-passphrase")
+    monkeypatch.setenv("HERMES_VAULT_POLICY", str(policy_path))
+
+    # Create vault with OAuth token
+    salt_path.write_bytes(os.urandom(16))
+    vault = Vault(db_path, salt_path, "test-passphrase")
+    vault.initialize()
+
+    future = utc_now() + timedelta(hours=24)
+    rec = vault.add_credential(
+        service="google",
+        secret="test-google-oauth-token",
+        credential_type="oauth_access_token",
+        alias="default",
+        replace_existing=True,
+    )
+    vault.set_expiry(rec.id, future)
+
+    # Create policy granting test-agent get_env access to google
+    policy_yaml = """\
+agents:
+  test-agent:
+    services:
+      google:
+        actions:
+          - get_env
+    max_ttl_seconds: 3600
+    raw_secret_access: false
+    ephemeral_env_only: true
+"""
+    policy_path.write_text(policy_yaml, encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        _hermes_group,
+        ["--no-banner", "broker", "env", "google", "--agent", "test-agent"],
+    )
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    data = json.loads(result.output)
+    assert "oauth_refresh" in data.get("metadata", {}), (
+        f"Expected oauth_refresh in metadata, got: {data}"
+    )
+    assert data["metadata"]["oauth_refresh"]["refreshed"] is False
+
+
+def test_broker_env_cli_denies_with_sanitized_reason(monkeypatch, tmp_path: Path) -> None:
+    """CLI broker env must deny expired OAuth tokens without refresh token, with sanitized reason."""
+    home = tmp_path
+    db_path = home / "vault.db"
+    salt_path = home / "master_key_salt.bin"
+    policy_path = home / "policy.yaml"
+
+    monkeypatch.setenv("HERMES_VAULT_HOME", str(home))
+    monkeypatch.setenv("HERMES_VAULT_PASSPHRASE", "test-passphrase")
+    monkeypatch.setenv("HERMES_VAULT_POLICY", str(policy_path))
+
+    # Create vault with expired OAuth token — no refresh token
+    salt_path.write_bytes(os.urandom(16))
+    vault = Vault(db_path, salt_path, "test-passphrase")
+    vault.initialize()
+
+    past = utc_now() - timedelta(seconds=10)
+    rec = vault.add_credential(
+        service="google",
+        secret="expired-oauth-token",
+        credential_type="oauth_access_token",
+        alias="default",
+        replace_existing=True,
+    )
+    vault.set_expiry(rec.id, past)
+    # Deliberately no refresh token
+
+    # Create policy granting test-agent get_env access to google
+    policy_yaml = """\
+agents:
+  test-agent:
+    services:
+      google:
+        actions:
+          - get_env
+          - rotate
+    max_ttl_seconds: 3600
+    raw_secret_access: false
+    ephemeral_env_only: true
+"""
+    policy_path.write_text(policy_yaml, encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        _hermes_group,
+        ["--no-banner", "broker", "env", "google", "--agent", "test-agent"],
+    )
+
+    assert result.exit_code == 1, (
+        f"Expected exit code 1, got {result.exit_code}: {result.output}"
+    )
+    data = json.loads(result.output)
+    assert "reason" in data
+    # No raw token leaked in reason
+    assert "expired-oauth-token" not in data["reason"], (
+        f"Raw token leaked in reason: {data['reason']}"
+    )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -21,7 +22,8 @@ from hermes_vault.mcp_server import (
     read_resource,
     server,
 )
-from hermes_vault.models import CredentialStatus
+from hermes_vault.models import CredentialStatus, utc_now
+from hermes_vault.vault import Vault
 
 
 # ── helpers ────────────────────────────────────────────────────────────────────
@@ -858,3 +860,62 @@ agents:
         "HERMES_VAULT_MCP_DEFAULT_AGENT",
     ):
         os.environ.pop(key, None)
+
+
+# ── MCP OAuth freshness tests ────────────────────────────────────────────────
+
+def test_get_ephemeral_env_mcp_includes_oauth_refresh_metadata(vault_with_policy, tmp_path):
+    """MCP get_ephemeral_env response includes oauth_refresh metadata when credential is OAuth."""
+    import hermes_vault.mcp_server as mcp_mod
+    os.environ["HERMES_VAULT_HOME"] = str(tmp_path)
+    # Replace the google API key with an OAuth access token far from expiry
+    future = utc_now() + timedelta(hours=24)
+    rec = vault_with_policy.vault.add_credential(
+        service="google",
+        secret="ya29.valid-token",
+        credential_type="oauth_access_token",
+        alias="primary",
+        replace_existing=True,
+    )
+    vault_with_policy.vault.set_expiry(rec.id, future)
+    # Use the same broker instance for MCP calls
+    mcp_mod._broker = vault_with_policy
+
+    result = _run_async(call_tool("get_ephemeral_env", {
+        "agent_id": "test-agent",
+        "service": "google",
+    }))
+    data = json.loads(result[0].text)
+    assert "env" in data
+    assert "metadata" in data
+    assert "oauth_refresh" in data["metadata"]
+    # Token is far from expiry, so no refresh needed
+    assert data["metadata"]["oauth_refresh"]["refreshed"] is False
+
+
+def test_get_ephemeral_env_mcp_denies_expired_no_refresh(vault_with_policy, tmp_path):
+    """MCP get_ephemeral_env denies with sanitized message when OAuth token is expired and no refresh token."""
+    import hermes_vault.mcp_server as mcp_mod
+    os.environ["HERMES_VAULT_HOME"] = str(tmp_path)
+    # Replace the google API key with an expired OAuth access token (no refresh token)
+    past = utc_now() - timedelta(hours=1)
+    rec = vault_with_policy.vault.add_credential(
+        service="google",
+        secret="ya29.expired-token",
+        credential_type="oauth_access_token",
+        alias="primary",
+        replace_existing=True,
+    )
+    vault_with_policy.vault.set_expiry(rec.id, past)
+    # No refresh token is added for google, so refresh will fail
+    # Use the same broker instance
+    mcp_mod._broker = vault_with_policy
+
+    result = _run_async(call_tool("get_ephemeral_env", {
+        "agent_id": "test-agent",
+        "service": "google",
+    }))
+    text = result[0].text
+    # Should be denied with a sanitized message (no raw tokens)
+    assert "Denied:" in text
+    assert "ya29" not in text

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -594,3 +594,72 @@ def test_capabilities_empty_explicit_list_grants_all() -> None:
     for cap in AgentCapability:
         allowed, _ = policy.can_capability("hermes", cap)
         assert allowed is True
+
+
+# ── rotate action for OAuth freshness ──────────────────────
+
+
+def test_can_rotate_denied_when_only_get_env_granted() -> None:
+    """An agent with only get_env should be denied rotate."""
+    config = PolicyConfig(
+        agents={
+            "dwight": AgentPolicy(
+                services=["openai"],
+                max_ttl_seconds=900,
+            )
+        }
+    )
+    agent = config.agents["dwight"]
+    config = config.model_copy(
+        update={
+            "agents": {
+                "dwight": agent.model_copy(
+                    update={
+                        "service_actions": {
+                            "openai": ServicePolicyEntry(
+                                actions=[ServiceAction.get_env],
+                            )
+                        }
+                    }
+                )
+            }
+        }
+    )
+    policy = PolicyEngine(config)
+
+    allowed, reason = policy.can("dwight", "openai", ServiceAction.rotate)
+    assert allowed is False
+    assert "not permitted" in reason
+
+
+def test_can_rotate_allowed_when_get_env_and_rotate_granted() -> None:
+    """An agent with get_env + rotate should be allowed rotate."""
+    config = PolicyConfig(
+        agents={
+            "dwight": AgentPolicy(
+                services=["openai"],
+                max_ttl_seconds=900,
+            )
+        }
+    )
+    agent = config.agents["dwight"]
+    config = config.model_copy(
+        update={
+            "agents": {
+                "dwight": agent.model_copy(
+                    update={
+                        "service_actions": {
+                            "openai": ServicePolicyEntry(
+                                actions=[ServiceAction.get_env, ServiceAction.rotate],
+                            )
+                        }
+                    }
+                )
+            }
+        }
+    )
+    policy = PolicyEngine(config)
+
+    allowed, reason = policy.can("dwight", "openai", ServiceAction.rotate)
+    assert allowed is True
+    assert "allowed" in reason

--- a/tests/test_release_regression.py
+++ b/tests/test_release_regression.py
@@ -28,8 +28,8 @@ def test_release_version_surfaces_align() -> None:
 
     from hermes_vault.mcp_server import server
 
-    assert pyproject["project"]["version"] == "0.14.0"
-    assert hermes_vault.__version__ == "0.14.0"
+    assert pyproject["project"]["version"] == "0.15.0"
+    assert hermes_vault.__version__ == "0.15.0"
     assert server.version == hermes_vault.__version__
 
 
@@ -43,6 +43,15 @@ def test_release_story_mentions_lifecycle_and_recovery() -> None:
     assert "policy drift" in readme.lower()
     assert "backup-verify" in operator_guide
     assert "restore --dry-run" in operator_guide
+
+
+def test_release_story_mentions_oauth_freshness() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    readme = (repo_root / "README.md").read_text(encoding="utf-8")
+    changelog = (repo_root / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert "Agent OAuth Freshness" in changelog
+    assert "oauth_refresh" in readme
 
 
 # ── TTL enforcement edge cases ────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "hermes-vault"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## v0.15.0 Agent OAuth Freshness

### Summary

When an agent requests env materialization through CLI `broker env` or MCP `get_ephemeral_env`, Hermes Vault now automatically refreshes near-expiry OAuth access tokens **before** handoff — using the existing `RefreshEngine`.

### Changes

**18 files changed, 1035 insertions, 11 deletions**

| Area | Change |
|------|--------|
| Broker | `_ensure_oauth_freshness()` checks expiry, refreshes via RefreshEngine when needed |
| Policy | Live refresh requires `ServiceAction.rotate` permission |
| CLI | `broker env` JSON includes `oauth_refresh` metadata; fixed double-encoding bug |
| MCP | `get_ephemeral_env` response includes `metadata` with `oauth_refresh` |
| Audit | Action `broker_env_oauth_refresh` records every attempt |
| Docs | README, CHANGELOG, operator-guide, mcp-server, lifecycle, threat-model updated |
| Version | 0.15.0 everywhere |

### Metadata model

```json
{"oauth_refresh": {"refreshed": true}}   // token was refreshed
{"oauth_refresh": {"refreshed": false}}  // token was current
{"oauth_refresh": {"refreshed": null}}   // no expiry (unknown)
{"oauth_refresh": {"refreshed": false, "error": "sanitized reason"}}  // refresh failed, token ok
// Non-OAuth: no oauth_refresh field at all
```

### Test results (final run)

```
692 passed, 1 skipped, 1 warning in 95.74s
```

(Up from 675 passed baseline — 17 new tests)

### Deferred

- PR #19 (EvoLink verifier) — not included, can review separately as patch follow-up