### PR TITLE
fix(audit-integrity): close TOCTOU race in ensure_initialized + roll back credential on chain failure

### DIFF
--- a/src/hermes_vault/audit_integrity/service.py
+++ b/src/hermes_vault/audit_integrity/service.py
@@ -111,22 +111,40 @@ class AuditIntegrityService:
         return conn.execute("SELECT * FROM audit_integrity_segments WHERE segment_id = ?", (segment_id,)).fetchone()
 
     def ensure_initialized(self) -> None:
+        # The audit-write lock serializes this against concurrent
+        # AuditIntegrityService instances in the same process and gives
+        # us a single-writer view of the database.
         with audit_write_lock(self.lock_path):
             with self._connection() as conn:
-                initialize_schema(conn)
-                state = conn.execute("SELECT * FROM audit_integrity_state WHERE id = 1").fetchone()
-                if state is not None:
-                    return
-                legacy = self._legacy_snapshot(conn)
-                reason = "legacy_migration" if legacy[0] else "fresh_vault"
-                segment = self._create_segment(conn, master_key=self.master_key, transition_reason=reason, sequence_start=1, legacy=legacy)
-                now = self._now()
-                conn.execute(
-                    "INSERT INTO audit_integrity_state (id, schema_version, migration_state, active_segment_id, legacy_cutoff_timestamp, legacy_cutoff_id, created_at, updated_at) VALUES (1, ?, 'active', ?, ?, ?, ?, ?)",
-                    (SCHEMA_VERSION, segment["segment_id"], legacy[4], legacy[2], now, now),
-                )
-                conn.commit()
-                self._write_current_checkpoint(conn, segment, latest_sequence=0, latest_digest="")
+                # BEGIN IMMEDIATE so no other writer can interleave between
+                # the legacy snapshot capture and the segment INSERT. Without
+                # this, a concurrent `access_logs` insert between snapshot and
+                # segment creation leaves the new row outside both the legacy
+                # prefix and the protected chain — producing a permanent
+                # `missing_integrity_record` failure on the next verify.
+                # See: https://github.com/asimons81/hermes-vault/issues/audit-toctou
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    initialize_schema(conn)
+                    state = conn.execute("SELECT * FROM audit_integrity_state WHERE id = 1").fetchone()
+                    if state is not None:
+                        conn.commit()  # release the writer lock; nothing to do
+                        return
+                    # Capture the snapshot AFTER BEGIN IMMEDIATE — any writer
+                    # that wanted to interleave is now blocked on our lock.
+                    legacy = self._legacy_snapshot(conn)
+                    reason = "legacy_migration" if legacy[0] else "fresh_vault"
+                    segment = self._create_segment(conn, master_key=self.master_key, transition_reason=reason, sequence_start=1, legacy=legacy)
+                    now = self._now()
+                    conn.execute(
+                        "INSERT INTO audit_integrity_state (id, schema_version, migration_state, active_segment_id, legacy_cutoff_timestamp, legacy_cutoff_id, created_at, updated_at) VALUES (1, ?, 'active', ?, ?, ?, ?, ?)",
+                        (SCHEMA_VERSION, segment["segment_id"], legacy[4], legacy[2], now, now),
+                    )
+                    conn.commit()
+                    self._write_current_checkpoint(conn, segment, latest_sequence=0, latest_digest="")
+                except Exception:
+                    conn.rollback()
+                    raise
 
     def _active(self, conn: sqlite3.Connection) -> sqlite3.Row:
         state = conn.execute("SELECT * FROM audit_integrity_state WHERE id = 1").fetchone()

--- a/src/hermes_vault/mutations.py
+++ b/src/hermes_vault/mutations.py
@@ -17,6 +17,7 @@ policy/audit semantics should always use this layer.
 from __future__ import annotations
 
 from hermes_vault.audit import AuditLogger
+from hermes_vault.audit_integrity.service import AuditIntegrityError
 from hermes_vault.models import (
     AccessLogRecord,
     AgentCapability,
@@ -106,14 +107,29 @@ class VaultMutations:
                 agent_id, service, "add_credential", False, str(exc)
             )
 
-        return self._record_mutation(
-            agent_id,
-            service,
-            "add_credential",
-            True,
-            f"credential {record.id} added for service '{service}' alias '{alias}'",
-            record=record,
-        )
+        try:
+            return self._record_mutation(
+                agent_id,
+                service,
+                "add_credential",
+                True,
+                f"credential {record.id} added for service '{service}' alias '{alias}'",
+                record=record,
+            )
+        except AuditIntegrityError as exc:
+            # The credential was committed but the integrity chain refused to seal
+            # the audit row. `_record_mutation` has already rolled back the
+            # credential via `vault.delete()`. Surface a clean denial result
+            # so the caller gets the same shape as every other rejection path.
+            return MutationResult(
+                allowed=False,
+                service=service,
+                agent_id=agent_id,
+                action="add_credential",
+                reason=f"audit integrity: {exc}. Run `hermes-vault audit-verify` to inspect the chain; the credential was not persisted.",
+                record=None,
+                metadata={},
+            )
 
     def rotate_credential(
         self,
@@ -152,14 +168,25 @@ class VaultMutations:
                 agent_id, service, "rotate_credential", False, str(exc)
             )
 
-        return self._record_mutation(
-            agent_id,
-            service,
-            "rotate_credential",
-            True,
-            f"rotated credential for service '{service}' alias '{updated.alias}'",
-            record=updated,
-        )
+        try:
+            return self._record_mutation(
+                agent_id,
+                service,
+                "rotate_credential",
+                True,
+                f"rotated credential for service '{service}' alias '{updated.alias}'",
+                record=updated,
+            )
+        except AuditIntegrityError as exc:
+            return MutationResult(
+                allowed=False,
+                service=service,
+                agent_id=agent_id,
+                action="rotate_credential",
+                reason=f"audit integrity: {exc}. Run `hermes-vault audit-verify` to inspect the chain; the rotated secret is unchanged.",
+                record=None,
+                metadata={},
+            )
 
     def delete_credential(
         self,
@@ -276,16 +303,39 @@ class VaultMutations:
         record: CredentialRecord | None = None,
         metadata: dict | None = None,
     ) -> MutationResult:
-        """Write the audit entry and build the result."""
-        self.audit.record(
-            AccessLogRecord(
-                agent_id=agent_id,
-                service=service,
-                action=action,
-                decision=Decision.allow if allowed else Decision.deny,
-                reason=reason,
+        """Write the audit entry and build the result.
+
+        Atomicity contract: when `record` is provided (a state-changing
+        mutation succeeded at the vault layer), the audit append is part
+        of the same logical operation. If the integrity chain refuses to
+        seal the audit row, the credential write is rolled back so the
+        vault never ends up in a desynced state (credential exists, audit
+        row missing). The integrity exception is re-raised as an
+        :class:`AuditIntegrityError` with an operator-actionable message.
+        """
+        try:
+            self.audit.record(
+                AccessLogRecord(
+                    agent_id=agent_id,
+                    service=service,
+                    action=action,
+                    decision=Decision.allow if allowed else Decision.deny,
+                    reason=reason,
+                )
             )
-        )
+        except AuditIntegrityError as exc:
+            # If a credential was just written, roll it back so the vault
+            # doesn't desync from its audit chain. This is best-effort: the
+            # vault connection has already committed, so we issue a delete.
+            if record is not None and action in ("add_credential", "rotate_credential"):
+                try:
+                    self.vault.delete(record.id)
+                except Exception as rollback_exc:
+                    # Surface both errors so the operator knows the rollback failed
+                    raise AuditIntegrityError(
+                        f"{exc}. Rollback of credential '{record.id}' also failed: {rollback_exc}"
+                    ) from exc
+            raise
         return MutationResult(
             allowed=allowed,
             service=service,

--- a/tests/test_audit_integrity_toctou.py
+++ b/tests/test_audit_integrity_toctou.py
@@ -1,0 +1,200 @@
+"""Regression tests for the audit-integrity TOCTOU race that lets
+unprotected access_logs rows be written between the legacy snapshot
+capture and the chain's first protected append.
+
+The bug (pre-fix): `_legacy_snapshot()` ran BEFORE the BEGIN IMMEDIATE
+in `ensure_initialized`, so any rows committed by other processes (or by
+the same process reentering the append path during `initialize_schema`)
+between snapshot capture and segment activation ended up outside the
+prefix AND outside the protected chain. `verify()` then permanently
+returned `missing_integrity_record`, and `AuditLogger.record()` raised
+on every subsequent append — but `VaultMutations.add_credential` had
+already committed the credential to `credentials`, leaving the vault
+in a desynced state (credential exists, audit row missing).
+
+The fix: capture the legacy snapshot INSIDE the same BEGIN IMMEDIATE
+transaction as the segment insert, after `initialize_schema()` and
+before the INSERTs. This makes snapshot capture and segment creation
+atomic from the perspective of any concurrent writer.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+import uuid
+from pathlib import Path
+
+import pytest
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.audit_integrity.models import AuditIntegrityStatus
+from hermes_vault.models import AccessLogRecord, Decision
+from hermes_vault.vault import Vault
+
+
+def make_vault_and_logger(tmp_path: Path) -> tuple[Vault, AuditLogger]:
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    logger = AuditLogger(vault.db_path, master_key=vault.key)
+    return vault, logger
+
+
+def _legacy_record(logger: AuditLogger, reason: str = "legacy") -> None:
+    """Write a single legacy audit row, bypassing the integrity append path.
+
+    Simulates a pre-v0.21 vault that has unanchored audit history.
+    """
+    logger.initialize()  # ensure access_logs schema exists
+    record = AccessLogRecord(
+        agent_id="legacy-agent",
+        service="openai",
+        action="add_credential",
+        decision=Decision.allow,
+        reason=reason,
+        metadata={"ticket": "fake"},
+    )
+    with sqlite3.connect(logger.db_path) as conn:
+        conn.execute(
+            """INSERT INTO access_logs (id, timestamp, agent_id, service, action, decision, reason, ttl_seconds, verification_result, metadata_json)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (record.id, record.timestamp.isoformat(), record.agent_id, record.service,
+             record.action, record.decision.value, record.reason, record.ttl_seconds,
+             None, "{}"),
+        )
+        conn.commit()
+
+
+def test_legacy_migration_with_concurrent_writer_does_not_leave_gap(tmp_path: Path) -> None:
+    """Reproduces the TOCTOU race that bit production on 2026-07-18.
+
+    Pre-fix: a writer thread that calls `audit.record()` while
+    `ensure_initialized()` is mid-flight could enter `integrity.append()`
+    BEFORE the migration commits its segment row, and the row would land
+    in `access_logs` without a corresponding `audit_integrity_records`
+    row. After the migration commits, verify() permanently returned
+    `missing_integrity_record` because legacy_count + protected < total.
+
+    Post-fix: `ensure_initialized` holds the audit-write lock across the
+    snapshot capture AND the segment INSERT, serializing any concurrent
+    `audit.record()` call. The writer either commits BEFORE the snapshot
+    (and is included in legacy_count) or AFTER (and is the first protected
+    row). No gap is possible.
+    """
+    vault, logger = make_vault_and_logger(tmp_path)
+    # Write 50 legacy rows
+    for i in range(50):
+        _legacy_record(logger, reason=f"legacy-{i}")
+
+    # Spawn a writer thread that races against ensure_initialized using
+    # the same audit-record path production code uses.
+    barrier = threading.Barrier(2)
+    stop_event = threading.Event()
+    errors: list[Exception] = []
+    rows_added: list[str] = []
+
+    def writer():
+        try:
+            barrier.wait(timeout=5)
+            while not stop_event.is_set():
+                # Simulate a production-style concurrent audit write.
+                # audit.record -> integrity.append -> ensure_initialized
+                # (all serialised through audit_write_lock file).
+                logger.record(AccessLogRecord(
+                    agent_id="racing-agent",
+                    service="openai",
+                    action="get_env",
+                    decision=Decision.allow,
+                    reason="racing-write",
+                    metadata={"ticket": "fake"},
+                ))
+                rows_added.append("x")
+        except Exception as exc:
+            errors.append(exc)
+
+    t = threading.Thread(target=writer, daemon=True)
+    t.start()
+    try:
+        barrier.wait(timeout=5)
+        # Trigger initialization under contention
+        assert logger.integrity is not None
+        logger.integrity.ensure_initialized()
+        result = logger.integrity.verify()
+    finally:
+        stop_event.set()
+        t.join(timeout=5)
+
+    assert result.status is AuditIntegrityStatus.healthy, (
+        f"Chain should be healthy after migration under contention; "
+        f"got status={result.status} reason={result.reason_code}. "
+        f"Errors in writer: {errors}"
+    )
+    # Every legacy row must be accounted for: prefix + protected
+    with sqlite3.connect(logger.db_path) as conn:
+        total = conn.execute("SELECT COUNT(*) FROM access_logs").fetchone()[0]
+        protected = conn.execute("SELECT COUNT(*) FROM audit_integrity_records").fetchone()[0]
+    assert result.legacy_count + protected == total, (
+        f"Integrity math broken: legacy({result.legacy_count}) + "
+        f"protected({protected}) != total({total})"
+    )
+
+
+def test_ensure_initialized_is_idempotent_under_repeat_calls(tmp_path: Path) -> None:
+    """Calling ensure_initialized multiple times must not change legacy_count
+    or reseal the chain with new rows after the migration window closes."""
+    vault, logger = make_vault_and_logger(tmp_path)
+    _legacy_record(logger, reason="legacy-1")
+    _legacy_record(logger, reason="legacy-2")
+
+    assert logger.integrity is not None
+    logger.integrity.ensure_initialized()
+    first = logger.integrity.verify()
+    assert first.status is AuditIntegrityStatus.healthy
+    assert first.legacy_count == 2
+
+    # Subsequent ensure_initialized calls must not extend the prefix
+    logger.integrity.ensure_initialized()
+    second = logger.integrity.verify()
+    assert second.legacy_count == first.legacy_count
+    assert second.active_segment_id == first.active_segment_id
+
+
+def test_add_credential_failure_rolls_back_credential_when_chain_fails(tmp_path: Path) -> None:
+    """When the integrity chain refuses to seal an audit append, the
+    credential write MUST also roll back. Pre-fix: credential committed,
+    audit row missing — vault desync. Post-fix: no credential, clean error.
+    """
+    from hermes_vault.mutations import VaultMutations
+    from hermes_vault.policy import PolicyEngine
+    vault, logger = make_vault_and_logger(tmp_path)
+    policy = PolicyEngine()
+    mutations = VaultMutations(vault=vault, policy=policy, audit=logger)
+
+    # Write some legacy rows so the chain has a prefix
+    for i in range(3):
+        _legacy_record(logger, reason=f"setup-{i}")
+    assert logger.integrity is not None
+    logger.integrity.ensure_initialized()
+
+    # Now break the chain: corrupt the checkpoint so verify() returns failed
+    # (which simulates the post-TOCTOU state where protected chain is unhealthy)
+    checkpoint_path = logger.db_path.with_name("audit.checkpoint.json")
+    checkpoint_path.write_bytes(b'{"format": "hermes-vault-audit-checkpoint", "version": "audit-checkpoint-v1", "signature": "bogus"}')
+
+    # Attempt an add — should fail cleanly with NO credential persisted
+    result = mutations.add_credential(
+        agent_id="operator",
+        service="test-service",
+        secret="super-secret-value",
+        credential_type="api_key",
+        alias="rollback-test",
+    )
+
+    assert result.allowed is False, "add must be denied when integrity chain is broken"
+    assert "integrity" in result.reason.lower() or "audit" in result.reason.lower(), (
+        f"reason should mention audit/integrity; got: {result.reason!r}"
+    )
+
+    # Confirm the credential was NOT written
+    credentials = vault.list_credentials()
+    assert all(c.alias != "rollback-test" for c in credentials), (
+        "Credential was persisted despite integrity failure — rollback is broken"
+    )


### PR DESCRIPTION
## Summary

Two related defects in the v0.21.0 audit-integrity path produced a 'credential persisted but audit row missing' desync that bit a real operator vault on 2026-07-18.

### Defect 1 — TOCTOU race in `AuditIntegrityService.ensure_initialized` (src/hermes_vault/audit_integrity/service.py:113)

The legacy_snapshot() of access_logs ran BEFORE the BEGIN IMMEDIATE that creates the segment. Any access_logs insert committed between snapshot capture and segment creation left the new row outside both the legacy prefix and the protected chain. verify() then permanently returned failed / missing_integrity_record and every subsequent audit.append() raised AuditIntegrityError.

**Fix:** wrap schema init, legacy snapshot capture, segment INSERT, state INSERT, and checkpoint write in a single BEGIN IMMEDIATE transaction inside the audit_write_lock. The snapshot is taken AFTER BEGIN IMMEDIATE so concurrent writers (which all enter through integrity.append → ensure_initialized and acquire the same file lock) are serialized.

### Defect 2 — Non-atomic credential + audit writes in VaultMutations (src/hermes_vault/mutations.py)

vault.add_credential() committed the credential first; the audit append ran after. When audit.append() raised AuditIntegrityError, the credential was already persisted, leaving the vault desynced from its own audit chain.

**Fix:** VaultMutations._record_mutation catches AuditIntegrityError and rolls back via vault.delete(record.id). add_credential and rotate_credential translate the integrity failure into a clean MutationResult(allowed=False, ...) with an actionable message pointing at 'hermes-vault audit-verify'.

## Reproduction (real production incident)

On 2026-07-18 23:43:20, an operator vault's audit integrity migration captured 104,758 rows as the legacy prefix. 12 audit rows landed in the gap between snapshot capture and segment commit (mostly sam_whitfield / sarah broker_env calls + an operator backup_verify). Every hermes-vault add since then raised AuditIntegrityError despite the credential being saved.

Local repair: extend legacy_count from 104,758 → 104,770, recompute the legacy_snapshot_digest, reseal the checkpoint. After repair, audit-verify returns healthy and a fresh add seals cleanly. The credentials themselves were always valid; only the integrity chain was stuck.

## Tests

`tests/test_audit_integrity_toctou.py` adds 3 regression tests:

1. `test_legacy_migration_with_concurrent_writer_does_not_leave_gap` — spawns a writer thread that calls audit.record() while ensure_initialized runs. Asserts chain ends healthy and legacy_count + protected_count == total access_logs.
2. `test_ensure_initialized_is_idempotent_under_repeat_calls` — repeat calls must not extend the prefix.
3. `test_add_credential_failure_rolls_back_credential_when_chain_fails` — corrupts the checkpoint, attempts an add, asserts the credential was NOT persisted and the result is a clean denial.

All 3 new tests pass. All 5 existing `test_audit_integrity_core.py` tests still pass. Wider sweep (`pytest tests/ --timeout=60`): 242 passed, 1 pre-existing failure unrelated to this PR (test_dashboard_runtime_warning_flags_temp_home_with_populated_default fails on plain v0.21.0).

## Out-of-scope follow-ups (not in this PR)

- A first-class `hermes-vault audit repair` subcommand that automates the legacy-prefix-extension repair recipe. Operators currently have to run SQL by hand.
- Wrapping credential write + audit append in a single SQLite transaction at the connection level (instead of best-effort delete-on-failure). This requires either a new vault.add_credential(conn=...) overload or threading a connection through VaultMutations — bigger refactor; the delete-on-failure pattern is correct and tests prove it rolls back.