### PR TITLE
chore: add temporary Ruff cleanup runner

### DIFF
--- a/.github/workflows/ruff-branch-fixer.yml
+++ b/.github/workflows/ruff-branch-fixer.yml
@@ -1,0 +1,98 @@
+name: Temporary Ruff branch fixer
+
+on:
+  push:
+    branches:
+      - chore/ruff-cleanup
+
+permissions:
+  contents: write
+
+jobs:
+  fix:
+    if: github.repository == 'asimons81/hermes-vault' && github.actor == 'asimons81'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out cleanup branch
+        uses: actions/checkout@v7
+        with:
+          ref: chore/ruff-cleanup
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Merge current master
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin master
+          git merge --no-edit origin/master
+
+      - name: Apply reviewed Ruff fixes
+        shell: bash
+        run: |
+          python -m pip install ruff==0.15.22
+          ruff check . --select F --fix --unsafe-fixes
+
+      - name: Enable full Pyflakes enforcement
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          pyproject = Path("pyproject.toml")
+          text = pyproject.read_text(encoding="utf-8")
+          old = (
+              "# Start with fatal correctness classes as the blocking baseline. The full\n"
+              "# Pyflakes report is preserved as an advisory CI artifact for cleanup.\n"
+              "select = [\"E9\", \"F63\", \"F7\", \"F82\"]"
+          )
+          new = (
+              "# Block syntax failures and the full Pyflakes correctness family.\n"
+              "# Style-only rules remain out of scope until adopted intentionally.\n"
+              "select = [\"E9\", \"F\"]"
+          )
+          if old not in text:
+              raise SystemExit("expected Ruff configuration not found")
+          pyproject.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+          workflow = Path(".github/workflows/ci.yml")
+          text = workflow.read_text(encoding="utf-8")
+          old = '''      - name: Run blocking Ruff checks
+        shell: bash
+        run: ruff check . --output-format=concise | tee ruff-blocking-report.txt
+
+      - name: Run full Ruff baseline
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: ruff check . --select F --output-format=concise | tee ruff-advisory-report.txt
+'''
+          new = '''      - name: Run Ruff checks
+        shell: bash
+        run: ruff check . --output-format=concise | tee ruff-report.txt
+'''
+          if old not in text:
+              raise SystemExit("expected Ruff CI block not found")
+          text = text.replace(old, new, 1)
+          artifact_old = "            ruff-blocking-report.txt\n            ruff-advisory-report.txt\n            mypy-report.txt"
+          artifact_new = "            ruff-report.txt\n            mypy-report.txt"
+          if artifact_old not in text:
+              raise SystemExit("expected Ruff artifact list not found")
+          workflow.write_text(text.replace(artifact_old, artifact_new, 1), encoding="utf-8")
+          PY
+
+      - name: Verify and commit
+        shell: bash
+        run: |
+          ruff check . --output-format=concise
+          rm -f .github/workflows/ruff-finalize.yml
+          rm -f .github/workflows/ruff-branch-fixer.yml
+          git diff --check
+          git add -A
+          git commit -m "chore: eliminate Ruff advisory baseline"
+          git push origin HEAD:chore/ruff-cleanup


### PR DESCRIPTION
## Purpose

Temporarily installs a tightly scoped branch-only runner so #28 can apply the five reviewed Ruff F841 fixes, merge current `master`, enable full Pyflakes enforcement, and delete both temporary workflow files.

## Safety

- triggers only for pushes to `chore/ruff-cleanup`
- runs only when the actor is `asimons81`
- writes only to that feature branch
- removes itself from the cleanup branch before #28 merges
- no secrets or provider calls

Close and remove this runner through #28 after the cleanup branch has been finalized.