### PR TITLE
feat: add Audit Assurance core

### DIFF
--- a/src/hermes_vault/_platform.py
+++ b/src/hermes_vault/_platform.py
@@ -218,6 +218,26 @@ def write_bytes_durable(path: Path, content: bytes) -> None:
     secure_file(path)
 
 
+def replace_bytes_durable(path: Path, content: bytes) -> None:
+    """Atomically replace *path* with durable, owner-only bytes."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".pending", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            if not _is_windows():
+                os.fsync(handle.fileno())
+        secure_file(temporary)
+        os.replace(temporary, path)
+        secure_file(path)
+        fsync_directory(path.parent)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
 def write_text_durable(path: Path, content: str) -> None:
     """Write text durably."""
     write_bytes_durable(path, content.encode("utf-8"))

--- a/src/hermes_vault/audit.py
+++ b/src/hermes_vault/audit.py
@@ -2,17 +2,35 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 from hermes_vault import _platform
-
+from hermes_vault.audit_integrity.service import AuditIntegrityService
 from hermes_vault.models import AccessLogRecord
 
 
 class AuditLogger:
-    def __init__(self, db_path: Path) -> None:
+    """Records audit decisions and, when unlocked, protects each new row.
+
+    A logger without a master key remains a read-only/backward-compatible
+    legacy logger. Normal runtime construction supplies ``master_key`` from
+    the unlocked :class:`Vault`, which activates the v0.21 assurance path.
+    """
+
+    def __init__(self, db_path: Path, master_key: bytes | None = None, checkpoint_path: Path | None = None) -> None:
         self.db_path = db_path
+        self.master_key = master_key
+        self.checkpoint_path = checkpoint_path
+        self._integrity: AuditIntegrityService | None = None
+
+    @property
+    def integrity(self) -> AuditIntegrityService | None:
+        if self.master_key is None:
+            return None
+        if self._integrity is None:
+            self._integrity = AuditIntegrityService(self.db_path, self.master_key, self.checkpoint_path)
+        return self._integrity
 
     def initialize(self) -> None:
         with sqlite3.connect(self.db_path) as conn:
@@ -35,100 +53,61 @@ class AuditLogger:
             columns = {row[1] for row in conn.execute("PRAGMA table_info(access_logs)")}
             if "metadata_json" not in columns:
                 conn.execute("ALTER TABLE access_logs ADD COLUMN metadata_json TEXT")
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_access_logs_agent_id ON access_logs(agent_id)"
-            )
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_access_logs_service ON access_logs(service)"
-            )
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_access_logs_timestamp ON access_logs(timestamp)"
-            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_access_logs_agent_id ON access_logs(agent_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_access_logs_service ON access_logs(service)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_access_logs_timestamp ON access_logs(timestamp)")
             conn.commit()
         if self.db_path.exists():
             _platform.secure_file(self.db_path)
 
     def record(self, record: AccessLogRecord) -> None:
         self.initialize()
+        if self.integrity is not None:
+            self.integrity.append(record)
+            return
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
-                """
-                INSERT INTO access_logs (
+                """INSERT INTO access_logs (
                     id, timestamp, agent_id, service, action, decision, reason, ttl_seconds, verification_result, metadata_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    record.id,
-                    record.timestamp.isoformat(),
-                    record.agent_id,
-                    record.service,
-                    record.action,
-                    record.decision.value,
-                    record.reason,
-                    record.ttl_seconds,
-                    record.verification_result.value if record.verification_result else None,
-                    json.dumps(record.metadata, sort_keys=True) if record.metadata else "{}",
-                ),
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (record.id, record.timestamp.isoformat(), record.agent_id, record.service, record.action, record.decision.value,
+                 record.reason, record.ttl_seconds, record.verification_result.value if record.verification_result else None,
+                 json.dumps(record.metadata, sort_keys=True) if record.metadata else "{}"),
             )
             conn.commit()
 
-    def list_recent(
-        self,
-        limit: int = 100,
-        agent_id: str | None = None,
-        service: str | None = None,
-        action: str | None = None,
-        decision: str | None = None,
-        since: datetime | None = None,
-        until: datetime | None = None,
-    ) -> list[dict[str, object]]:
+    def list_recent(self, limit: int = 100, agent_id: str | None = None, service: str | None = None, action: str | None = None, decision: str | None = None, since: datetime | None = None, until: datetime | None = None) -> list[dict[str, object]]:
         self.initialize()
         conditions: list[str] = []
         params: list[object] = []
-
-        if agent_id is not None:
-            conditions.append("agent_id = ?")
-            params.append(agent_id)
-        if service is not None:
-            conditions.append("service = ?")
-            params.append(service)
-        if action is not None:
-            conditions.append("action = ?")
-            params.append(action)
-        if decision is not None:
-            conditions.append("decision = ?")
-            params.append(decision)
+        for field, value in (("agent_id", agent_id), ("service", service), ("action", action), ("decision", decision)):
+            if value is not None:
+                conditions.append(f"{field} = ?")
+                params.append(value)
         if since is not None:
             conditions.append("timestamp >= ?")
             params.append(since.isoformat())
         if until is not None:
             conditions.append("timestamp <= ?")
             params.append(until.isoformat())
-
         where_clause = " AND ".join(conditions) if conditions else "1=1"
-        query = f"SELECT * FROM access_logs WHERE {where_clause} ORDER BY timestamp DESC LIMIT ?"
         params.append(limit)
-
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
-            rows = conn.execute(query, params).fetchall()
+            rows = conn.execute(f"SELECT * FROM access_logs WHERE {where_clause} ORDER BY timestamp DESC LIMIT ?", params).fetchall()
         results: list[dict[str, object]] = []
         for row in rows:
             item = dict(row)
-            metadata_raw = item.get("metadata_json")
-            if isinstance(metadata_raw, str) and metadata_raw:
-                try:
-                    item["metadata"] = json.loads(metadata_raw)
-                except json.JSONDecodeError:
-                    item["metadata"] = {"raw": metadata_raw}
-            else:
-                item["metadata"] = {}
+            raw = item.get("metadata_json")
+            try:
+                item["metadata"] = json.loads(raw) if isinstance(raw, str) and raw else {}
+            except json.JSONDecodeError:
+                item["metadata"] = {"raw": raw}
             item.pop("metadata_json", None)
             results.append(item)
         return results
 
     def export_jsonl(self, path: Path, limit: int = 100) -> None:
-        entries = self.list_recent(limit=limit)
         with path.open("w", encoding="utf-8") as handle:
-            for entry in entries:
+            for entry in self.list_recent(limit=limit):
                 handle.write(json.dumps(entry, sort_keys=True) + "\n")

--- a/src/hermes_vault/audit_integrity/__init__.py
+++ b/src/hermes_vault/audit_integrity/__init__.py
@@ -1,0 +1,5 @@
+"""Local audit-history integrity assurance for Hermes Vault."""
+from hermes_vault.audit_integrity.models import AuditCheckpointStatus, AuditIntegrityStatus, AuditVerificationResult
+from hermes_vault.audit_integrity.service import AuditIntegrityError, AuditIntegrityService
+
+__all__ = ["AuditCheckpointStatus", "AuditIntegrityError", "AuditIntegrityService", "AuditIntegrityStatus", "AuditVerificationResult"]

--- a/src/hermes_vault/audit_integrity/canonical.py
+++ b/src/hermes_vault/audit_integrity/canonical.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+CANONICAL_JSON_VERSION = "canonical-json-v1"
+
+
+def _timestamp(value: datetime) -> str:
+    if value.tzinfo is None:
+        raise TypeError("Naive timestamps are not supported in audit evidence")
+    return value.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def normalize(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise TypeError("Non-finite floats are not supported in audit evidence")
+        return value
+    if isinstance(value, datetime):
+        return _timestamp(value)
+    if isinstance(value, Enum):
+        return normalize(value.value)
+    if isinstance(value, list) or isinstance(value, tuple):
+        return [normalize(item) for item in value]
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise TypeError("Audit evidence dictionary keys must be strings")
+        return {key: normalize(item) for key, item in value.items()}
+    raise TypeError(f"Unsupported audit evidence value: {type(value).__name__}")
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(normalize(value), sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+
+
+def framed(parts: list[bytes]) -> bytes:
+    return b"".join(len(part).to_bytes(8, "big") + part for part in parts)

--- a/src/hermes_vault/audit_integrity/checkpoint.py
+++ b/src/hermes_vault/audit_integrity/checkpoint.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+from hermes_vault import _platform
+from hermes_vault.audit_integrity.canonical import canonical_bytes
+from hermes_vault.audit_integrity.crypto import CHECKPOINT_SIGNING_CONTEXT, sign, verify
+
+CHECKPOINT_FORMAT = "hermes-vault-audit-checkpoint"
+CHECKPOINT_VERSION = "audit-checkpoint-v1"
+
+
+class AuditLockError(RuntimeError):
+    pass
+
+
+@contextmanager
+def audit_write_lock(path: Path, timeout_seconds: float = 5.0) -> Iterator[None]:
+    deadline = time.monotonic() + timeout_seconds
+    payload = json.dumps({"version": "audit-lock-v1", "pid": os.getpid(), "created_at": datetime.now(timezone.utc).isoformat()}, sort_keys=True)
+    while True:
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+            _platform.secure_file(path)
+            break
+        except FileExistsError:
+            try:
+                age = time.time() - path.stat().st_mtime
+                if age > timeout_seconds * 12:
+                    path.unlink(missing_ok=True)
+                    continue
+            except OSError:
+                pass
+            if time.monotonic() >= deadline:
+                raise AuditLockError("Audit write coordination is unavailable; retry after the other operation finishes.")
+            time.sleep(0.05)
+    try:
+        yield
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def signed_checkpoint(payload: dict[str, object], master_key: bytes) -> dict[str, object]:
+    unsigned = dict(payload)
+    unsigned.pop("signature", None)
+    unsigned["format"] = CHECKPOINT_FORMAT
+    unsigned["version"] = CHECKPOINT_VERSION
+    unsigned["signature"] = sign(master_key, CHECKPOINT_SIGNING_CONTEXT, canonical_bytes(unsigned))
+    return unsigned
+
+
+def write_checkpoint(path: Path, payload: dict[str, object], master_key: bytes) -> dict[str, object]:
+    signed = signed_checkpoint(payload, master_key)
+    _platform.replace_bytes_durable(path, canonical_bytes(signed) + b"\n")
+    return signed
+
+
+def read_checkpoint(path: Path) -> dict[str, object] | None:
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def checkpoint_signature_valid(payload: dict[str, object], public_key: str) -> bool:
+    signature = payload.get("signature")
+    unsigned = dict(payload)
+    unsigned.pop("signature", None)
+    return isinstance(signature, str) and verify(public_key, signature, canonical_bytes(unsigned))

--- a/src/hermes_vault/audit_integrity/crypto.py
+++ b/src/hermes_vault/audit_integrity/crypto.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+ENTRY_SIGNING_CONTEXT = b"hermes-vault/audit-entry-signing/ed25519-v1"
+CHECKPOINT_SIGNING_CONTEXT = b"hermes-vault/audit-checkpoint-signing/ed25519-v1"
+KEY_DERIVATION_VERSION = "hkdf-sha256-ed25519-v1"
+ENTRY_SIGNATURE_VERSION = "ed25519-entry-v1"
+CHECKPOINT_SIGNATURE_VERSION = "ed25519-checkpoint-v1"
+
+
+def digest(value: bytes) -> bytes:
+    return hashlib.sha256(value).digest()
+
+
+def digest_hex(value: bytes) -> str:
+    return digest(value).hex()
+
+
+def derive_seed(master_key: bytes, context: bytes) -> bytes:
+    return HKDF(algorithm=hashes.SHA256(), length=32, salt=None, info=context).derive(master_key)
+
+
+def private_key(master_key: bytes, context: bytes) -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(derive_seed(master_key, context))
+
+
+def public_key_b64(master_key: bytes, context: bytes) -> str:
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+    return base64.b64encode(private_key(master_key, context).public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)).decode("ascii")
+
+
+def sign(master_key: bytes, context: bytes, payload: bytes) -> str:
+    return base64.b64encode(private_key(master_key, context).sign(payload)).decode("ascii")
+
+
+def verify(public_key: str, signature: str, payload: bytes) -> bool:
+    try:
+        Ed25519PublicKey.from_public_bytes(base64.b64decode(public_key, validate=True)).verify(base64.b64decode(signature, validate=True), payload)
+    except (ValueError, TypeError):
+        return False
+    except Exception:
+        return False
+    return True

--- a/src/hermes_vault/audit_integrity/migration.py
+++ b/src/hermes_vault/audit_integrity/migration.py
@@ -1,0 +1,4 @@
+"""Migration helpers live in :mod:`service` so migration and append share one transaction boundary."""
+from hermes_vault.audit_integrity.service import AuditIntegrityService
+
+__all__ = ["AuditIntegrityService"]

--- a/src/hermes_vault/audit_integrity/models.py
+++ b/src/hermes_vault/audit_integrity/models.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from enum import StrEnum
+
+
+class AuditIntegrityStatus(StrEnum):
+    healthy = "healthy"
+    legacy = "legacy"
+    incomplete = "incomplete"
+    failed = "failed"
+
+
+class AuditCheckpointStatus(StrEnum):
+    valid = "valid"
+    missing = "missing"
+    stale = "stale"
+    ahead = "ahead"
+    invalid_signature = "invalid_signature"
+    invalid_format = "invalid_format"
+    segment_mismatch = "segment_mismatch"
+    registry_mismatch = "registry_mismatch"
+    unsupported_version = "unsupported_version"
+
+
+@dataclass(frozen=True)
+class AuditVerificationResult:
+    status: AuditIntegrityStatus
+    reason_code: str
+    chain_version: str | None
+    serialization_version: str | None
+    active_segment_id: str | None
+    active_segment_number: int | None
+    verified_count: int
+    legacy_count: int
+    first_verified_sequence: int | None
+    last_verified_sequence: int | None
+    checkpoint_status: AuditCheckpointStatus
+    failure_sequence: int | None
+    failure_segment_id: str | None
+    sanitized_reason: str
+    recommended_next_step: str
+    verified_at: datetime
+
+    def to_dict(self) -> dict[str, object]:
+        value = asdict(self)
+        value["status"] = self.status.value
+        value["checkpoint_status"] = self.checkpoint_status.value
+        value["verified_at"] = self.verified_at.astimezone(timezone.utc).isoformat()
+        return value

--- a/src/hermes_vault/audit_integrity/repository.py
+++ b/src/hermes_vault/audit_integrity/repository.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from hermes_vault.audit_integrity.canonical import canonical_bytes
+from hermes_vault.audit_integrity.crypto import digest_hex
+
+
+def registry_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    conn.row_factory = sqlite3.Row
+    return conn.execute("SELECT * FROM audit_integrity_segments ORDER BY segment_number").fetchall()
+
+
+def registry_digest(conn: sqlite3.Connection) -> str:
+    rows = registry_rows(conn)
+    public = []
+    for row in rows:
+        public.append({key: row[key] for key in (
+            "segment_id", "segment_number", "chain_version", "serialization_version", "key_derivation_version",
+            "entry_signature_version", "checkpoint_signature_version", "entry_public_key", "checkpoint_public_key",
+            "sequence_start", "sequence_end", "predecessor_segment_id", "predecessor_tip_digest", "transition_reason",
+            "legacy_count", "legacy_snapshot_digest", "legacy_first_id", "legacy_last_id", "created_at", "closed_at"
+        )})
+    return digest_hex(canonical_bytes(public))
+
+
+def access_log_payload(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "id": row["id"], "timestamp": row["timestamp"], "agent_id": row["agent_id"], "service": row["service"],
+        "action": row["action"], "decision": row["decision"], "reason": row["reason"],
+        "ttl_seconds": row["ttl_seconds"], "verification_result": row["verification_result"], "metadata_json": row["metadata_json"],
+    }

--- a/src/hermes_vault/audit_integrity/schema.py
+++ b/src/hermes_vault/audit_integrity/schema.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import sqlite3
+
+SCHEMA_VERSION = "audit-integrity-schema-v1"
+
+
+def initialize_schema(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript("""
+    CREATE TABLE IF NOT EXISTS access_logs (
+      id TEXT PRIMARY KEY, timestamp TEXT NOT NULL, agent_id TEXT NOT NULL, service TEXT NOT NULL, action TEXT NOT NULL,
+      decision TEXT NOT NULL, reason TEXT NOT NULL, ttl_seconds INTEGER, verification_result TEXT, metadata_json TEXT
+    );
+    CREATE TABLE IF NOT EXISTS audit_integrity_state (      id INTEGER PRIMARY KEY CHECK (id = 1), schema_version TEXT NOT NULL, migration_state TEXT NOT NULL,
+      active_segment_id TEXT, legacy_cutoff_timestamp TEXT, legacy_cutoff_id TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS audit_integrity_segments (
+      segment_id TEXT PRIMARY KEY, segment_number INTEGER NOT NULL UNIQUE, chain_version TEXT NOT NULL,
+      serialization_version TEXT NOT NULL, key_derivation_version TEXT NOT NULL, entry_signature_version TEXT NOT NULL,
+      checkpoint_signature_version TEXT NOT NULL, entry_public_key TEXT NOT NULL, checkpoint_public_key TEXT NOT NULL,
+      sequence_start INTEGER NOT NULL, sequence_end INTEGER, predecessor_segment_id TEXT, predecessor_tip_digest TEXT,
+      transition_reason TEXT NOT NULL CHECK (transition_reason IN ('fresh_vault','legacy_migration','master_key_rotation','checkpoint_recovery')),
+      legacy_count INTEGER NOT NULL DEFAULT 0, legacy_snapshot_digest TEXT, legacy_first_id TEXT, legacy_last_id TEXT,
+      created_at TEXT NOT NULL, closed_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS audit_integrity_records (
+      sequence INTEGER PRIMARY KEY, segment_id TEXT NOT NULL, access_log_id TEXT NOT NULL UNIQUE, previous_digest TEXT NOT NULL,
+      entry_digest TEXT NOT NULL, signature TEXT NOT NULL, chain_version TEXT NOT NULL, serialization_version TEXT NOT NULL,
+      created_at TEXT NOT NULL, FOREIGN KEY(access_log_id) REFERENCES access_logs(id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_audit_integrity_records_segment_sequence ON audit_integrity_records(segment_id, sequence);
+    CREATE INDEX IF NOT EXISTS idx_audit_integrity_records_access_log ON audit_integrity_records(access_log_id);
+    CREATE INDEX IF NOT EXISTS idx_audit_integrity_records_digest ON audit_integrity_records(entry_digest);
+    CREATE TABLE IF NOT EXISTS audit_verification_runs (
+      verification_id TEXT PRIMARY KEY, verified_at TEXT NOT NULL, status TEXT NOT NULL, reason_code TEXT,
+      segment_id TEXT, chain_version TEXT, verified_count INTEGER NOT NULL, legacy_count INTEGER NOT NULL,
+      first_sequence INTEGER, last_sequence INTEGER, checkpoint_status TEXT NOT NULL, failure_sequence INTEGER, registry_digest TEXT
+    );
+    """)

--- a/src/hermes_vault/audit_integrity/service.py
+++ b/src/hermes_vault/audit_integrity/service.py
@@ -225,7 +225,6 @@ class AuditIntegrityService:
                     return self._failure("active_key_mismatch", segment_id=active["segment_id"], legacy=legacy_count)
                 first = registry_rows(conn)[0]
                 if first["legacy_count"]:
-                    snapshot = self._legacy_snapshot(conn)
                     cutoff_count = int(first["legacy_count"])
                     # A migration snapshot covers the original prefix, not later protected entries.
                     rows = conn.execute("SELECT id, timestamp, agent_id, service, action, decision, reason, ttl_seconds, verification_result, metadata_json FROM access_logs ORDER BY timestamp ASC, id ASC LIMIT ?", (cutoff_count,)).fetchall()

--- a/src/hermes_vault/audit_integrity/service.py
+++ b/src/hermes_vault/audit_integrity/service.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+from hermes_vault.audit_integrity.canonical import CANONICAL_JSON_VERSION, canonical_bytes, framed
+from hermes_vault.audit_integrity.checkpoint import (
+    CHECKPOINT_VERSION, AuditLockError, audit_write_lock, checkpoint_signature_valid, read_checkpoint, write_checkpoint,
+)
+from hermes_vault.audit_integrity.crypto import (
+    CHECKPOINT_SIGNATURE_VERSION, CHECKPOINT_SIGNING_CONTEXT, ENTRY_SIGNATURE_VERSION, ENTRY_SIGNING_CONTEXT,
+    KEY_DERIVATION_VERSION, digest_hex, public_key_b64, sign, verify,
+)
+from hermes_vault.audit_integrity.models import AuditCheckpointStatus, AuditIntegrityStatus, AuditVerificationResult
+from hermes_vault.audit_integrity.repository import access_log_payload, registry_digest, registry_rows
+from hermes_vault.audit_integrity.schema import SCHEMA_VERSION, initialize_schema
+
+CHAIN_VERSION = "sha256-chain-v1"
+
+
+class AuditIntegrityError(RuntimeError):
+    pass
+
+
+class AuditIntegrityService:
+    """Owns the protected audit append protocol and read-only verification."""
+
+    def __init__(self, db_path: Path, master_key: bytes, checkpoint_path: Path | None = None) -> None:
+        self.db_path = db_path
+        self.master_key = master_key
+        self.checkpoint_path = checkpoint_path or db_path.with_name("audit.checkpoint.json")
+        self.lock_path = self.checkpoint_path.with_suffix(".lock")
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def _connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, timeout=10)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _failure(
+        self, reason: str, checkpoint: AuditCheckpointStatus = AuditCheckpointStatus.valid, *, sequence: int | None = None,
+        segment_id: str | None = None, verified: int = 0, legacy: int = 0,
+    ) -> AuditVerificationResult:
+        message = {
+            "checkpoint_missing": "The authenticated checkpoint is missing.",
+            "checkpoint_stale": "The checkpoint does not cover the database tip.",
+            "checkpoint_ahead": "The checkpoint refers to evidence not present in the database.",
+            "checkpoint_invalid_signature": "The checkpoint signature is invalid.",
+            "checkpoint_invalid_format": "The checkpoint format is invalid.",
+            "segment_registry_mismatch": "The checkpoint does not authenticate the current segment registry.",
+            "entry_digest_mismatch": "An audit entry no longer matches its protected digest.",
+            "entry_signature_mismatch": "An audit entry signature is invalid.",
+            "previous_digest_mismatch": "The protected audit chain is discontinuous.",
+            "sequence_gap": "The protected audit sequence is incomplete.",
+            "missing_access_log": "A protected audit record has no corresponding audit row.",
+            "missing_integrity_record": "An audit row is not protected by an integrity record.",
+            "active_key_mismatch": "The active audit public key does not match the unlocked vault.",
+            "legacy_anchor_mismatch": "The recorded legacy snapshot no longer matches its original rows.",
+            "unsupported_chain_version": "This audit chain version is not supported by this Hermes Vault version.",
+            "unsupported_serialization_version": "This audit serialization version is not supported by this Hermes Vault version.",
+            "unsupported_signature_version": "This audit signature version is not supported by this Hermes Vault version.",
+            "database_unreadable": "The audit database could not be verified.",
+        }.get(reason, "Audit evidence could not be verified.")
+        return AuditVerificationResult(
+            status=AuditIntegrityStatus.incomplete if checkpoint in {AuditCheckpointStatus.missing, AuditCheckpointStatus.stale, AuditCheckpointStatus.ahead} else AuditIntegrityStatus.failed,
+            reason_code=reason, chain_version=CHAIN_VERSION, serialization_version=CANONICAL_JSON_VERSION,
+            active_segment_id=segment_id, active_segment_number=None, verified_count=verified, legacy_count=legacy,
+            first_verified_sequence=1 if verified else None, last_verified_sequence=sequence if verified else None,
+            checkpoint_status=checkpoint, failure_sequence=sequence, failure_segment_id=segment_id,
+            sanitized_reason=message,
+            recommended_next_step="Run `hermes-vault audit checkpoint advance` only after reviewing the evidence." if checkpoint == AuditCheckpointStatus.stale else "Do not append audit records; inspect the integrity result and restore from a verified backup if needed.",
+            verified_at=datetime.now(timezone.utc),
+        )
+
+    def _legacy_snapshot(self, conn: sqlite3.Connection) -> tuple[int, str | None, str | None, str | None, str | None]:
+        table = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'access_logs'").fetchone()
+        if table is None:
+            return 0, None, None, None, None
+        rows = conn.execute("SELECT id, timestamp, agent_id, service, action, decision, reason, ttl_seconds, verification_result, metadata_json FROM access_logs ORDER BY timestamp ASC, id ASC").fetchall()
+        if not rows:
+            return 0, None, None, None, None
+        frames = []
+        for row in rows:
+            frames.append(framed([(b"" if value is None else str(value).encode("utf-8")) for value in row]))
+        return len(rows), rows[0]["id"], rows[-1]["id"], digest_hex(b"".join(frames)), rows[-1]["timestamp"]
+
+    def _create_segment(
+        self, conn: sqlite3.Connection, *, master_key: bytes, transition_reason: str, sequence_start: int,
+        predecessor_segment_id: str | None = None, predecessor_tip_digest: str | None = None,
+        legacy: tuple[int, str | None, str | None, str | None, str | None] | None = None,
+    ) -> sqlite3.Row:
+        number = int(conn.execute("SELECT COALESCE(MAX(segment_number), 0) + 1 FROM audit_integrity_segments").fetchone()[0])
+        segment_id = str(uuid4())
+        now = self._now()
+        legacy_count, first, last, snapshot, _ = legacy or (0, None, None, None, None)
+        conn.execute(
+            """INSERT INTO audit_integrity_segments (
+                segment_id, segment_number, chain_version, serialization_version, key_derivation_version, entry_signature_version,
+                checkpoint_signature_version, entry_public_key, checkpoint_public_key, sequence_start, predecessor_segment_id,
+                predecessor_tip_digest, transition_reason, legacy_count, legacy_snapshot_digest, legacy_first_id, legacy_last_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (segment_id, number, CHAIN_VERSION, CANONICAL_JSON_VERSION, KEY_DERIVATION_VERSION, ENTRY_SIGNATURE_VERSION,
+             CHECKPOINT_SIGNATURE_VERSION, public_key_b64(master_key, ENTRY_SIGNING_CONTEXT), public_key_b64(master_key, CHECKPOINT_SIGNING_CONTEXT),
+             sequence_start, predecessor_segment_id, predecessor_tip_digest, transition_reason, legacy_count, snapshot, first, last, now),
+        )
+        return conn.execute("SELECT * FROM audit_integrity_segments WHERE segment_id = ?", (segment_id,)).fetchone()
+
+    def ensure_initialized(self) -> None:
+        with audit_write_lock(self.lock_path):
+            with self._connection() as conn:
+                initialize_schema(conn)
+                state = conn.execute("SELECT * FROM audit_integrity_state WHERE id = 1").fetchone()
+                if state is not None:
+                    return
+                legacy = self._legacy_snapshot(conn)
+                reason = "legacy_migration" if legacy[0] else "fresh_vault"
+                segment = self._create_segment(conn, master_key=self.master_key, transition_reason=reason, sequence_start=1, legacy=legacy)
+                now = self._now()
+                conn.execute(
+                    "INSERT INTO audit_integrity_state (id, schema_version, migration_state, active_segment_id, legacy_cutoff_timestamp, legacy_cutoff_id, created_at, updated_at) VALUES (1, ?, 'active', ?, ?, ?, ?, ?)",
+                    (SCHEMA_VERSION, segment["segment_id"], legacy[4], legacy[2], now, now),
+                )
+                conn.commit()
+                self._write_current_checkpoint(conn, segment, latest_sequence=0, latest_digest="")
+
+    def _active(self, conn: sqlite3.Connection) -> sqlite3.Row:
+        state = conn.execute("SELECT * FROM audit_integrity_state WHERE id = 1").fetchone()
+        if state is None or state["active_segment_id"] is None:
+            raise AuditIntegrityError("Audit integrity state is not initialized.")
+        row = conn.execute("SELECT * FROM audit_integrity_segments WHERE segment_id = ?", (state["active_segment_id"],)).fetchone()
+        if row is None:
+            raise AuditIntegrityError("Audit integrity state references an unavailable segment.")
+        return row
+
+    def _tip(self, conn: sqlite3.Connection) -> tuple[int, str]:
+        row = conn.execute("SELECT sequence, entry_digest FROM audit_integrity_records ORDER BY sequence DESC LIMIT 1").fetchone()
+        return (int(row["sequence"]), str(row["entry_digest"])) if row else (0, "")
+
+    def _write_current_checkpoint(self, conn: sqlite3.Connection, segment: sqlite3.Row, *, latest_sequence: int, latest_digest: str) -> None:
+        legacy = registry_rows(conn)[0]
+        payload: dict[str, object] = {
+            "active_segment_id": segment["segment_id"], "active_segment_number": segment["segment_number"],
+            "latest_sequence": latest_sequence, "latest_entry_digest": latest_digest, "segment_registry_digest": registry_digest(conn),
+            "legacy_anchor_digest": legacy["legacy_snapshot_digest"] or "", "entry_public_key": segment["entry_public_key"],
+            "checkpoint_public_key": segment["checkpoint_public_key"], "updated_at": self._now(),
+        }
+        write_checkpoint(self.checkpoint_path, payload, self.master_key)
+
+    def append(self, record: object) -> None:
+        self.ensure_initialized()
+        current = self.verify()
+        if current.status != AuditIntegrityStatus.healthy:
+            raise AuditIntegrityError(current.sanitized_reason)
+        try:
+            with audit_write_lock(self.lock_path):
+                with self._connection() as conn:
+                    conn.execute("BEGIN IMMEDIATE")
+                    active = self._active(conn)
+                    sequence, previous_digest = self._tip(conn)
+                    next_sequence = sequence + 1
+                    metadata_json = canonical_bytes(getattr(record, "metadata")).decode("utf-8") if getattr(record, "metadata") else "{}"
+                    values = (
+                        getattr(record, "id"), getattr(record, "timestamp").isoformat(), getattr(record, "agent_id"),
+                        getattr(record, "service"), getattr(record, "action"), getattr(record, "decision").value,
+                        getattr(record, "reason"), getattr(record, "ttl_seconds"),
+                        getattr(record, "verification_result").value if getattr(record, "verification_result") else None, metadata_json,
+                    )
+                    conn.execute("INSERT INTO access_logs (id, timestamp, agent_id, service, action, decision, reason, ttl_seconds, verification_result, metadata_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", values)
+                    row = conn.execute("SELECT * FROM access_logs WHERE id = ?", (getattr(record, "id"),)).fetchone()
+                    entry_digest = digest_hex(canonical_bytes(access_log_payload(row)))
+                    envelope = {"chain_version": CHAIN_VERSION, "serialization_version": CANONICAL_JSON_VERSION, "segment_id": active["segment_id"], "sequence": next_sequence, "previous_digest": previous_digest, "entry_digest": entry_digest}
+                    signature = sign(self.master_key, ENTRY_SIGNING_CONTEXT, canonical_bytes(envelope))
+                    conn.execute("INSERT INTO audit_integrity_records (sequence, segment_id, access_log_id, previous_digest, entry_digest, signature, chain_version, serialization_version, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (next_sequence, active["segment_id"], getattr(record, "id"), previous_digest, entry_digest, signature, CHAIN_VERSION, CANONICAL_JSON_VERSION, self._now()))
+                    conn.execute("UPDATE audit_integrity_state SET updated_at = ? WHERE id = 1", (self._now(),))
+                    conn.commit()
+                    self._write_current_checkpoint(conn, active, latest_sequence=next_sequence, latest_digest=entry_digest)
+        except AuditLockError as exc:
+            raise AuditIntegrityError(str(exc)) from exc
+
+    def _verify_checkpoint(self, conn: sqlite3.Connection, active: sqlite3.Row, sequence: int, tip: str) -> tuple[AuditCheckpointStatus, str | None]:
+        checkpoint = read_checkpoint(self.checkpoint_path)
+        if checkpoint is None:
+            return AuditCheckpointStatus.missing, "checkpoint_missing"
+        if checkpoint.get("format") != "hermes-vault-audit-checkpoint" or checkpoint.get("version") != CHECKPOINT_VERSION:
+            return AuditCheckpointStatus.invalid_format, "checkpoint_invalid_format"
+        if not checkpoint_signature_valid(checkpoint, str(active["checkpoint_public_key"])):
+            return AuditCheckpointStatus.invalid_signature, "checkpoint_invalid_signature"
+        if checkpoint.get("active_segment_id") != active["segment_id"]:
+            return AuditCheckpointStatus.segment_mismatch, "checkpoint_segment_mismatch"
+        if checkpoint.get("segment_registry_digest") != registry_digest(conn):
+            return AuditCheckpointStatus.registry_mismatch, "segment_registry_mismatch"
+        checkpoint_sequence = checkpoint.get("latest_sequence")
+        if not isinstance(checkpoint_sequence, int):
+            return AuditCheckpointStatus.invalid_format, "checkpoint_invalid_format"
+        if checkpoint_sequence < sequence or checkpoint.get("latest_entry_digest") != tip:
+            return AuditCheckpointStatus.stale, "checkpoint_stale"
+        if checkpoint_sequence > sequence:
+            return AuditCheckpointStatus.ahead, "checkpoint_ahead"
+        return AuditCheckpointStatus.valid, None
+
+    def verify(self, *, require_checkpoint: bool = True) -> AuditVerificationResult:
+        try:
+            with self._connection() as conn:
+                existing = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'audit_integrity_state'").fetchone()
+                legacy_count = int(conn.execute("SELECT COUNT(*) FROM access_logs").fetchone()[0]) if conn.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'access_logs'").fetchone() else 0
+                if existing is None:
+                    return AuditVerificationResult(AuditIntegrityStatus.legacy, "legacy_only", None, None, None, None, 0, legacy_count, None, None, AuditCheckpointStatus.missing, None, None, "Legacy history remains readable but was not retrospectively protected.", "Create a verified backup before initializing Audit Assurance.", datetime.now(timezone.utc))
+                state = conn.execute("SELECT * FROM audit_integrity_state WHERE id = 1").fetchone()
+                if state is None or state["migration_state"] != "active":
+                    return self._failure("migration_interrupted", AuditCheckpointStatus.missing, legacy=legacy_count)
+                active = self._active(conn)
+                if active["chain_version"] != CHAIN_VERSION:
+                    return self._failure("unsupported_chain_version", segment_id=active["segment_id"], legacy=legacy_count)
+                if active["serialization_version"] != CANONICAL_JSON_VERSION:
+                    return self._failure("unsupported_serialization_version", segment_id=active["segment_id"], legacy=legacy_count)
+                if active["entry_signature_version"] != ENTRY_SIGNATURE_VERSION:
+                    return self._failure("unsupported_signature_version", segment_id=active["segment_id"], legacy=legacy_count)
+                if active["entry_public_key"] != public_key_b64(self.master_key, ENTRY_SIGNING_CONTEXT) or active["checkpoint_public_key"] != public_key_b64(self.master_key, CHECKPOINT_SIGNING_CONTEXT):
+                    return self._failure("active_key_mismatch", segment_id=active["segment_id"], legacy=legacy_count)
+                first = registry_rows(conn)[0]
+                if first["legacy_count"]:
+                    snapshot = self._legacy_snapshot(conn)
+                    cutoff_count = int(first["legacy_count"])
+                    # A migration snapshot covers the original prefix, not later protected entries.
+                    rows = conn.execute("SELECT id, timestamp, agent_id, service, action, decision, reason, ttl_seconds, verification_result, metadata_json FROM access_logs ORDER BY timestamp ASC, id ASC LIMIT ?", (cutoff_count,)).fetchall()
+                    frames = [framed([(b"" if value is None else str(value).encode("utf-8")) for value in row]) for row in rows]
+                    if len(rows) != cutoff_count or digest_hex(b"".join(frames)) != first["legacy_snapshot_digest"]:
+                        return self._failure("legacy_anchor_mismatch", segment_id=active["segment_id"], legacy=cutoff_count)
+                rows = conn.execute("SELECT r.*, a.id AS aid, a.timestamp, a.agent_id, a.service, a.action, a.decision, a.reason, a.ttl_seconds, a.verification_result, a.metadata_json FROM audit_integrity_records r LEFT JOIN access_logs a ON a.id = r.access_log_id ORDER BY r.sequence").fetchall()
+                previous = ""
+                expected_sequence = 1
+                for row in rows:
+                    if row["aid"] is None:
+                        return self._failure("missing_access_log", sequence=row["sequence"], segment_id=row["segment_id"], verified=len(rows), legacy=legacy_count)
+                    if int(row["sequence"]) != expected_sequence:
+                        return self._failure("sequence_gap", sequence=row["sequence"], segment_id=row["segment_id"], verified=expected_sequence - 1, legacy=legacy_count)
+                    if row["previous_digest"] != previous:
+                        return self._failure("previous_digest_mismatch", sequence=row["sequence"], segment_id=row["segment_id"], verified=expected_sequence - 1, legacy=legacy_count)
+                    payload = {key: row[key] for key in ("aid", "timestamp", "agent_id", "service", "action", "decision", "reason", "ttl_seconds", "verification_result", "metadata_json")}
+                    payload["id"] = payload.pop("aid")
+                    if digest_hex(canonical_bytes(payload)) != row["entry_digest"]:
+                        return self._failure("entry_digest_mismatch", sequence=row["sequence"], segment_id=row["segment_id"], verified=expected_sequence - 1, legacy=legacy_count)
+                    segment = conn.execute("SELECT * FROM audit_integrity_segments WHERE segment_id = ?", (row["segment_id"],)).fetchone()
+                    if segment is None:
+                        return self._failure("segment_registry_mismatch", sequence=row["sequence"], segment_id=row["segment_id"], verified=expected_sequence - 1, legacy=legacy_count)
+                    envelope = {"chain_version": row["chain_version"], "serialization_version": row["serialization_version"], "segment_id": row["segment_id"], "sequence": row["sequence"], "previous_digest": row["previous_digest"], "entry_digest": row["entry_digest"]}
+                    if not verify(segment["entry_public_key"], row["signature"], canonical_bytes(envelope)):
+                        return self._failure("entry_signature_mismatch", sequence=row["sequence"], segment_id=row["segment_id"], verified=expected_sequence - 1, legacy=legacy_count)
+                    previous = str(row["entry_digest"])
+                    expected_sequence += 1
+                # No unprotected rows may appear after the preserved migration prefix.
+                protected = int(conn.execute("SELECT COUNT(*) FROM audit_integrity_records").fetchone()[0])
+                if legacy_count != int(first["legacy_count"]) + protected:
+                    return self._failure("missing_integrity_record", segment_id=active["segment_id"], verified=protected, legacy=int(first["legacy_count"]))
+                sequence, tip = self._tip(conn)
+                checkpoint_status, reason = self._verify_checkpoint(conn, active, sequence, tip) if require_checkpoint else (AuditCheckpointStatus.valid, None)
+                if reason:
+                    return self._failure(reason, checkpoint_status, sequence=sequence, segment_id=active["segment_id"], verified=protected, legacy=int(first["legacy_count"]))
+                result = AuditVerificationResult(AuditIntegrityStatus.healthy, "none", CHAIN_VERSION, CANONICAL_JSON_VERSION, active["segment_id"], int(active["segment_number"]), protected, int(first["legacy_count"]), 1 if protected else None, sequence if protected else None, checkpoint_status, None, None, "Protected audit history verified from the migration anchor forward.", "Continue normal operation; retain verified backups.", datetime.now(timezone.utc))
+                self._record_run(conn, result)
+                conn.commit()
+                return result
+        except sqlite3.Error:
+            return self._failure("database_unreadable")
+
+    def _record_run(self, conn: sqlite3.Connection, result: AuditVerificationResult) -> None:
+        conn.execute("INSERT INTO audit_verification_runs (verification_id, verified_at, status, reason_code, segment_id, chain_version, verified_count, legacy_count, first_sequence, last_sequence, checkpoint_status, failure_sequence, registry_digest) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (str(uuid4()), result.verified_at.isoformat(), result.status.value, result.reason_code, result.active_segment_id, result.chain_version, result.verified_count, result.legacy_count, result.first_verified_sequence, result.last_verified_sequence, result.checkpoint_status.value, result.failure_sequence, registry_digest(conn)))
+
+    def advance_checkpoint(self) -> AuditVerificationResult:
+        self.ensure_initialized()
+        result = self.verify(require_checkpoint=False)
+        if result.status != AuditIntegrityStatus.healthy:
+            return result
+        with audit_write_lock(self.lock_path):
+            with self._connection() as conn:
+                active = self._active(conn)
+                sequence, tip = self._tip(conn)
+                self._write_current_checkpoint(conn, active, latest_sequence=sequence, latest_digest=tip)
+        return self.verify()
+
+    def establish_checkpoint(self) -> AuditVerificationResult:
+        return self.advance_checkpoint()
+
+    def rotate_segment(self, new_master_key: bytes) -> None:
+        self.ensure_initialized()
+        result = self.verify()
+        if result.status != AuditIntegrityStatus.healthy:
+            raise AuditIntegrityError(result.sanitized_reason)
+        with audit_write_lock(self.lock_path):
+            with self._connection() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                old = self._active(conn)
+                sequence, tip = self._tip(conn)
+                now = self._now()
+                conn.execute("UPDATE audit_integrity_segments SET sequence_end = ?, closed_at = ? WHERE segment_id = ?", (sequence, now, old["segment_id"]))
+                new = self._create_segment(conn, master_key=new_master_key, transition_reason="master_key_rotation", sequence_start=sequence + 1, predecessor_segment_id=old["segment_id"], predecessor_tip_digest=tip)
+                conn.execute("UPDATE audit_integrity_state SET active_segment_id = ?, updated_at = ? WHERE id = 1", (new["segment_id"], now))
+                conn.commit()
+                old_key = self.master_key
+                self.master_key = new_master_key
+                try:
+                    self._write_current_checkpoint(conn, new, latest_sequence=sequence, latest_digest=tip)
+                except Exception:
+                    self.master_key = old_key
+                    raise
+
+    def recover_checkpoint(self) -> AuditVerificationResult:
+        """Start a new explicit segment; never rewrites a failed segment or prior evidence."""
+        self.ensure_initialized()
+        result = self.verify()
+        if result.status == AuditIntegrityStatus.healthy:
+            return result
+        if result.status == AuditIntegrityStatus.failed:
+            return result
+        with audit_write_lock(self.lock_path):
+            with self._connection() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                old = self._active(conn)
+                sequence, tip = self._tip(conn)
+                now = self._now()
+                conn.execute("UPDATE audit_integrity_segments SET sequence_end = ?, closed_at = ? WHERE segment_id = ?", (sequence, now, old["segment_id"]))
+                new = self._create_segment(conn, master_key=self.master_key, transition_reason="checkpoint_recovery", sequence_start=sequence + 1, predecessor_segment_id=old["segment_id"], predecessor_tip_digest=tip)
+                conn.execute("UPDATE audit_integrity_state SET active_segment_id = ?, updated_at = ? WHERE id = 1", (new["segment_id"], now))
+                conn.commit()
+                self._write_current_checkpoint(conn, new, latest_sequence=sequence, latest_digest=tip)
+        return self.verify()

--- a/src/hermes_vault/audit_integrity/verifier.py
+++ b/src/hermes_vault/audit_integrity/verifier.py
@@ -1,0 +1,6 @@
+"""Public verification entry point."""
+from hermes_vault.audit_integrity.service import AuditIntegrityService
+
+
+def verify_audit_integrity(service: AuditIntegrityService):
+    return service.verify()

--- a/src/hermes_vault/bootstrap.py
+++ b/src/hermes_vault/bootstrap.py
@@ -208,7 +208,7 @@ def run_bootstrap(
 
             passphrase = resolve_passphrase(prompt=True, profile_name=settings.profile_name)
             vault = Vault(settings.db_path, settings.salt_path, passphrase)
-            mutations = VaultMutations(vault=vault, policy=policy, audit=AuditLogger(settings.db_path))
+            mutations = VaultMutations(vault=vault, policy=policy, audit=AuditLogger(settings.db_path, master_key=vault.key))
             redacted_lines: set[int] = set()
             for index, env_name, secret, decision in env_entries:
                 alias = env_name.lower()

--- a/src/hermes_vault/cli.py
+++ b/src/hermes_vault/cli.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import json
 import os
@@ -252,7 +252,7 @@ def build_services(prompt: bool = False) -> tuple[Vault, PolicyEngine, Broker, V
     policy.write_default(settings.effective_policy_path)
     passphrase = resolve_passphrase(prompt=prompt, profile_name=settings.profile_name)
     vault = Vault(settings.db_path, settings.salt_path, passphrase)
-    audit = AuditLogger(settings.db_path)
+    audit = AuditLogger(settings.db_path, master_key=vault.key)
     verifier = Verifier(plugin_dir=settings.verifier_plugin_dir)
     broker = Broker(vault=vault, policy=policy, verifier=verifier, audit=audit)
     mutations = VaultMutations(vault=vault, policy=policy, audit=audit)
@@ -2196,6 +2196,7 @@ def rotate_master_key(
         console.print(f"[red]Rotation failed: {exc}[/red]")
         raise typer.Exit(code=2)
 
+    audit = AuditLogger(settings.db_path, master_key=vault.key)
     audit.record(AccessLogRecord(
         agent_id="operator",
         service="*",

--- a/src/hermes_vault/dashboard.py
+++ b/src/hermes_vault/dashboard.py
@@ -94,7 +94,7 @@ def build_dashboard_context(*, prompt: bool = True, profile: str | None = None) 
     policy.write_default(settings.effective_policy_path)
     passphrase_result = resolve_passphrase_with_source(prompt=prompt, profile_name=settings.profile_name)
     vault = Vault(settings.db_path, settings.salt_path, passphrase_result.passphrase)
-    audit = AuditLogger(settings.db_path)
+    audit = AuditLogger(settings.db_path, master_key=vault.key)
     broker = Broker(
         vault=vault,
         policy=policy,

--- a/src/hermes_vault/mcp_server.py
+++ b/src/hermes_vault/mcp_server.py
@@ -241,7 +241,7 @@ def _build_broker(profile: str | None = None) -> Broker:
     policy.write_default(settings.effective_policy_path)
     passphrase = resolve_passphrase(prompt=False, profile_name=settings.profile_name)
     vault = Vault(settings.db_path, settings.salt_path, passphrase)
-    audit = AuditLogger(settings.db_path)
+    audit = AuditLogger(settings.db_path, master_key=vault.key)
     verifier = Verifier(plugin_dir=settings.verifier_plugin_dir)
     scanner = Scanner(settings, policy=policy)
     return Broker(vault=vault, policy=policy, verifier=verifier, audit=audit, scanner=scanner)

--- a/src/hermes_vault/oauth/oauth_refresh.py
+++ b/src/hermes_vault/oauth/oauth_refresh.py
@@ -98,7 +98,7 @@ class RefreshEngine:
     def audit(self):
         if self._audit is None:
             from hermes_vault.audit import AuditLogger
-            self._audit = AuditLogger(self.vault.db_path)
+            self._audit = AuditLogger(self.vault.db_path, master_key=self.vault.key)
         return self._audit
 
     def set_audit(self, audit) -> None:

--- a/src/hermes_vault/vault.py
+++ b/src/hermes_vault/vault.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from hermes_vault import _platform
+from hermes_vault.audit_integrity.service import AuditIntegrityError, AuditIntegrityService
 from hermes_vault.crypto import (
     CRYPTO_VERSION,
     CorruptKeyMaterialError,
@@ -1482,6 +1483,12 @@ class Vault:
         else:
             pass  # empty vault — old passphrase can't be verified by data
 
+        audit_integrity = AuditIntegrityService(self.db_path, old_key)
+        audit_integrity.ensure_initialized()
+        audit_result = audit_integrity.verify()
+        if audit_result.status.value != "healthy":
+            raise AuditIntegrityError(audit_result.sanitized_reason)
+
         if backup_path is not None:
             self.export_backup()
             content = json.dumps(self.export_backup(), indent=2, sort_keys=True)
@@ -1526,6 +1533,11 @@ class Vault:
 
         journal["status"] = "db_committed"
         journal["committed_at"] = utc_now().isoformat()
+        journal["audit_transition_state"] = "pending"
+        journal["old_segment_id"] = audit_result.active_segment_id or ""
+        self._write_rotation_journal(journal)
+        audit_integrity.rotate_segment(new_key)
+        journal["audit_transition_state"] = "checkpoint_committed"
         self._write_rotation_journal(journal)
         # DPAPI-aware write: when HERMES_VAULT_DPAPI=1 is set, the
         # new master key is wrapped with DPAPI on write. Otherwise the

--- a/tests/test_audit_integrity_core.py
+++ b/tests/test_audit_integrity_core.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.audit_integrity.models import AuditIntegrityStatus
+from hermes_vault.audit_integrity.service import AuditIntegrityError
+from hermes_vault.models import AccessLogRecord, Decision
+from hermes_vault.vault import Vault
+
+
+def make_logger(tmp_path: Path) -> AuditLogger:
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    return AuditLogger(vault.db_path, master_key=vault.key)
+
+
+def record(logger: AuditLogger, reason: str = "allowed") -> None:
+    logger.record(AccessLogRecord(agent_id="test-agent", service="openai", action="get_env", decision=Decision.allow, reason=reason, metadata={"ticket": "fake"}))
+
+
+def test_fresh_audit_history_is_signed_and_verified(tmp_path: Path) -> None:
+    logger = make_logger(tmp_path)
+    record(logger)
+
+    result = logger.integrity.verify()  # type: ignore[union-attr]
+
+    assert result.status is AuditIntegrityStatus.healthy
+    assert result.verified_count == 1
+    assert (tmp_path / "audit.checkpoint.json").exists()
+
+
+def test_mutated_audit_row_fails_verification(tmp_path: Path) -> None:
+    logger = make_logger(tmp_path)
+    record(logger)
+    with sqlite3.connect(logger.db_path) as conn:
+        conn.execute("UPDATE access_logs SET reason = 'changed' ")
+        conn.commit()
+
+    result = logger.integrity.verify()  # type: ignore[union-attr]
+
+    assert result.status is AuditIntegrityStatus.failed
+    assert result.reason_code == "entry_digest_mismatch"
+
+
+def test_stale_checkpoint_blocks_append_until_operator_advances_it(tmp_path: Path) -> None:
+    logger = make_logger(tmp_path)
+    record(logger)
+    checkpoint = tmp_path / "audit.checkpoint.json"
+    original = checkpoint.read_bytes()
+    record(logger)
+    checkpoint.write_bytes(original)
+
+    result = logger.integrity.verify()  # type: ignore[union-attr]
+    assert result.status is AuditIntegrityStatus.incomplete
+    assert result.reason_code == "checkpoint_stale"
+    with pytest.raises(AuditIntegrityError):
+        record(logger)
+
+    advanced = logger.integrity.advance_checkpoint()  # type: ignore[union-attr]
+    assert advanced.status is AuditIntegrityStatus.healthy
+    record(logger)
+
+
+def test_legacy_history_is_anchored_without_rewriting_rows(tmp_path: Path) -> None:
+    vault = Vault(tmp_path / "audit.db", tmp_path / "salt.bin", "test-passphrase")
+    logger = AuditLogger(vault.db_path)
+    record(logger, reason="legacy")
+    before = (tmp_path / "audit.db").read_bytes()
+    protected = AuditLogger(vault.db_path, master_key=vault.key)
+    protected.integrity.ensure_initialized()  # type: ignore[union-attr]
+
+    result = protected.integrity.verify()  # type: ignore[union-attr]
+
+    assert result.status is AuditIntegrityStatus.healthy
+    assert result.legacy_count == 1
+    assert before != b""
+
+def test_rotation_creates_a_new_segment_and_retains_history(tmp_path: Path) -> None:
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "old-passphrase")
+    logger = AuditLogger(vault.db_path, master_key=vault.key)
+    record(logger)
+
+    vault.rotate_master_key("old-passphrase", "new-passphrase")
+    reopened = Vault(vault.db_path, vault.salt_path, "new-passphrase")
+    result = AuditLogger(reopened.db_path, master_key=reopened.key).integrity.verify()  # type: ignore[union-attr]
+
+    assert result.status is AuditIntegrityStatus.healthy
+    assert result.active_segment_number == 2
+    assert result.verified_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "hermes-vault"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Implemented scope

Implements Issue #30's security-critical Audit Assurance core: canonical serialization, HKDF-derived Ed25519 evidence signatures, integrity schema and registry, durable authenticated checkpoints, append coordination, legacy anchoring, read-only verification, and master-key rotation segments.

## Non-goals

Backup v2/recovery and final CLI, dashboard, MCP presentation surfaces remain for Issues #31 and #32. No release version bump is included.

## Schema and security

Adds integrity state, segments, records, and sanitized verification history. Private signing material is derived only in memory and is neither stored nor exported. Existing legacy rows are retained and anchored rather than rewritten.

## Validation

- uv run python -m pytest tests/ -q --tb=short (801 passed, 1 skipped)
- uv run ruff check src/hermes_vault/audit_integrity src/hermes_vault/audit.py src/hermes_vault/vault.py tests/test_audit_integrity_core.py
- Focused audit, rotation, and dashboard regressions.

## Compatibility and risks

Legacy history remains readable and is explicitly described as protected from the migration anchor forward. Existing baseline mypy findings remain outside this change; the new rotation-journal type issue was fixed. Closes #30.