### PR TITLE
fix: resolve temporary Ruff runner self-conflict

### DIFF
--- a/.github/workflows/ruff-branch-fixer.yml
+++ b/.github/workflows/ruff-branch-fixer.yml
@@ -38,7 +38,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin master
-          git merge --no-edit origin/master
+          git merge -X theirs --no-edit origin/master
 
       - name: Apply reviewed Ruff fixes
         shell: bash


### PR DESCRIPTION
## Problem

The scoped PR #28 fixer correctly starts from `master`, but `git merge origin/master` conflicts on the fixer workflow because the cleanup branch carries an older temporary copy.

## Fix

Use Git's recursive merge preference for the current `master` side:

```bash
git merge -X theirs --no-edit origin/master
```

The workflow still remains restricted to same-repository PR #28 and still deletes itself before the cleanup PR merges.

No product code changes. Full normal and deep-security checks required.