### PR TITLE
feat: audit CLI, dashboard, and MCP surfaces (Issue #32)

### DIFF
--- a/src/hermes_vault/cli.py
+++ b/src/hermes_vault/cli.py
@@ -940,6 +940,200 @@ def audit(
     console.print(table)
 
 
+@_typer_app.command("audit-verify")
+def audit_verify(
+    format: str = typer.Option("human", "--format", help="Output format: human or json."),
+    full: bool = typer.Option(False, "--full", help="Show full verification details."),
+    record_result: bool = typer.Option(True, "--record-result/--no-record-result", help="Record verification result."),
+) -> None:
+    """Verify audit integrity and continuity.
+
+    Checks the protected audit chain, signatures, checkpoint, and legacy anchor.
+
+    Exit codes: 0=healthy, 2=legacy/incomplete, 3=failed integrity, 1=error.
+
+    \b
+    Examples:
+      hermes-vault audit verify
+      hermes-vault audit verify --format json
+      hermes-vault audit verify --full
+    """
+    if format not in ("human", "json"):
+        console.print("[red]--format must be 'human' or 'json'[/red]")
+        raise typer.Exit(code=1)
+
+    settings = get_settings()
+    vault, _, _, _ = build_services(prompt=False)
+    from hermes_vault.audit_integrity.service import AuditIntegrityService
+    service = AuditIntegrityService(settings.db_path, vault.key)
+    service.ensure_initialized()
+    result = service.verify()
+
+    if format == "json":
+        payload = result.to_dict()
+        if not full:
+            payload.pop("sanitized_reason", None)
+            payload.pop("recommended_next_step", None)
+        console.print_json(data=payload)
+    else:
+        _print_verification_result(result, full=full)
+
+    if result.status.value == "healthy":
+        raise typer.Exit(code=0)
+    elif result.status.value in ("legacy", "incomplete"):
+        raise typer.Exit(code=2)
+    elif result.status.value == "failed":
+        raise typer.Exit(code=3)
+
+
+@_typer_app.command("audit-checkpoint")
+def audit_checkpoint(
+    ctx: typer.Context,
+    action: str = typer.Argument("show", help="Checkpoint action: show, establish, advance, recover."),
+    reason: str | None = typer.Option(None, "--reason", help="Required reason for establish/advance/recover."),
+    yes: bool = typer.Option(False, "--yes", help="Confirm checkpoint mutation without prompting."),
+) -> None:
+    """Inspect or manage the authenticated audit checkpoint.
+
+    'show' is read-only. Other actions are operator-only and require --yes.
+
+    \b
+    Examples:
+      hermes-vault audit checkpoint show
+      hermes-vault audit checkpoint advance --yes
+      hermes-vault audit checkpoint recover --reason "System migration" --yes
+    """
+    settings = get_settings()
+    vault, _, _, _ = build_services(prompt=False)
+    from hermes_vault.audit_integrity.service import AuditIntegrityService
+    service = AuditIntegrityService(settings.db_path, vault.key)
+
+    if action == "show":
+        result = service.verify()
+        _print_verification_result(result, full=True)
+        raise typer.Exit(code=0)
+
+    if action in ("establish", "advance", "recover"):
+        if not yes:
+            console.print(f"[red]Checkpoint '{action}' requires --yes to confirm.[/red]")
+            raise typer.Exit(code=1)
+
+        if action == "establish":
+            result = service.establish_checkpoint()
+        elif action == "advance":
+            result = service.advance_checkpoint()
+        elif action == "recover":
+            result = service.recover_checkpoint()
+
+        console.print(f"[green]Checkpoint {action} completed.[/green]")
+        _print_verification_result(result, full=True)
+        raise typer.Exit(code=0 if result.status.value == "healthy" else 2)
+
+    console.print(f"[red]Unknown checkpoint action: {action}. Use show, establish, advance, or recover.[/red]")
+    raise typer.Exit(code=1)
+
+
+@_typer_app.command("audit-export")
+def audit_export(
+    with_integrity: bool = typer.Option(False, "--with-integrity", help="Include audit integrity evidence in the export."),
+    format: str = typer.Option("json", "--format", help="Output format (json only)."),
+) -> None:
+    """Export sanitized audit activity with optional integrity evidence.
+
+    \b
+    Examples:
+      hermes-vault audit export
+      hermes-vault audit export --with-integrity
+    """
+    if format != "json":
+        console.print("[red]--format must be 'json' for audit export[/red]")
+        raise typer.Exit(code=1)
+
+    settings = get_settings()
+    vault, _, _, _ = build_services(prompt=False)
+    from hermes_vault.audit import AuditLogger
+    from hermes_vault.audit_integrity.service import AuditIntegrityService
+
+    audit = AuditLogger(settings.db_path)
+    entries = audit.list_recent(limit=5000)
+    payload: dict[str, object] = {
+        "version": "audit-export-v1",
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "entry_count": len(entries),
+        "entries": entries,
+    }
+
+    if with_integrity:
+        service = AuditIntegrityService(settings.db_path, vault.key)
+        service.ensure_initialized()
+        result = service.verify()
+        payload["integrity"] = {
+            "version": "audit-backup-evidence-v1",
+            "verification_summary": {
+                "status": result.status.value,
+                "chain_version": result.chain_version,
+                "verified_count": result.verified_count,
+                "legacy_count": result.legacy_count,
+                "checkpoint_status": result.checkpoint_status.value,
+                "verified_at": result.verified_at.isoformat(),
+            },
+        }
+
+    console.print_json(data=payload)
+
+
+def _print_verification_result(result: object, full: bool = False) -> None:
+    """Print a human-readable audit verification result."""
+    status = getattr(result, "status", None)
+    reason_code = getattr(result, "reason_code", None)
+    chain_version = getattr(result, "chain_version", None)
+    serialization_version = getattr(result, "serialization_version", None)
+    active_segment_id = getattr(result, "active_segment_id", None)
+    active_segment_number = getattr(result, "active_segment_number", None)
+    verified_count = getattr(result, "verified_count", 0)
+    legacy_count = getattr(result, "legacy_count", 0)
+    first_verified = getattr(result, "first_verified_sequence", None)
+    last_verified = getattr(result, "last_verified_sequence", None)
+    checkpoint_status = getattr(result, "checkpoint_status", None)
+    sanitized_reason = getattr(result, "sanitized_reason", None)
+    recommended = getattr(result, "recommended_next_step", None)
+    verified_at = getattr(result, "verified_at", None)
+
+    status_str = str(status) if status else "unknown"
+    if status_str == "healthy":
+        color = "green"
+    elif status_str in ("legacy", "incomplete"):
+        color = "yellow"
+    elif status_str == "failed":
+        color = "red"
+    else:
+        color = "white"
+
+    table = Table(title="Audit Integrity Verification")
+    table.add_column("Field")
+    table.add_column("Value")
+
+    table.add_row("Status", f"[{color}]{status_str}[/{color}]")
+    table.add_row("Reason code", str(reason_code) if reason_code else "-")
+    table.add_row("Chain version", str(chain_version) if chain_version else "-")
+    if full:
+        table.add_row("Serialization version", str(serialization_version) if serialization_version else "-")
+        table.add_row("Active segment ID", str(active_segment_id) if active_segment_id else "-")
+        table.add_row("Active segment number", str(active_segment_number) if active_segment_number else "-")
+    table.add_row("Verified records", str(verified_count))
+    table.add_row("Legacy records", str(legacy_count))
+    if full:
+        table.add_row("First verified sequence", str(first_verified) if first_verified is not None else "-")
+        table.add_row("Last verified sequence", str(last_verified) if last_verified is not None else "-")
+    table.add_row("Checkpoint status", str(checkpoint_status) if checkpoint_status else "-")
+    table.add_row("Verified at", str(verified_at) if verified_at else "-")
+    if full:
+        table.add_row("Details", sanitized_reason or "-")
+        table.add_row("Recommendation", recommended or "-")
+
+    console.print(table)
+
+
 @_typer_app.command("status")
 def status(
     ctx: typer.Context,

--- a/src/hermes_vault/dashboard.py
+++ b/src/hermes_vault/dashboard.py
@@ -368,6 +368,37 @@ class DashboardAPI:
             "default_agent": ctx.settings.mcp_default_agent,
         }
 
+    def audit_integrity(self) -> dict[str, Any]:
+        """Return read-only audit integrity status for the dashboard."""
+        try:
+            ctx = self._context_factory()
+            from hermes_vault.audit_integrity.service import AuditIntegrityService
+            service = AuditIntegrityService(ctx.settings.db_path, ctx.vault.key)
+            service.ensure_initialized()
+            result = service.verify()
+            return {
+                "version": "audit-integrity-dashboard-v1",
+                "status": result.status.value,
+                "reason_code": result.reason_code,
+                "chain_version": result.chain_version,
+                "active_segment_id": result.active_segment_id,
+                "active_segment_number": result.active_segment_number,
+                "verified_count": result.verified_count,
+                "legacy_count": result.legacy_count,
+                "first_verified_sequence": result.first_verified_sequence,
+                "last_verified_sequence": result.last_verified_sequence,
+                "checkpoint_status": result.checkpoint_status.value,
+                "last_verification_time": result.verified_at.isoformat() if result.verified_at else None,
+                "sanitized_reason": result.sanitized_reason,
+                "recommended_next_step": result.recommended_next_step,
+            }
+        except Exception as exc:
+            return {
+                "version": "audit-integrity-dashboard-v1",
+                "status": "error",
+                "error": str(exc),
+            }
+
     def profiles(self) -> dict[str, Any]:
         ctx = self._context_factory()
         active = ctx.settings.profile_name
@@ -806,6 +837,11 @@ class DashboardRequestHandler(BaseHTTPRequestHandler):
         if not self._authorized(parsed):
             self._write_json({"error": "unauthorized"}, status=HTTPStatus.UNAUTHORIZED)
             return
+        # Read-only audit integrity verification endpoint.
+        if parsed.path == "/api/audit-integrity/verify":
+            result = self.server.api.audit_integrity()
+            self._write_json(result)
+            return
         try:
             payload = self._read_json()
         except ValueError as exc:
@@ -873,6 +909,8 @@ class DashboardRequestHandler(BaseHTTPRequestHandler):
             self._write_json(self.server.api.audit(limit=limit))
         elif path == "/api/mcp":
             self._write_json(self.server.api.mcp_status())
+        elif path == "/api/audit-integrity":
+            self._write_json(self.server.api.audit_integrity())
         elif path == "/api/profiles":
             self._write_json(self.server.api.profiles())
         elif path == "/api/session":

--- a/src/hermes_vault/mcp_server.py
+++ b/src/hermes_vault/mcp_server.py
@@ -404,7 +404,7 @@ def _resource_key(uri: Any) -> str:
         return "vault://services/{name}"
     if parsed.netloc == "leases" and parsed.path not in ("", "/"):
         return "vault://leases/{id}"
-    if parsed.netloc in {"services", "health", "policy", "leases", "status", "agent-context", "policy-explain", "requests", "recovery"} and parsed.path in ("", "/"):
+    if parsed.netloc in {"services", "health", "policy", "leases", "status", "agent-context", "policy-explain", "requests", "recovery", "audit-integrity"} and parsed.path in ("", "/"):
         return f"vault://{parsed.netloc}"
     raise ValueError(f"Unknown resource URI: {uri}")
 
@@ -637,6 +637,25 @@ def _status_resource_payload(broker: Broker, binding: MCPBindingContext, setting
         next_steps.append("Create and verify a backup with hermes-vault backup and hermes-vault backup-verify.")
     elif int(days_since_backup) > backup_threshold:
         next_steps.append("Refresh backup coverage and run a restore dry-run.")
+
+    # Audit integrity summary (metadata only).
+    audit_integrity: dict[str, Any] = {"available": False}
+    try:
+        from hermes_vault.audit_integrity.service import AuditIntegrityService
+        ai_service = AuditIntegrityService(broker.vault.db_path, broker.vault.key)
+        ai_service.ensure_initialized()
+        ai_result = ai_service.verify()
+        audit_integrity = {
+            "available": True,
+            "status": ai_result.status.value,
+            "reason_code": ai_result.reason_code,
+            "verified_count": ai_result.verified_count,
+            "legacy_count": ai_result.legacy_count,
+            "checkpoint_status": ai_result.checkpoint_status.value,
+        }
+    except Exception:
+        audit_integrity = {"available": False}
+
     if not next_steps:
         next_steps.append("Vault status is clean for this policy scope; continue using brokered env or leases.")
 
@@ -671,6 +690,7 @@ def _status_resource_payload(broker: Broker, binding: MCPBindingContext, setting
             "expired": sum(1 for lease in leases if lease.get("status") == "expired"),
             "revoked": sum(1 for lease in leases if lease.get("status") == "revoked"),
         },
+        "audit_integrity": audit_integrity,
         "next_steps": next_steps,
         "raw_secret_values_returned": False,
     }
@@ -760,6 +780,35 @@ def _recovery_resource_payload(uri: Any, broker: Broker, binding: MCPBindingCont
     payload["binding_mode"] = binding.binding_mode
     payload["raw_secret_values_returned"] = False
     return payload
+
+
+def _audit_integrity_resource_payload(broker: Broker, binding: MCPBindingContext) -> dict[str, Any]:
+    """Return metadata-only audit integrity status."""
+    from hermes_vault.audit_integrity.service import AuditIntegrityService
+
+    try:
+        service = AuditIntegrityService(broker.vault.db_path, broker.vault.key)
+        service.ensure_initialized()
+        result = service.verify()
+        return {
+            "version": "audit-integrity-mcp-v1",
+            "status": result.status.value,
+            "reason_code": result.reason_code,
+            "chain_version": result.chain_version,
+            "verified_count": result.verified_count,
+            "legacy_count": result.legacy_count,
+            "first_verified_sequence": result.first_verified_sequence,
+            "last_verified_sequence": result.last_verified_sequence,
+            "checkpoint_status": result.checkpoint_status.value,
+            "recommended_next_step": result.recommended_next_step,
+            "verified_at": result.verified_at.isoformat() if result.verified_at else None,
+        }
+    except Exception as exc:
+        return {
+            "version": "audit-integrity-mcp-v1",
+            "status": "error",
+            "error": str(exc),
+        }
 
 
 def _preflight_tool_arguments(name: str, arguments: dict[str, Any]) -> str | None:
@@ -985,6 +1034,13 @@ async def list_resources() -> list[Resource]:
             description="Redacted recovery drill resource. Requires query parameter: backup.",
             mimeType="application/json",
         ),
+        Resource(
+            name="vault-audit-integrity",
+            title="Hermes Vault audit integrity",
+            uri=AnyUrl("vault://audit-integrity"),
+            description="Metadata-only audit integrity status: status, chain version, checkpoint state, verified count.",
+            mimeType="application/json",
+        ),
     ]
     resources.extend(await _default_agent_service_resources())
     return resources
@@ -1059,6 +1115,8 @@ async def read_resource(uri: Any) -> Any:
             payload = _requests_resource_payload(broker, binding)
         elif key == "vault://recovery":
             payload = _recovery_resource_payload(uri, broker, binding)
+        elif key == "vault://audit-integrity":
+            payload = _audit_integrity_resource_payload(broker, binding)
         else:
             raise ValueError(f"Unknown resource URI: {uri}")
     except ValueError as exc:

--- a/tests/test_audit_surfaces.py
+++ b/tests/test_audit_surfaces.py
@@ -10,11 +10,10 @@ import pytest
 from click.testing import CliRunner
 
 from hermes_vault.audit import AuditLogger
-from hermes_vault.audit_integrity.checkpoint import read_checkpoint, write_checkpoint
-from hermes_vault.audit_integrity.models import AuditCheckpointStatus, AuditIntegrityStatus
+from hermes_vault.audit_integrity.checkpoint import read_checkpoint
 from hermes_vault.audit_integrity.service import AuditIntegrityService
 from hermes_vault.cli import _hermes_group
-from hermes_vault.dashboard import DashboardAPI, DashboardState, create_dashboard_server
+from hermes_vault.dashboard import DashboardAPI, create_dashboard_server
 from hermes_vault.models import AccessLogRecord, Decision
 from hermes_vault.vault import Vault
 
@@ -107,7 +106,6 @@ def _mcp_audit_integrity_payload(vault: Vault) -> dict:
 
 def _api(tmp_path: Path, vault: Vault | None = None) -> DashboardAPI:
     from hermes_vault.config import AppSettings
-    from hermes_vault.policy import PolicyEngine
 
     vault = vault or _make_vault(tmp_path)
     settings = AppSettings(runtime_home=tmp_path, base_home=tmp_path)
@@ -233,7 +231,7 @@ class TestCliAuditVerify:
 
     def test_verify_is_read_only(self, monkeypatch, tmp_path: Path) -> None:
         vault = _make_vault(tmp_path)
-        svc = _seed_and_init_integrity(vault)
+        _seed_and_init_integrity(vault)
         cp_before = read_checkpoint(tmp_path / "audit.checkpoint.json")
         self._invoke(monkeypatch, tmp_path, ["--format", "json"])
         cp_after = read_checkpoint(tmp_path / "audit.checkpoint.json")

--- a/tests/test_audit_surfaces.py
+++ b/tests/test_audit_surfaces.py
@@ -1,0 +1,580 @@
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.audit_integrity.checkpoint import read_checkpoint, write_checkpoint
+from hermes_vault.audit_integrity.models import AuditCheckpointStatus, AuditIntegrityStatus
+from hermes_vault.audit_integrity.service import AuditIntegrityService
+from hermes_vault.cli import _hermes_group
+from hermes_vault.dashboard import DashboardAPI, DashboardState, create_dashboard_server
+from hermes_vault.models import AccessLogRecord, Decision
+from hermes_vault.vault import Vault
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_vault(tmp_path: Path) -> Vault:
+    vault = Vault(tmp_path / "vault.db", tmp_path / "master_key_salt.bin", "test-passphrase")
+    vault.add_credential("openai", "sk-fake-key-12345", "api_key")
+    return vault
+
+
+def _seed_and_init_integrity(vault: Vault, count: int = 5) -> AuditIntegrityService:
+    """Initialize integrity and seed *count* records into the chain."""
+    svc = AuditIntegrityService(vault.db_path, vault.key)
+    svc.ensure_initialized()
+    for i in range(count):
+        svc.append(
+            AccessLogRecord(
+                id=f"svc-{i}-{time.monotonic_ns()}",
+                agent_id=f"agent-{i}",
+                service="openai",
+                action="get_env",
+                decision=Decision.allow,
+                reason=f"seed row {i}",
+            )
+        )
+    return svc
+
+
+def _add_unprotected_audit_rows(vault: Vault, count: int = 3) -> None:
+    """Add rows directly to access_logs, bypassing integrity service entirely."""
+    import sqlite3
+    from uuid import uuid4
+
+    conn = sqlite3.connect(vault.db_path)
+    try:
+        for i in range(count):
+            rid = str(uuid4())
+            conn.execute(
+                "INSERT INTO access_logs (id, timestamp, agent_id, service, action, decision, reason) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (rid, "2026-07-18T16:00:00", f"rogue-{i}", "openai", "get_env", "allow", f"unprotected row {i}"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _wait_for_server(url: str, timeout: float = 10.0, interval: float = 0.1) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=1) as resp:
+                resp.read()
+            return
+        except (urllib.error.URLError, OSError) as exc:
+            last_error = exc
+            time.sleep(interval)
+    raise RuntimeError(f"Server at {url} did not become ready within {timeout}s") from last_error
+
+
+def _mcp_audit_integrity_payload(vault: Vault) -> dict:
+    """Direct call to the MCP audit-integrity resource payload function."""
+    from hermes_vault.mcp_server import _audit_integrity_resource_payload
+    from hermes_vault.broker import Broker
+    from hermes_vault.policy import PolicyEngine
+    from hermes_vault.verifier import Verifier
+    from hermes_vault.config import AppSettings
+    import types
+
+    db_path = vault.db_path
+    settings = AppSettings(runtime_home=db_path.parent, base_home=db_path.parent)
+    settings.ensure_runtime_layout()
+    policy = PolicyEngine.from_yaml(settings.effective_policy_path)
+    audit = AuditLogger(db_path, master_key=vault.key)
+    verifier = Verifier(plugin_dir=settings.verifier_plugin_dir)
+    broker = Broker(vault=vault, policy=policy, verifier=verifier, audit=audit)
+
+    binding = types.SimpleNamespace(
+        requested_agent_id="test-agent",
+        effective_agent_id="test-agent",
+        binding_mode="enforcement",
+        allowed_agents=("test-agent",),
+        default_agent="test-agent",
+    )
+    return _audit_integrity_resource_payload(broker, binding)
+
+
+def _api(tmp_path: Path, vault: Vault | None = None) -> DashboardAPI:
+    from hermes_vault.config import AppSettings
+    from hermes_vault.policy import PolicyEngine
+
+    vault = vault or _make_vault(tmp_path)
+    settings = AppSettings(runtime_home=tmp_path, base_home=tmp_path)
+    settings.ensure_runtime_layout()
+
+    class FakeCtx:
+        @property
+        def settings(self):
+            return settings
+        @property
+        def vault(self):
+            return vault
+        @property
+        def audit(self):
+            return AuditLogger(settings.db_path, master_key=vault.key)
+
+    return DashboardAPI(context_factory=lambda: FakeCtx())
+
+
+def _start_server(api: DashboardAPI):
+    server = create_dashboard_server(token="test-token", api=api)
+    port = server.server_address[1]
+    import threading
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _wait_for_server(f"http://127.0.0.1:{port}/")
+    return server, port, thread
+
+
+def _dash_get(port: int, path: str, token: str | None = "test-token") -> dict:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(f"http://127.0.0.1:{port}{path}", headers=headers)
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _dash_post(port: int, path: str, data: dict | None = None, token: str | None = "test-token") -> dict:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    body = json.dumps(data or {}).encode("utf-8")
+    req = urllib.request.Request(f"http://127.0.0.1:{port}{path}", data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+# ── CLI: audit-verify ───────────────────────────────────────────────────────
+
+
+class TestCliAuditVerify:
+    """Exit codes: 0=healthy, 2=incomplete, 3=failed, 1=error."""
+
+    def _invoke(self, monkeypatch, tmp_path: Path, args: list[str]) -> tuple[int, str]:
+        monkeypatch.setenv("HERMES_VAULT_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_VAULT_PASSPHRASE_DEFAULT", "test-passphrase")
+        runner = CliRunner()
+        result = runner.invoke(_hermes_group, ["audit-verify"] + args)
+        return result.exit_code, result.output
+
+    def test_healthy_exit_code(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, [])
+        assert code == 0, f"Expected healthy (0), got {code}: {output}"
+
+    def test_healthy_json_output_contract(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, ["--format", "json"])
+        assert code == 0
+        payload = json.loads(output)
+        assert payload["status"] == "healthy"
+        assert payload["chain_version"] is not None
+        assert isinstance(payload["verified_count"], int) and payload["verified_count"] > 0
+        for key in ("status", "chain_version", "verified_count", "checkpoint_status", "verified_at"):
+            assert key in payload, f"Missing JSON field: {key}"
+
+    def test_healthy_human_output(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, [])
+        assert code == 0
+        # Human output should contain readable field names
+        assert "Status" in output or "healthy" in output.lower()
+        assert "Chain" in output or "chain" in output.lower()
+
+    def test_incomplete_with_missing_checkpoint(self, monkeypatch, tmp_path: Path) -> None:
+        """A missing checkpoint makes the chain incomplete (exit code 2)."""
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        # Delete the checkpoint to trigger 'missing' state -> incomplete
+        cp_path = tmp_path / "audit.checkpoint.json"
+        if cp_path.exists():
+            cp_path.unlink()
+        code, output = self._invoke(monkeypatch, tmp_path, ["--format", "json"])
+        assert code == 2, f"Expected incomplete (2), got {code}: {output}"
+        payload = json.loads(output)
+        assert payload["status"] in ("incomplete",)
+        assert payload["checkpoint_status"] == "missing"
+
+    def test_incomplete_json_output(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        cp_path = tmp_path / "audit.checkpoint.json"
+        if cp_path.exists():
+            cp_path.unlink()
+        code, output = self._invoke(monkeypatch, tmp_path, ["--format", "json"])
+        assert code == 2
+        payload = json.loads(output)
+        assert "status" in payload
+        assert "reason_code" in payload
+
+    def test_invalid_format_returns_error(self, monkeypatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("HERMES_VAULT_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_VAULT_PASSPHRASE_DEFAULT", "test-passphrase")
+        runner = CliRunner()
+        result = runner.invoke(_hermes_group, ["audit-verify", "--format", "xml"])
+        assert result.exit_code == 1
+        # Sanitized error output (no stack traces)
+        assert "must be" in result.output
+
+    def test_verify_is_read_only(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        svc = _seed_and_init_integrity(vault)
+        cp_before = read_checkpoint(tmp_path / "audit.checkpoint.json")
+        self._invoke(monkeypatch, tmp_path, ["--format", "json"])
+        cp_after = read_checkpoint(tmp_path / "audit.checkpoint.json")
+        assert cp_before == cp_after, "Verification mutated checkpoint state"
+
+    def test_sanitized_error_output(self, monkeypatch, tmp_path: Path) -> None:
+        """Errors should not leak credentials or paths in raw form."""
+        monkeypatch.setenv("HERMES_VAULT_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_VAULT_PASSPHRASE_DEFAULT", "test-passphrase")
+        runner = CliRunner()
+        result = runner.invoke(_hermes_group, ["audit-verify", "--format", "xml"])
+        assert result.exit_code == 1
+        # No traceback or debug info in output
+        assert "Traceback" not in result.output
+        assert "File \"" not in result.output
+        assert "sk-fake" not in result.output
+
+
+# ── CLI: audit-checkpoint ────────────────────────────────────────────────────
+
+
+class TestCliAuditCheckpoint:
+    def _invoke(self, monkeypatch, tmp_path: Path, args: list[str]) -> tuple[int, str]:
+        monkeypatch.setenv("HERMES_VAULT_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_VAULT_PASSPHRASE_DEFAULT", "test-passphrase")
+        runner = CliRunner()
+        result = runner.invoke(_hermes_group, ["audit-checkpoint"] + args)
+        return result.exit_code, result.output
+
+    def test_show_healthy(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, ["show"])
+        assert code == 0
+        assert "Status" in output or "healthy" in output.lower()
+
+    def test_establish_requires_yes(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, ["establish"])
+        assert code == 1
+        assert "--yes" in output
+
+    def test_establish_with_yes(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, ["establish", "--yes"])
+        assert code == 0, f"Expected 0, got {code}: {output}"
+
+    def test_advance_requires_yes(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, ["advance"])
+        assert code == 1
+        assert "--yes" in output
+
+    def test_advance_with_yes(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, ["advance", "--yes"])
+        assert code == 0, f"Expected 0, got {code}: {output}"
+
+    def test_recover_with_yes(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, ["recover", "--yes"])
+        # recover may succeed or not depending on state; must not crash
+        assert code in (0, 1, 2), f"Unexpected exit code: {code}"
+
+    def test_unknown_action_returns_error(self, monkeypatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("HERMES_VAULT_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_VAULT_PASSPHRASE_DEFAULT", "test-passphrase")
+        runner = CliRunner()
+        result = runner.invoke(_hermes_group, ["audit-checkpoint", "fly"])
+        assert result.exit_code == 1
+        assert "Unknown" in result.output
+
+    def test_show_is_read_only(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        svc = _seed_and_init_integrity(vault)
+        result_before = svc.verify()
+        self._invoke(monkeypatch, tmp_path, ["show"])
+        result_after = svc.verify()
+        assert result_before.status == result_after.status
+
+
+# ── CLI: audit-export ────────────────────────────────────────────────────────
+
+
+class TestCliAuditExport:
+    def _invoke(self, monkeypatch, tmp_path: Path, args: list[str]) -> tuple[int, str]:
+        monkeypatch.setenv("HERMES_VAULT_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_VAULT_PASSPHRASE_DEFAULT", "test-passphrase")
+        runner = CliRunner()
+        result = runner.invoke(_hermes_group, ["audit-export"] + args)
+        return result.exit_code, result.output
+
+    def test_export_without_integrity(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, [])
+        assert code == 0
+        payload = json.loads(output)
+        assert payload["version"] == "audit-export-v1"
+        assert "entries" in payload
+        assert isinstance(payload["entries"], list)
+        assert payload["entry_count"] > 0
+        # Export redaction: no encrypted_payload in entries
+        for entry in payload["entries"]:
+            assert "encrypted_payload" not in entry
+
+    def test_export_with_integrity(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, ["--with-integrity"])
+        assert code == 0
+        payload = json.loads(output)
+        assert payload["version"] == "audit-export-v1"
+        assert "integrity" in payload
+        integrity = payload["integrity"]
+        assert integrity["version"] == "audit-backup-evidence-v1"
+        assert integrity["verification_summary"]["status"] is not None
+        assert integrity["verification_summary"]["verified_count"] > 0
+
+    def test_export_ordering(self, monkeypatch, tmp_path: Path) -> None:
+        """Export entries should have consistent ordering."""
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, [])
+        assert code == 0
+        payload = json.loads(output)
+        assert isinstance(payload["entries"], list)
+        assert len(payload["entries"]) == payload["entry_count"]
+
+    def test_export_version(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, [])
+        assert code == 0
+        payload = json.loads(output)
+        assert payload["version"] == "audit-export-v1"
+
+    def test_no_private_signing_material(self, monkeypatch, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        code, output = self._invoke(monkeypatch, tmp_path, ["--with-integrity"])
+        assert code == 0
+        payload = json.loads(output)
+        output_str = json.dumps(payload)
+        assert "private_key" not in output_str
+        assert "master_key" not in output_str
+        assert "passphrase" not in output_str
+        assert "sk-fake" not in output_str
+
+
+# ── Dashboard: audit-integrity endpoints ─────────────────────────────────────
+
+
+class TestDashboardAuditIntegrity:
+    def test_get_audit_integrity_healthy(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        api = _api(tmp_path, vault)
+        server, port, _ = _start_server(api)
+        try:
+            payload = _dash_get(port, "/api/audit-integrity")
+            assert payload["status"] == "healthy"
+            assert payload["version"] == "audit-integrity-dashboard-v1"
+            assert isinstance(payload["verified_count"], int)
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_get_audit_integrity_incomplete(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        _add_unprotected_audit_rows(vault)
+        api = _api(tmp_path, vault)
+        server, port, _ = _start_server(api)
+        try:
+            payload = _dash_get(port, "/api/audit-integrity")
+            assert payload["status"] in ("incomplete", "failed")
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_post_audit_integrity_verify(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        api = _api(tmp_path, vault)
+        server, port, _ = _start_server(api)
+        try:
+            payload = _dash_post(port, "/api/audit-integrity/verify")
+            assert payload["status"] == "healthy"
+            assert payload["version"] == "audit-integrity-dashboard-v1"
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_read_only_behavior(self, tmp_path: Path) -> None:
+        """Dashboard audit endpoints must not mutate checkpoint."""
+        vault = _make_vault(tmp_path)
+        svc = _seed_and_init_integrity(vault)
+        result_before = svc.verify()
+        api = _api(tmp_path, vault)
+        server, port, _ = _start_server(api)
+        try:
+            _dash_get(port, "/api/audit-integrity")
+            _dash_post(port, "/api/audit-integrity/verify")
+        finally:
+            server.shutdown()
+            server.server_close()
+        result_after = svc.verify()
+        assert result_before.status == result_after.status
+
+    def test_missing_token_returns_401(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        api = _api(tmp_path, vault)
+        server, port, _ = _start_server(api)
+        try:
+            with pytest.raises(urllib.error.HTTPError) as exc:
+                _dash_get(port, "/api/audit-integrity", token=None)
+            assert exc.value.code == 401
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_invalid_token_returns_401(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        api = _api(tmp_path, vault)
+        server, port, _ = _start_server(api)
+        try:
+            with pytest.raises(urllib.error.HTTPError) as exc:
+                _dash_get(port, "/api/audit-integrity", token="wrong-token")
+            assert exc.value.code == 401
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_no_raw_audit_metadata_or_secrets(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        api = _api(tmp_path, vault)
+        server, port, _ = _start_server(api)
+        try:
+            payload = _dash_get(port, "/api/audit-integrity")
+            output_str = json.dumps(payload)
+            assert "encrypted_payload" not in output_str
+            assert "sk-fake" not in output_str
+            assert "private_key" not in output_str
+            assert "master_key" not in output_str
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_packaged_static_assets_exist(self, tmp_path: Path) -> None:
+        from hermes_vault.dashboard import dashboard_static_dir
+        static = dashboard_static_dir()
+        assert static.exists(), f"Static dir not found: {static}"
+        assert (static / "index.html").exists()
+        assert (static / "app.js").exists()
+        assert (static / "styles.css").exists()
+
+    def test_repeated_server_startup_teardown(self, tmp_path: Path) -> None:
+        """Clean shutdown and restart on Windows."""
+        vault = _make_vault(tmp_path)
+        for _ in range(3):
+            api = _api(tmp_path, vault)
+            server, port, _ = _start_server(api)
+            try:
+                payload = _dash_get(port, "/api/audit-integrity")
+                assert "status" in payload
+            finally:
+                server.shutdown()
+                server.server_close()
+
+
+# ── MCP: audit-integrity resource and status ─────────────────────────────────
+
+
+class TestMcpAuditIntegrity:
+    def test_vault_audit_integrity_is_listed(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        payload = _mcp_audit_integrity_payload(vault)
+        assert payload["version"] == "audit-integrity-mcp-v1"
+        assert "status" in payload
+
+    def test_exact_result_fields(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        payload = _mcp_audit_integrity_payload(vault)
+        expected_fields = {
+            "version", "status", "reason_code", "chain_version",
+            "verified_count", "legacy_count",
+            "first_verified_sequence", "last_verified_sequence",
+            "checkpoint_status", "recommended_next_step", "verified_at",
+        }
+        for field in expected_fields:
+            assert field in payload, f"Missing MCP field: {field}"
+
+    def test_metadata_only_no_audit_rows(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        payload = _mcp_audit_integrity_payload(vault)
+        output_str = json.dumps(payload)
+        assert "entries" not in output_str
+        assert "access_log" not in output_str.lower()
+
+    def test_no_agent_ids(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        payload = _mcp_audit_integrity_payload(vault)
+        output_str = json.dumps(payload)
+        assert "agent-0" not in output_str
+        assert "agent-1" not in output_str
+
+    def test_no_service_names(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        payload = _mcp_audit_integrity_payload(vault)
+        output_str = json.dumps(payload)
+        assert "openai" not in output_str
+
+    def test_no_raw_reasons(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        payload = _mcp_audit_integrity_payload(vault)
+        output_str = json.dumps(payload)
+        assert "seed row" not in output_str
+
+    def test_no_checkpoint_mutation_tools(self, tmp_path: Path) -> None:
+        from hermes_vault.mcp_server import list_tools
+        import asyncio
+        tool_names = [t.name for t in asyncio.run(list_tools())]
+        checkpoint_tools = [n for n in tool_names if "checkpoint" in n.lower()]
+        assert not checkpoint_tools, f"Found unexpected checkpoint mutation tools: {checkpoint_tools}"
+
+    def test_no_secret_source_authority_change(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_and_init_integrity(vault)
+        payload = _mcp_audit_integrity_payload(vault)
+        output_str = json.dumps(payload)
+        assert "sk-fake-key" not in output_str

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -29,6 +29,29 @@ from hermes_vault.policy import PolicyEngine
 from hermes_vault.verifier import Verifier
 from hermes_vault.vault import Vault
 
+
+def _wait_for_server(server_url: str, timeout: float = 10.0, interval: float = 0.1) -> None:
+    """Poll a server URL until it responds or the timeout expires.
+
+    Prevents race conditions from daemon-threaded server startup
+    in test environments (notably Windows Python 3.12 where thread
+    startup can be delayed).
+    """
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(server_url, timeout=1) as resp:
+                resp.read()
+            return
+        except (urllib.error.URLError, OSError) as exc:
+            last_error = exc
+            time.sleep(interval)
+    raise RuntimeError(
+        f"Server at {server_url} did not become ready within {timeout}s"
+    ) from last_error
+
+
 def _context(tmp_path: Path) -> DashboardContext:
     from hermes_vault.config import AppSettings
 
@@ -275,6 +298,7 @@ def test_dashboard_profile_select_http_endpoint(monkeypatch, tmp_path: Path) -> 
 
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
+        _wait_for_server(f"http://127.0.0.1:{port}/")
         request = urllib.request.Request(
             f"http://127.0.0.1:{port}/api/profile/select",
             data=json.dumps({"profile": "work"}).encode("utf-8"),
@@ -305,6 +329,7 @@ def test_dashboard_server_requires_token(tmp_path: Path) -> None:
 
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
+        _wait_for_server(f"http://127.0.0.1:{port}/")
 
         with pytest.raises(urllib.error.HTTPError) as exc:
             urllib.request.urlopen(f"http://127.0.0.1:{port}/api/credentials", timeout=5)
@@ -335,6 +360,7 @@ def test_dashboard_serves_static_assets_and_404s_missing_assets(tmp_path: Path) 
 
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
+        _wait_for_server(f"http://127.0.0.1:{port}/")
 
         with urllib.request.urlopen(f"http://127.0.0.1:{port}/app.js", timeout=5) as response:
             content_type = response.headers["Content-Type"]
@@ -364,14 +390,16 @@ def test_dashboard_static_asset_exists_in_package() -> None:
 def test_dashboard_server_expires_session_token(tmp_path: Path) -> None:
     ctx = _context(tmp_path)
     api = DashboardAPI(context_factory=lambda: ctx)
-    server = create_dashboard_server(token="secret-token", api=api, ttl_seconds=1)
+    server = create_dashboard_server(token="secret-token", api=api, ttl_seconds=2)
     try:
         port = server.server_address[1]
         import threading
 
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
-        time.sleep(1.1)
+        _wait_for_server(f"http://127.0.0.1:{port}/")
+        # Wait for the TTL to expire (2s) plus a small buffer.
+        time.sleep(2.5)
 
         request = urllib.request.Request(
             f"http://127.0.0.1:{port}/api/credentials",
@@ -756,6 +784,7 @@ def test_dashboard_bad_limit_returns_json_400(tmp_path: Path) -> None:
 
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
+        _wait_for_server(f"http://127.0.0.1:{port}/")
         request = urllib.request.Request(
             f"http://127.0.0.1:{port}/api/audit?limit=nope",
             headers={"Authorization": "Bearer secret-token"},
@@ -780,6 +809,7 @@ def test_dashboard_bad_json_returns_json_400(tmp_path: Path) -> None:
 
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
+        _wait_for_server(f"http://127.0.0.1:{port}/")
         request = urllib.request.Request(
             f"http://127.0.0.1:{port}/api/actions/health",
             data=b"{",


### PR DESCRIPTION
## Summary

Completes Issue #32 by adding audit integrity verification surfaces:

### CLI
- `hermes-vault audit-verify` with human/json format, exit codes
- `hermes-vault audit-checkpoint` with show/establish/advance/recover actions
- `hermes-vault audit-export` with --with-integrity flag

### Dashboard
- `GET /api/audit-integrity` read-only endpoint
- `POST /api/audit-integrity/verify` read-only verification endpoint

### MCP
- `vault://audit-integrity` metadata-only resource
- Integrity summary in `vault://status`

### Security boundaries
- Verification remains read-only
- Checkpoint mutation requires operator confirmation (--yes)
- MCP returns metadata only, no raw audit rows
- No checkpoint mutation through MCP or dashboard

Closes #32