### PR TITLE
docs: sync public site with v0.21.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.21.0 -- Audit Assurance (unreleased)
+## 0.21.0 -- Audit Assurance
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Hermes Vault runs natively on Windows -- no WSL required.
 
 ```powershell
 # Install with uv (recommended)
-uv tool install git+https://github.com/asimons81/hermes-vault.git@v0.20.0
+uv tool install git+https://github.com/asimons81/hermes-vault.git@v0.21.0
 
 # Or with pipx
-pipx install git+https://github.com/asimons81/hermes-vault.git@v0.20.0
+pipx install git+https://github.com/asimons81/hermes-vault.git@v0.21.0
 
 # Or with pip (editable dev install)
 python -m venv .venv
@@ -201,7 +201,7 @@ When `--redact-source` is used, only successfully imported env lines are comment
 
 ## Hermes Vault Console
 
-Hermes Vault Console, introduced in v0.8.0 and expanded through v0.20.0, is the local dashboard for the credential broker. It gives operators one browser view of vault health, credential metadata, policy drift, audit activity, MCP binding, agent context, access requests, recovery posture, and safe operations without turning the browser into a secret viewer.
+Hermes Vault Console, introduced in v0.8.0 and expanded through v0.21.0, is the local dashboard for the credential broker. It gives operators one browser view of vault health, credential metadata, policy drift, audit activity, MCP binding, agent context, access requests, recovery posture, and safe operations without turning the browser into a secret viewer.
 
 Launch it from the same machine that owns the vault:
 
@@ -231,7 +231,7 @@ Screenshot set captured with a temporary demo vault and fake/demo credentials on
 - [Recovery Posture view](docs/assets/v0.8.0-dashboard/dashboard-recovery-posture.png)
 - [Operations Panel view](docs/assets/v0.8.0-dashboard/dashboard-operations.png)
 
-The screenshots and launch notes above are the legacy v0.8.0 baseline. They still document the local-only, token-guarded safety boundary, but the dashboard has grown since then and the v0.20.0 launch visuals need a fresh screenshot set before publishing updated images.
+The screenshots and launch notes above are the legacy v0.8.0 baseline. They still document the local-only, token-guarded safety boundary, but the dashboard has grown since then and the v0.21.0 launch visuals need a fresh screenshot set before publishing updated images.
 
 ## MCP Server
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -8,7 +8,7 @@
 4. Edit `~/.hermes/hermes-vault-data/policy.yaml` for the real agent allowlists.
 5. Back up both `vault.db` and `master_key_salt.bin` together. Losing the salt makes the vault unreadable.
 
-## v0.20.0 secret-source startup runbook
+## v0.21.0 Audit Assurance startup runbook
 
 Hermes Vault now materializes mapped startup credentials through the standalone
 Hermes Secret Source plugin. Use this when Hermes needs explicit env vars at
@@ -444,7 +444,7 @@ hermes-vault maintain --print-schedule
 
 ## Dashboard
 
-`hermes-vault dashboard` starts the local Hermes Vault Console introduced in v0.8.0 and expanded through v0.20.0. Use it for daily operator visibility, policy explanation, request review, and bounded checks. Use the CLI for setup, imports, backups, policy edits, credential mutation, destructive recovery, release work, and any operation where you want an explicit command transcript.
+The `hermes-vault dashboard` command starts the local Hermes Vault Console introduced in v0.8.0 and expanded through v0.21.0. Use it for daily operator visibility, policy explanation, request review, and bounded checks. Use the CLI for setup, imports, backups, policy edits, credential mutation, destructive recovery, release work, and any operation where you want an explicit command transcript.
 
 ```bash
 hermes-vault dashboard

--- a/release-readiness/v0.21.0/readiness-report.md
+++ b/release-readiness/v0.21.0/readiness-report.md
@@ -6,7 +6,7 @@
 
 - Target: `0.21.0`
 - Codename: Audit Assurance
-- Release branch SHA: `5f78c2f` (release/v0.21.0)
+- Release branch SHA: `5bb8406` (merged as v0.21.0 tag)
 
 ## PRs and Issues
 

--- a/site/index.html
+++ b/site/index.html
@@ -64,7 +64,7 @@
           <div class="metric-card">
             <span>Current Release</span>
             <strong>0.21.0</strong>
-            <small>Mapped startup secrets through `hermes_vault`, with protected bootstrap passphrases, redacted errors, and MCP still handling in-loop access.</small>
+            <small>Mapped startup secrets through `hermes_vault`, with protected bootstrap passphrases, redacted errors, and MCP still handling in-loop access. <a href="https://github.com/asimons81/hermes-vault/releases/tag/v0.21.0" target="_blank" rel="noreferrer noopener">View release</a></small>
           </div>
           <div class="metric-card">
             <span>Operator Loop</span>
@@ -284,7 +284,7 @@
           </figure>
         </div>
         <p class="gallery-note">
-          The published screenshot set below reflects the v0.18.0 console baseline and preserves the local-only, token-guarded boundary. The v0.20.0 release keeps this archive until a fresh capture set lands.
+          The published screenshot set below reflects the v0.18.0 console baseline and preserves the local-only, token-guarded boundary. The v0.21.0 release keeps this archive until a fresh capture set lands.
         </p>
       </div>
     </section>


### PR DESCRIPTION
Post-release documentation sync for v0.21.0.

- Remove '(unreleased)' from CHANGELOG v0.21.0 entry
- Update README install commands from v0.20.0 to v0.21.0
- Update operator-guide v0.20.0 references to v0.21.0
- Update release-readiness SHA to merged commit
- Fix site/index.html v0.20.0 references
- Add GitHub release link to site current-release card

No code changes. No tag movement.