### PR TITLE
chore: target temporary Ruff fixer to PR #28

### DIFF
--- a/.github/workflows/ruff-branch-fixer.yml
+++ b/.github/workflows/ruff-branch-fixer.yml
@@ -1,16 +1,24 @@
-name: Temporary Ruff branch fixer
+name: Temporary Ruff PR fixer
 
 on:
-  push:
+  pull_request_target:
+    types:
+      - synchronize
+      - reopened
     branches:
-      - chore/ruff-cleanup
+      - master
 
 permissions:
   contents: write
 
 jobs:
   fix:
-    if: github.repository == 'asimons81/hermes-vault' && github.actor == 'asimons81'
+    if: >-
+      github.repository == 'asimons81/hermes-vault' &&
+      github.event.pull_request.number == 28 &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref == 'chore/ruff-cleanup' &&
+      github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check out cleanup branch
@@ -90,6 +98,7 @@ jobs:
         shell: bash
         run: |
           ruff check . --output-format=concise
+          rm -f .github/ruff-cleanup-trigger.txt
           rm -f .github/workflows/ruff-finalize.yml
           rm -f .github/workflows/ruff-branch-fixer.yml
           git diff --check


### PR DESCRIPTION
## Purpose

Makes the already-reviewed temporary Ruff fixer run only for synchronizations of same-repository PR #28.

## Security constraints

- `pull_request_target` is restricted to PR number 28
- head repository must equal this repository
- head branch must be `chore/ruff-cleanup`
- bot-authored recursive updates are skipped
- the job writes only to `chore/ruff-cleanup`
- PR #28 removes this workflow before merge

## Work performed on PR #28

- merge current master
- apply Ruff's five reviewed F841 fixes
- enable the full Pyflakes `F` family as blocking
- remove the advisory duplicate Ruff step
- delete the trigger marker and both temporary workflow files

Full normal and deep-security validation are required before this runner reaches master.