### PR TITLE
test: automate post-merge security validation

### DIFF
--- a/.github/workflows/post-merge-security-validation.yml
+++ b/.github/workflows/post-merge-security-validation.yml
@@ -104,6 +104,37 @@ jobs:
             dist/
           if-no-files-found: error
 
+  dashboard-screenshots:
+    name: Fake-data dashboard screenshots
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install project and browser tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . playwright
+          python -m playwright install --with-deps chromium
+
+      - name: Capture fake-data screenshots
+        run: python validation/capture_dashboard_screenshots.py
+
+      - name: Upload screenshot evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-screenshot-evidence
+          path: dashboard-screenshots/
+          if-no-files-found: error
+
   real-windows-dpapi:
     name: Real Windows DPAPI round trip
     runs-on: windows-latest
@@ -126,8 +157,10 @@ jobs:
       - name: Run real DPAPI validation
         shell: pwsh
         run: |
-          python validation/real_dpapi_validation.py |
-            Tee-Object -FilePath real-dpapi-validation.json
+          $output = python validation/real_dpapi_validation.py 2>&1
+          $exitCode = $LASTEXITCODE
+          $output | Tee-Object -FilePath real-dpapi-validation.json
+          if ($exitCode -ne 0) { exit $exitCode }
 
       - name: Upload DPAPI evidence
         if: always()

--- a/.github/workflows/post-merge-security-validation.yml
+++ b/.github/workflows/post-merge-security-validation.yml
@@ -1,0 +1,189 @@
+name: Post-merge security validation
+
+on:
+  push:
+    branches:
+      - chore/post-merge-validation
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: post-merge-security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  HERMES_AGENT_CONFORMANCE_SHA: 2ea39daeb1f675d72e5c21c9400f2d58d7e6d71a
+
+jobs:
+  operator-security:
+    name: Disposable vault and recovery boundaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run disposable operator validation
+        shell: bash
+        run: python validation/operator_security_validation.py | tee operator-security-validation.json
+
+      - name: Run focused security-boundary tests
+        shell: bash
+        run: |
+          python -m pytest tests -q --tb=short \
+            -k "secret_source or dashboard or recovery or backup or dpapi" \
+            --junitxml=focused-security-tests.xml
+
+      - name: Upload operator evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-security-evidence
+          path: |
+            operator-security-validation.json
+            focused-security-tests.xml
+          if-no-files-found: error
+
+  packaged-dashboard:
+    name: Installed wheel dashboard boundaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+
+      - name: Install wheel in a clean environment
+        shell: bash
+        run: |
+          python -m venv /tmp/hermes-vault-packaged-validation
+          /tmp/hermes-vault-packaged-validation/bin/python -m pip install --upgrade pip
+          /tmp/hermes-vault-packaged-validation/bin/python -m pip install dist/*.whl
+
+      - name: Validate packaged dashboard
+        shell: bash
+        run: |
+          /tmp/hermes-vault-packaged-validation/bin/python \
+            validation/packaged_dashboard_validation.py \
+            | tee packaged-dashboard-validation.json
+
+      - name: Upload packaged runtime evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: packaged-dashboard-evidence
+          path: |
+            packaged-dashboard-validation.json
+            dist/
+          if-no-files-found: error
+
+  real-windows-dpapi:
+    name: Real Windows DPAPI round trip
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install project with Windows support
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,windows]"
+
+      - name: Run real DPAPI validation
+        shell: pwsh
+        run: |
+          python validation/real_dpapi_validation.py |
+            Tee-Object -FilePath real-dpapi-validation.json
+
+      - name: Upload DPAPI evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: real-windows-dpapi-evidence
+          path: real-dpapi-validation.json
+          if-no-files-found: error
+
+  upstream-hermes-conformance:
+    name: Upstream Hermes Secret Source conformance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Hermes Vault
+        uses: actions/checkout@v4
+
+      - name: Check out pinned Hermes Agent
+        uses: actions/checkout@v4
+        with:
+          repository: NousResearch/hermes-agent
+          ref: ${{ env.HERMES_AGENT_CONFORMANCE_SHA }}
+          path: upstream-hermes
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install minimal conformance dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Run upstream conformance kit
+        env:
+          HERMES_AGENT_ROOT: ${{ github.workspace }}/upstream-hermes
+          PYTHONPATH: ${{ github.workspace }}/upstream-hermes
+        run: |
+          python -m pytest validation/test_upstream_hermes_conformance.py \
+            -q --tb=short --junitxml=upstream-hermes-conformance.xml
+
+      - name: Record pinned upstream commit
+        shell: bash
+        run: |
+          printf '{\n  "hermes_agent_commit": "%s"\n}\n' \
+            "${HERMES_AGENT_CONFORMANCE_SHA}" \
+            > upstream-hermes-version.json
+
+      - name: Upload conformance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upstream-hermes-conformance-evidence
+          path: |
+            upstream-hermes-conformance.xml
+            upstream-hermes-version.json
+          if-no-files-found: error

--- a/release-readiness/v0.20.0/readiness-report.md
+++ b/release-readiness/v0.20.0/readiness-report.md
@@ -4,7 +4,8 @@
 - Codename: Hermes Secret Source Plugin
 - Release commit: `32ecf03b3a1c946a990bda1d0ae699a2c1bd287a`
 - Hardening PR: #22 (squash-merge `034457b` onto master)
-- Report status: All blocking CI checks pass — awaiting security manual checks
+- Post-merge validation PR: #27
+- Report status: **Ready**
 
 ## Scope
 
@@ -19,11 +20,11 @@ The v0.20.0 changelog records the following maintainer validation:
 - upstream Hermes Secret Source conformance
 - isolated manual startup smoke cases for missing passphrase, valid mapping, aliases, empty values, policy denial, malformed refs, and closed-stdin behavior
 
-This report does not convert those notes into independent proof. Exact counts and fresh results must be added from a clean checkout.
+The post-merge validation below adds independent clean-runner evidence rather than treating those publication notes as proof.
 
 ## Repository-hardening validation
 
-The `chore/repo-hardening` branch adds independent GitHub checks for:
+PR #22 established independent GitHub checks for:
 
 - full tests on Ubuntu and Windows
 - Python 3.11 and 3.12
@@ -35,97 +36,145 @@ The `chore/repo-hardening` branch adds independent GitHub checks for:
 - dependency vulnerability audit
 - full-history secret scanning
 
-### Results
+### Hardening defects found and resolved
 
-#### Windows test fixes
+#### Typer 0.27.0 / Click 8.4.2 compatibility
 
-Two pre-existing Windows-only failures were fixed in this PR:
+Typer 0.27.0+ vendors an `Exit` class that is not a subclass of `click.exceptions.Exit`. The custom CLI invocation layer now normalizes `typer.Exit` into Click's expected exception while preserving the intended exit code across old and new attribute names.
 
-1. **`test_import_from_env_redact_source_only_imported_lines`** — Rich's
-   Console wraps output at 80 columns on non-TTY output. The long Windows
-   `tmp_path` pushed the tail of the output line across a word-wrap
-   boundary, so the substring `"1 skipped line"` spanned a newline.
-   Changed assertion to `"1 skipped"` which is immune to line-wrapping.
+#### Windows-only test assumptions
 
-2. **`test_v2_policy_normalizes_service_names`** — Used hardcoded
-   `Path("/tmp/_test_v2_norm.yaml")` which resolves to a relative path on
-   Windows. Changed to use `tmp_path` (pytest fixture) for a platform-
-   appropriate temp directory.
+- Rich output assertions no longer depend on an 80-column line-wrap boundary.
+- Policy normalization uses pytest's platform-neutral `tmp_path` rather than a hardcoded `/tmp` path.
 
-Reference: commit `70a9d44` of `chore/repo-hardening` branch.
+#### Real pywin32 DPAPI contract
 
-Typer 0.27.0+ vendored its own `Exit` exception class
-(`typer._click.exceptions.Exit` with attribute `.exit_code`) that is NOT a
-subclass of `click.exceptions.Exit` (which uses `.exit_code` in click 8.4.2 but
-`.code` in older click). Click's `main()` catches `click.exceptions.Exit` but
-cannot catch the vendored sibling class, so the exception propagates uncaught
-through Click's handler chain. The CliRunner then intercepts it as a generic
-`Exception` and sets `exit_code=1` regardless of the intended exit code.
+Post-merge validation found that the fake DPAPI shim had hidden a production incompatibility. Real pywin32 accepts five positional arguments for `CryptUnprotectData` and returns `(description, plaintext)`. Hermes Vault previously passed six arguments and expected raw bytes.
 
-**Fix:** Added a `typer.Exit` normalization handler in `HermesGroup.invoke()`
-(`src/hermes_vault/cli.py:171-183`) that catches the exception, reads the exit
-code from whichever attribute the installed version provides (`.exit_code` or
-`.code`), and re-raises as `click.exceptions.Exit` so Click's standard handler
-chain processes it correctly. This works with all typer versions (>=0.12.0) and
-click 8.x.
+`src/hermes_vault/dpapi.py` now uses the real pywin32 signature, normalizes the tuple result to bytes, and retains compatibility with raw-byte test doubles. `tests/test_dpapi_pywin32_contract.py` locks the real return shape into the normal suite.
 
-Reference: commit `HEAD` of `chore/repo-hardening` branch.
+## Final cross-platform CI evidence
 
-- [x] Linux tests pass on Python 3.11  
-  CI run: `29471789038`  
-  Core: 797 passed, 0 failed in 48.25s  
-  Secret Source plugin: 14 passed  
-  ✅
-- [x] Linux tests pass on Python 3.12  
-  Core: 797 passed, 0 failed in 50.83s  
-  Secret Source plugin: 14 passed  
-  ✅
-- [x] Windows tests pass on Python 3.11  
-  Core: 796 passed, 1 skipped (DPAPI symlink), 0 failed in 7m 58s  
-  Secret Source plugin: 14 passed  
-  ✅
-- [x] Windows tests pass on Python 3.12  
-  Core: 796 passed, 1 skipped (DPAPI symlink), 0 failed in 3m 42s  
-  Secret Source plugin: 14 passed  
-  ✅
-- [x] Ruff passes  
-  `ruff check . --output-format=concise` → "All checks passed!"
-- [x] mypy findings reviewed and triaged  
-  60 errors across 14 files — pre-existing baseline unchanged. No new errors
-  introduced by this fix. Advisory only (non-blocking).
-- [x] sdist and wheel build successfully  
-  `python -m build` → `hermes_vault-0.20.0.tar.gz` and `hermes_vault-0.20.0-py3-none-any.whl`
-- [x] built wheel installs and `hermes-vault --help` succeeds  
-  Validated via CI `Build and install package` job (artifacts pass smoke test)
-- [x] dependency audit passes or findings are documented  
-  All identified CVEs are in transitive dev/optional dependencies (pillow, nltk,
-  starlette, python-multipart, httplib2, msgpack, pynacl, pip, setuptools) --
-  nothing in hermes-vault's declared runtime deps. Project deps:
-  cryptography, mcp, pydantic, PyYAML, rich, typer, pathspec, requests.
-- [x] Gitleaks passes or findings are documented as verified test fixtures  
-  CI: full-history scan passed on run `29471789038` (Secret scan job: success)
+Validation commit: `4013dbc09b2b844d7bf59d15e55bb1093ad43ecb`
+
+CI run: `29475535741`
+
+- [x] Ubuntu, Python 3.11
+  - Core: 798 passed, 0 failed, 0 skipped
+  - Secret Source plugin: 14 passed
+- [x] Ubuntu, Python 3.12
+  - Core: 798 passed, 0 failed, 0 skipped
+  - Secret Source plugin: 14 passed
+- [x] Windows, Python 3.11
+  - Core: 797 passed, 1 skipped, 0 failed
+  - Secret Source plugin: 14 passed
+- [x] Windows, Python 3.12
+  - Core: 797 passed, 1 skipped, 0 failed
+  - Secret Source plugin: 14 passed
+- [x] Blocking Ruff checks pass
+- [x] Advisory Ruff and mypy reports were captured
+- [x] Source distribution and wheel build successfully
+- [x] Built wheel installs and `hermes-vault --help` succeeds
+- [x] Dependency audit passes
+- [x] Full-history Gitleaks scan passes
+
+Advisory engineering debt is tracked separately:
+
+- Ruff/Pyflakes cleanup: #24
+- Mypy cleanup: #25
+
+## Post-merge security validation
+
+Security validation run: `29475535772`
+
+### Disposable vault and recovery boundaries
+
+- [x] Fake credentials only
+- [x] Disposable vault home
+- [x] Lease-required broker access denies before checkout
+- [x] Lease checkout returns the expected ephemeral environment
+- [x] Mapped Secret Source fetch succeeds
+- [x] Malformed references fail closed
+- [x] Unknown agents fail closed
+- [x] Backup verification succeeds
+- [x] Restore dry-run succeeds
+- [x] Recovery drill reports healthy
+- [x] Validation summary contains no raw fake secret
+- [x] Focused security suite: 100 passed, 0 failed, 0 skipped
+
+Evidence artifact: `operator-security-evidence`
+
+### Real Windows DPAPI
+
+Windows Server 2025, Python 3.11, project installed with the `windows` extra:
+
+- [x] pywin32 is available
+- [x] DPAPI envelope is created
+- [x] Credential decrypts after reopening with a different passphrase
+- [x] Plaintext secret is absent from the SQLite database bytes
+- [x] Master-key rotation completes
+- [x] Credential decrypts after the rotated reopen
+
+Evidence artifact: `real-windows-dpapi-evidence`
+
+### Installed-wheel dashboard boundaries
+
+The built wheel was installed into a clean virtual environment before validation.
+
+- [x] Dashboard binds to `127.0.0.1`
+- [x] Non-local binding is rejected
+- [x] Missing bearer token receives `401`
+- [x] Invalid bearer token receives `401`
+- [x] Authorized credential metadata is sanitized
+- [x] Raw fake secrets do not appear in the response
+- [x] Packaged `index.html`, JavaScript, CSS, and brand image load successfully
+
+Evidence artifact: `packaged-dashboard-evidence`
+
+### Current dashboard screenshots
+
+Playwright launched the real local dashboard with a disposable fake-data vault and captured:
+
+- `hermes-vault-v0.20-overview.png`
+- `hermes-vault-v0.20-credentials.png`
+
+The browser asserted that neither fake secret value appeared in rendered page text before capture.
+
+Evidence artifact: `dashboard-screenshot-evidence`
+
+### Upstream Hermes Agent conformance
+
+Hermes Agent source was checked out at:
+
+`2ea39daeb1f675d72e5c21c9400f2d58d7e6d71a`
+
+The official `tests/secret_sources/conformance.py` kit ran against the Hermes Vault plugin using real upstream `agent.secret_sources` modules:
+
+- [x] 10 passed
+- [x] 0 failed
+- [x] 0 skipped
+
+Evidence artifact: `upstream-hermes-conformance-evidence`
 
 ## Security-boundary review
 
-- [ ] Secret Source remains startup-only and mapped-only
-- [ ] `HERMES_VAULT_PASSPHRASE` cannot be overwritten
-- [ ] fetch remains non-interactive and never uses `shell=True`
-- [ ] empty values are omitted
-- [ ] partial success returns warnings without hiding skipped mappings
-- [ ] zero usable secrets returns a structured failure
-- [ ] policy denial fails closed
-- [ ] MCP and Secret Source remain separate authority paths
-- [ ] logs, errors, tests, docs, and workflow artifacts contain no real secret material
+- [x] Secret Source remains startup-only and mapped-only
+- [x] `HERMES_VAULT_PASSPHRASE` is protected from overwrite
+- [x] Fetch remains non-interactive and uses Hermes `run_secret_cli()` with argv lists, never `shell=True`
+- [x] Empty values are omitted
+- [x] Partial success returns warnings without hiding usable mappings
+- [x] Zero usable secrets returns a structured failure
+- [x] Policy denial fails closed
+- [x] MCP and Secret Source remain separate authority paths
+- [x] Plugin discovery timing and the subsequent-process requirement are documented
+- [x] Tests, validation summaries, screenshots, and workflow artifacts use fake material and expose no raw secret values
 
-## Manual checks still required
+## Plugin discovery timing
 
-- [ ] Run a clean Windows checkout with DPAPI extras installed
-- [ ] Exercise a disposable vault through add, broker env, Secret Source fetch, backup, verify, restore dry-run, and recovery drill
-- [ ] Confirm dashboard localhost binding and token rejection behavior
-- [ ] Confirm packaged dashboard static assets load from the built wheel
-- [ ] Run upstream Hermes conformance against the current Hermes Agent package rather than only the local compatibility fixture
-- [ ] Capture current v0.20.0 dashboard screenshots using fake credentials
+Hermes plugin discovery occurs after the first dotenv load in the process that discovers the plugin. The source is available to subsequently spawned Hermes processes, including later sessions and child processes. The install guide documents this behavior so operators restart or start a subsequent session after first discovery.
 
 ## Release decision
 
-Do not mark this report `Ready` until blocking GitHub checks pass and the manual security-sensitive checks above have been recorded with exact commands and outcomes.
+**Ready.**
+
+All blocking cross-platform CI checks pass. Real Windows DPAPI, disposable-vault recovery, installed-wheel dashboard boundaries, fake-data screenshot capture, and the current upstream Hermes Secret Source conformance kit have independent evidence. The remaining Ruff and mypy work is explicitly advisory and tracked outside the v0.20.0 release gate.

--- a/src/hermes_vault/dpapi.py
+++ b/src/hermes_vault/dpapi.py
@@ -60,20 +60,24 @@ def protect_master_key(plaintext_key: bytes) -> bytes:
     # Deferred import so pywin32 is a true optional dependency.
     import win32crypt  # noqa: PLC0415  -- intentional lazy import
 
-    # CryptProtectData accepts 6 positional args at runtime
-    # (data, entropy, reserved, prompt, prompt_flags, flags).
-    # Pyright's stub expects 5; the real pywin32 accepts 6.
-    return DPAPI_HEADER + win32crypt.CryptProtectData(  # type: ignore[call-arg]
+    # CryptProtectData accepts six positional args at runtime:
+    # data, description, optional entropy, reserved, prompt struct, flags.
+    return DPAPI_HEADER + win32crypt.CryptProtectData(
         plaintext_key, None, None, None, None, 0,
     )
 
 
 def unprotect_master_key(envelope: bytes) -> bytes:
-    """Unwrap a DPAPI envelope. Returns the original plaintext bytes.
+    """Unwrap a DPAPI envelope and return the original plaintext bytes.
+
+    Real pywin32 accepts five positional arguments for
+    ``CryptUnprotectData`` and returns ``(description, data)``. The small
+    compatibility branch also accepts a raw-bytes result from test doubles or
+    older wrappers so callers always receive bytes.
 
     Raises :class:`ValueError` if the envelope does not start with
     :data:`DPAPI_HEADER`. Raises :class:`RuntimeError` when DPAPI is
-    not usable here.
+    not usable here or the platform wrapper returns an unexpected shape.
     """
     if not is_available():
         raise RuntimeError(
@@ -85,9 +89,18 @@ def unprotect_master_key(envelope: bytes) -> bytes:
     # Deferred import so pywin32 is a true optional dependency.
     import win32crypt  # noqa: PLC0415  -- intentional lazy import
 
-    return win32crypt.CryptUnprotectData(
-        envelope[len(DPAPI_HEADER):], None, None, None, None, 0,
+    result = win32crypt.CryptUnprotectData(
+        envelope[len(DPAPI_HEADER):], None, None, None, 0,
     )
+    if isinstance(result, tuple):
+        if len(result) != 2:
+            raise RuntimeError("DPAPI returned an unexpected result shape.")
+        _description, plaintext = result
+    else:
+        plaintext = result
+    if not isinstance(plaintext, bytes):
+        raise RuntimeError("DPAPI returned non-byte plaintext.")
+    return plaintext
 
 
 def should_use_dpapi(salt_path: Path) -> bool:

--- a/tests/test_dpapi_pywin32_contract.py
+++ b/tests/test_dpapi_pywin32_contract.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sys
+
+from hermes_vault import _platform, dpapi
+
+
+class _RealShapeWin32Crypt:
+    @staticmethod
+    def CryptUnprotectData(data, optional_entropy, reserved, prompt_struct, flags):
+        assert optional_entropy is None
+        assert reserved is None
+        assert prompt_struct is None
+        assert flags == 0
+        return ("Hermes Vault", bytes(data))
+
+
+def test_unprotect_master_key_normalizes_real_pywin32_tuple(monkeypatch) -> None:
+    monkeypatch.setattr(_platform, "dpapi_available", lambda: True)
+    monkeypatch.setitem(sys.modules, "win32crypt", _RealShapeWin32Crypt)
+
+    plaintext = b"x" * 32
+    envelope = dpapi.DPAPI_HEADER + plaintext
+
+    assert dpapi.unprotect_master_key(envelope) == plaintext

--- a/validation/capture_dashboard_screenshots.py
+++ b/validation/capture_dashboard_screenshots.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.broker import Broker
+from hermes_vault.config import AppSettings
+from hermes_vault.dashboard import DashboardAPI, DashboardContext, create_dashboard_server
+from hermes_vault.policy import PolicyEngine
+from hermes_vault.vault import Vault
+from hermes_vault.verifier import Verifier
+
+
+TOKEN = "fake-screenshot-token"
+FAKE_SECRETS = {
+    "openai": "fake-openai-screenshot-secret",
+    "github": "fake-github-screenshot-secret",
+}
+
+
+def _context(home: Path) -> DashboardContext:
+    policy_path = home / "policy.yaml"
+    policy_path.write_text(
+        """
+agents:
+  hermes:
+    services:
+      openai:
+        actions: [get_env, verify, metadata, issue_lease, list_leases, show_lease]
+      github:
+        actions: [get_env, verify, metadata, issue_lease, list_leases, show_lease]
+    capabilities: [list_credentials]
+    raw_secret_access: false
+    ephemeral_env_only: true
+    max_ttl_seconds: 900
+""".lstrip(),
+        encoding="utf-8",
+    )
+    settings = AppSettings(runtime_home=home, base_home=home, policy_path=policy_path)
+    settings.ensure_runtime_layout()
+    policy = PolicyEngine.from_yaml(policy_path)
+    vault = Vault(settings.db_path, settings.salt_path, "fake-screenshot-passphrase")
+    vault.add_credential(
+        "openai",
+        FAKE_SECRETS["openai"],
+        "api_key",
+        alias="default",
+        tags=["ai", "validation"],
+        notes="Fake credential for release documentation",
+    )
+    vault.add_credential(
+        "github",
+        FAKE_SECRETS["github"],
+        "personal_access_token",
+        alias="work",
+        tags=["development", "validation"],
+        notes="Fake credential for release documentation",
+    )
+    audit = AuditLogger(settings.db_path)
+    broker = Broker(vault=vault, policy=policy, verifier=Verifier(), audit=audit)
+    broker.issue_lease(
+        agent_id="hermes",
+        service_or_id="openai",
+        ttl_seconds=600,
+        purpose="dashboard screenshot validation",
+    )
+    return DashboardContext(
+        settings=settings,
+        vault=vault,
+        policy=policy,
+        broker=broker,
+        audit=audit,
+    )
+
+
+def main() -> None:
+    output = Path("dashboard-screenshots")
+    output.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="hermes-vault-screenshots-") as raw_home:
+        ctx = _context(Path(raw_home))
+        api = DashboardAPI(context_factory=lambda: ctx)
+        server = create_dashboard_server(token=TOKEN, api=api)
+        try:
+            port = server.server_address[1]
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch(
+                    headless=True,
+                    args=["--disable-dev-shm-usage"],
+                )
+                page = browser.new_page(viewport={"width": 1600, "height": 1000})
+                page.goto(
+                    f"http://127.0.0.1:{port}/?token={TOKEN}&no_intro=1",
+                    wait_until="networkidle",
+                )
+                page.wait_for_function(
+                    "document.querySelector('#connection')?.textContent === 'Local session'"
+                )
+                page.wait_for_function(
+                    "document.querySelector('#metric-credentials')?.textContent === '2'"
+                )
+                body_text = page.locator("body").inner_text()
+                for secret in FAKE_SECRETS.values():
+                    assert secret not in body_text
+
+                overview_path = output / "hermes-vault-v0.20-overview.png"
+                page.screenshot(path=str(overview_path), full_page=True)
+
+                page.locator("button[data-view='credentials']").click()
+                page.wait_for_function(
+                    "document.querySelector('#credentials')?.classList.contains('active')"
+                )
+                page.wait_for_selector("#credential-table table")
+                credentials_text = page.locator("body").inner_text()
+                for secret in FAKE_SECRETS.values():
+                    assert secret not in credentials_text
+
+                credentials_path = output / "hermes-vault-v0.20-credentials.png"
+                page.screenshot(path=str(credentials_path), full_page=True)
+                browser.close()
+
+            summary = {
+                "version": "dashboard-screenshot-evidence-v1",
+                "fake_credentials_only": True,
+                "screenshots": [
+                    overview_path.name,
+                    credentials_path.name,
+                ],
+                "raw_secret_values_absent_from_rendered_ui": True,
+            }
+            (output / "evidence.json").write_text(
+                json.dumps(summary, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        finally:
+            server.shutdown()
+            server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/operator_security_validation.py
+++ b/validation/operator_security_validation.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.backup import restore_dry_run, verify_backup_file
+from hermes_vault.broker import Broker
+from hermes_vault.policy import PolicyEngine
+from hermes_vault.recovery import run_recovery_drill
+from hermes_vault.secret_source import fetch_secret_source_bindings
+from hermes_vault.vault import Vault
+from hermes_vault.verifier import Verifier
+
+
+FAKE_SECRET = "fake-openai-post-merge-validation"
+
+
+def _write_policy(path: Path) -> None:
+    path.write_text(
+        """
+agents:
+  hermes:
+    services:
+      openai:
+        actions: [get_env, verify, metadata, issue_lease, list_leases, show_lease]
+        require_lease_for_env: true
+    capabilities: [list_credentials]
+    raw_secret_access: false
+    ephemeral_env_only: true
+    max_ttl_seconds: 900
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="hermes-vault-validation-") as raw_home:
+        home = Path(raw_home)
+        policy_path = home / "policy.yaml"
+        db_path = home / "vault.db"
+        salt_path = home / "master_key_salt.bin"
+        backup_path = home / "vault-backup.json"
+        _write_policy(policy_path)
+
+        policy = PolicyEngine.from_yaml(policy_path)
+        vault = Vault(db_path, salt_path, "fake-local-passphrase")
+        vault.add_credential(
+            "openai",
+            FAKE_SECRET,
+            "api_key",
+            alias="default",
+            tags=["validation"],
+            notes="Disposable post-merge validation credential",
+        )
+        audit = AuditLogger(db_path)
+        broker = Broker(vault=vault, policy=policy, verifier=Verifier(), audit=audit)
+
+        denied_before_lease = broker.get_ephemeral_env(
+            service="openai",
+            agent_id="hermes",
+            ttl=300,
+        )
+        assert denied_before_lease.allowed is False
+        assert denied_before_lease.metadata.get("lease_required") is True
+
+        checkout = broker.lease_checkout(
+            agent_id="hermes",
+            service="openai",
+            ttl_seconds=300,
+            purpose="post-merge security validation",
+        )
+        assert checkout.allowed is True
+        assert checkout.env == {"OPENAI_API_KEY": FAKE_SECRET}
+        assert checkout.metadata["lease_checkout"]["lease_id"]
+
+        secret_source = fetch_secret_source_bindings(
+            vault=vault,
+            policy=policy,
+            agent_id="hermes",
+            ttl=300,
+            bindings=["OPENAI_API_KEY=hv://openai"],
+        )
+        assert secret_source.ok is True
+        assert secret_source.secrets == {"OPENAI_API_KEY": FAKE_SECRET}
+
+        malformed = fetch_secret_source_bindings(
+            vault=vault,
+            policy=policy,
+            agent_id="hermes",
+            ttl=300,
+            bindings=["OPENAI_API_KEY=not-a-vault-ref"],
+        )
+        assert malformed.ok is False
+        assert malformed.errors["OPENAI_API_KEY=not-a-vault-ref"].kind == "REF_INVALID"
+
+        denied_agent = fetch_secret_source_bindings(
+            vault=vault,
+            policy=policy,
+            agent_id="unknown-agent",
+            ttl=300,
+            bindings=["OPENAI_API_KEY=hv://openai"],
+        )
+        assert denied_agent.ok is False
+        assert denied_agent.errors["OPENAI_API_KEY"].kind == "AUTH_FAILED"
+
+        backup = vault.export_backup()
+        backup_path.write_text(json.dumps(backup, indent=2), encoding="utf-8")
+
+        verify = verify_backup_file(backup_path, vault)
+        assert verify.decryptable is True
+        assert not verify.findings
+
+        dry_run = restore_dry_run(backup_path, vault)
+        assert dry_run.decryptable is True
+        assert not dry_run.findings
+
+        recovery = run_recovery_drill(
+            backup_path=backup_path,
+            vault=vault,
+            policy=policy,
+        )
+        assert recovery.healthy is True
+        assert recovery.backup_verify["decryptable"] is True
+        assert recovery.restore_dry_run["decryptable"] is True
+
+        summary = {
+            "version": "post-merge-security-validation-v1",
+            "vault_home_disposable": True,
+            "credential_count": len(vault.list_credentials()),
+            "lease_checkout_allowed": checkout.allowed,
+            "secret_source_mapping_count": len(secret_source.secrets),
+            "malformed_ref_failed_closed": malformed.ok is False,
+            "unknown_agent_failed_closed": denied_agent.ok is False,
+            "backup_decryptable": verify.decryptable,
+            "restore_dry_run_decryptable": dry_run.decryptable,
+            "recovery_healthy": recovery.healthy,
+        }
+        rendered = json.dumps(summary, sort_keys=True)
+        assert FAKE_SECRET not in rendered
+        print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/packaged_dashboard_validation.py
+++ b/validation/packaged_dashboard_validation.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.broker import Broker
+from hermes_vault.config import AppSettings
+from hermes_vault.dashboard import (
+    DashboardAPI,
+    DashboardContext,
+    create_dashboard_server,
+    dashboard_static_dir,
+)
+from hermes_vault.policy import PolicyEngine
+from hermes_vault.vault import Vault
+from hermes_vault.verifier import Verifier
+
+
+FAKE_SECRET = "fake-dashboard-validation-secret"
+TOKEN = "fake-dashboard-validation-token"
+
+
+def _request(url: str, *, token: str | None = None) -> tuple[int, bytes]:
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def _context(home: Path) -> DashboardContext:
+    policy_path = home / "policy.yaml"
+    policy_path.write_text(
+        """
+agents:
+  hermes:
+    services:
+      openai:
+        actions: [get_env, verify, metadata]
+    capabilities: [list_credentials]
+    raw_secret_access: false
+    ephemeral_env_only: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+    settings = AppSettings(runtime_home=home, base_home=home, policy_path=policy_path)
+    settings.ensure_runtime_layout()
+    policy = PolicyEngine.from_yaml(policy_path)
+    vault = Vault(settings.db_path, settings.salt_path, "fake-dashboard-passphrase")
+    vault.add_credential("openai", FAKE_SECRET, "api_key", alias="default")
+    audit = AuditLogger(settings.db_path)
+    broker = Broker(vault=vault, policy=policy, verifier=Verifier(), audit=audit)
+    return DashboardContext(
+        settings=settings,
+        vault=vault,
+        policy=policy,
+        broker=broker,
+        audit=audit,
+    )
+
+
+def main() -> None:
+    static_root = dashboard_static_dir()
+    expected_assets = [
+        static_root / "index.html",
+        static_root / "app.js",
+        static_root / "styles.css",
+        static_root / "assets" / "hermes-vault-console-brand.png",
+    ]
+    for asset in expected_assets:
+        assert asset.is_file(), f"packaged dashboard asset missing: {asset}"
+
+    try:
+        create_dashboard_server(host="0.0.0.0")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("dashboard accepted a non-local bind address")
+
+    with tempfile.TemporaryDirectory(prefix="hermes-vault-dashboard-") as raw_home:
+        home = Path(raw_home)
+        ctx = _context(home)
+        api = DashboardAPI(context_factory=lambda: ctx)
+        server = create_dashboard_server(token=TOKEN, api=api)
+        try:
+            assert server.server_address[0] == "127.0.0.1"
+            port = server.server_address[1]
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+
+            base = f"http://127.0.0.1:{port}"
+            no_token_status, _ = _request(f"{base}/api/credentials")
+            wrong_token_status, _ = _request(
+                f"{base}/api/credentials",
+                token="wrong-validation-token",
+            )
+            ok_status, payload_bytes = _request(
+                f"{base}/api/credentials",
+                token=TOKEN,
+            )
+            assert no_token_status == 401
+            assert wrong_token_status == 401
+            assert ok_status == 200
+
+            payload_text = payload_bytes.decode("utf-8")
+            payload = json.loads(payload_text)
+            assert payload["credentials"][0]["service"] == "openai"
+            assert "encrypted_payload" not in payload_text
+            assert FAKE_SECRET not in payload_text
+
+            for relative_path in (
+                "index.html",
+                "app.js",
+                "styles.css",
+                "assets/hermes-vault-console-brand.png",
+            ):
+                status, body = _request(f"{base}/{relative_path}")
+                assert status == 200
+                assert body
+
+            summary = {
+                "version": "packaged-dashboard-validation-v1",
+                "static_asset_count": len(expected_assets),
+                "bound_to_localhost": True,
+                "missing_token_rejected": no_token_status == 401,
+                "invalid_token_rejected": wrong_token_status == 401,
+                "authorized_api_sanitized": FAKE_SECRET not in payload_text,
+            }
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        finally:
+            server.shutdown()
+            server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/real_dpapi_validation.py
+++ b/validation/real_dpapi_validation.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from hermes_vault import dpapi
+from hermes_vault.vault import Vault
+
+
+FAKE_SECRET = "fake-dpapi-validation-secret"
+
+
+def main() -> None:
+    if os.name != "nt":
+        raise RuntimeError("real DPAPI validation must run on Windows")
+    if not dpapi.is_available():
+        raise RuntimeError("DPAPI is unavailable after installing the Windows extra")
+
+    previous = os.environ.get("HERMES_VAULT_DPAPI")
+    os.environ["HERMES_VAULT_DPAPI"] = "1"
+    try:
+        with tempfile.TemporaryDirectory(prefix="hermes-vault-dpapi-") as raw_home:
+            home = Path(raw_home)
+            db_path = home / "vault.db"
+            salt_path = home / "master_key_salt.bin"
+
+            vault = Vault(db_path, salt_path, "fake-passphrase")
+            assert salt_path.read_bytes().startswith(dpapi.DPAPI_HEADER)
+            vault.add_credential("openai", FAKE_SECRET, "api_key", alias="default")
+
+            reopened = Vault(db_path, salt_path, "different-passphrase")
+            resolved = reopened.get_secret("openai")
+            assert resolved is not None
+            assert resolved.secret == FAKE_SECRET
+            assert FAKE_SECRET.encode("utf-8") not in db_path.read_bytes()
+
+            reopened.rotate_master_key("different-passphrase", "rotated-passphrase")
+            assert salt_path.read_bytes().startswith(dpapi.DPAPI_HEADER)
+            rotated = Vault(db_path, salt_path, "rotated-passphrase")
+            rotated_secret = rotated.get_secret("openai")
+            assert rotated_secret is not None
+            assert rotated_secret.secret == FAKE_SECRET
+
+            summary = {
+                "version": "real-dpapi-validation-v1",
+                "platform": "windows",
+                "pywin32_available": True,
+                "dpapi_envelope_created": True,
+                "credential_round_trip": True,
+                "master_key_rotation_round_trip": True,
+                "plaintext_absent_from_database": True,
+            }
+            rendered = json.dumps(summary, sort_keys=True)
+            assert FAKE_SECRET not in rendered
+            print(json.dumps(summary, indent=2, sort_keys=True))
+    finally:
+        if previous is None:
+            os.environ.pop("HERMES_VAULT_DPAPI", None)
+        else:
+            os.environ["HERMES_VAULT_DPAPI"] = previous
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/real_dpapi_validation.py
+++ b/validation/real_dpapi_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import json
 import os
 import tempfile
@@ -21,7 +22,13 @@ def main() -> None:
     previous = os.environ.get("HERMES_VAULT_DPAPI")
     os.environ["HERMES_VAULT_DPAPI"] = "1"
     try:
-        with tempfile.TemporaryDirectory(prefix="hermes-vault-dpapi-") as raw_home:
+        # sqlite3 connection context managers commit or roll back but do not
+        # guarantee immediate OS-handle release. Explicit collection below
+        # prevents Windows runner cleanup from racing delayed finalizers.
+        with tempfile.TemporaryDirectory(
+            prefix="hermes-vault-dpapi-",
+            ignore_cleanup_errors=True,
+        ) as raw_home:
             home = Path(raw_home)
             db_path = home / "vault.db"
             salt_path = home / "master_key_salt.bin"
@@ -55,6 +62,9 @@ def main() -> None:
             rendered = json.dumps(summary, sort_keys=True)
             assert FAKE_SECRET not in rendered
             print(json.dumps(summary, indent=2, sort_keys=True))
+
+            del rotated_secret, rotated, resolved, reopened, vault
+            gc.collect()
     finally:
         if previous is None:
             os.environ.pop("HERMES_VAULT_DPAPI", None)

--- a/validation/test_upstream_hermes_conformance.py
+++ b/validation/test_upstream_hermes_conformance.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT_ROOT = Path(os.environ["HERMES_AGENT_ROOT"]).resolve()
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_conformance = _load_module(
+    "upstream_hermes_secret_source_conformance",
+    HERMES_AGENT_ROOT / "tests" / "secret_sources" / "conformance.py",
+)
+_plugin = _load_module(
+    "hermes_vault_secret_source_plugin_upstream_validation",
+    REPO_ROOT / "plugins" / "hermes-vault-secret-source" / "__init__.py",
+)
+
+
+class TestHermesVaultUpstreamConformance(_conformance.SecretSourceConformance):
+    @pytest.fixture
+    def source(self):
+        return _plugin.HermesVaultSource()


### PR DESCRIPTION
## Summary

Automates and completes the remaining v0.20.0 security-readiness checks with reproducible CI evidence.

## Validation layers

- disposable vault operator flow covering lease-gated broker env, Secret Source mapping, malformed refs, denied agents, backup verification, restore dry-run, and recovery drill
- 100 focused source tests for Secret Source, dashboard, recovery, backup, and DPAPI boundaries
- clean installed-wheel dashboard validation covering packaged assets, localhost-only binding, missing/invalid token rejection, and sanitized authorized responses
- real Windows DPAPI creation, reopen, encrypted-database check, and master-key rotation using pywin32
- official upstream Hermes Secret Source conformance kit pinned to `NousResearch/hermes-agent@2ea39daeb1f675d72e5c21c9400f2d58d7e6d71a`
- Playwright screenshots from the real local dashboard using a disposable fake-data vault

## Production bug found and fixed

The real Windows job exposed a defect hidden by the existing fake DPAPI shim:

- pywin32 `CryptUnprotectData` accepts five arguments, not six
- it returns `(description, plaintext)`, not raw plaintext bytes

`src/hermes_vault/dpapi.py` now follows the real pywin32 contract and normalizes the result. A focused regression test covers that return shape.

## Evidence

Validation commit: `4013dbc09b2b844d7bf59d15e55bb1093ad43ecb`

### Post-merge security run `29475535772`

- Disposable vault and recovery boundaries: passed
- Focused security tests: 100 passed
- Installed wheel dashboard boundaries: passed
- Real Windows DPAPI round trip: passed
- Upstream Hermes conformance: 10 passed
- Fake-data dashboard screenshots: passed

### Normal CI run `29475535741`

- Ubuntu 3.11: 798 core + 14 plugin passed
- Ubuntu 3.12: 798 core + 14 plugin passed
- Windows 3.11: 797 core passed, 1 skipped + 14 plugin passed
- Windows 3.12: 797 core passed, 1 skipped + 14 plugin passed
- Static analysis: passed
- Package build and wheel smoke: passed
- Dependency audit: passed
- Full-history Gitleaks: passed

## Safety

- fake credentials only
- disposable temporary vault homes
- no provider calls
- no repository secrets required
- screenshots and evidence summaries are checked for raw fake-secret values

## Documentation

`release-readiness/v0.20.0/readiness-report.md` now records the exact evidence and marks v0.20.0 `Ready`.

## Tracking

Completes the release-security validation portion of #21. Branch protection remains a repository-settings action because the connected GitHub API does not expose ruleset or branch-protection mutations.

Keep this PR in draft until the final head CI run after the readiness-report update passes.