### PR TITLE
v0.23.1 — Patch: mcp SDK cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.23.1 -- Patch: mcp SDK cap (2026-08-01)
+
+### Fixed
+
+- **Cap mcp SDK below 2.0**: pin `mcp>=1.0.0,<2.0.0` in runtime and dev dependencies. mcp 2.0.0 removed `Server.list_tools`, which broke `import hermes_vault.mcp_server` (line 853, `@server.list_tools()`) on fresh pip installs of 0.23.0.
+
+### Upgrade notes
+
+- No upgrade or migration steps required. Users on 0.23.0 should reinstall as 0.23.1 (`uv tool install hermes-vault==0.23.1` or reinstall the git URL) so pip resolves mcp < 2.0.0.
+
 ## 0.23.0 -- Maintenance & Docs (2026-08-01)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 Hermes Vault is a local-first credential broker and encrypted vault for Hermes agents. It scans for risky plaintext secrets, stores credentials locally, verifies them before re-auth claims, and turns agent access into explainable, lease-aware operator workflows.
 
-v0.23.0 is the current release — a maintenance and documentation update following the **Vault Intelligence** (v0.22.0) line. Hermes Vault keeps its credential health intelligence: 45 built-in verifiers, verification coverage metrics, A-F health scores, bulk import/export/filtering, and the setup wizard.
+v0.23.1 is the current release — a patch on the **Vault Intelligence** (v0.22.0) line that caps the MCP SDK below 2.0 so pip-based installs import cleanly. Hermes Vault keeps its credential health intelligence: 45 built-in verifiers, verification coverage metrics, A-F health scores, bulk import/export/filtering, and the setup wizard.
+
+## What's New in 0.23.1
+
+v0.23.1 is a patch release fixing the MCP SDK constraint.
+
+- Cap `mcp>=1.0.0,<2.0.0` (runtime + dev deps): mcp 2.0.0 removed `Server.list_tools`, which broke `import hermes_vault.mcp_server` on fresh pip installs of 0.23.0
 
 ## What's New in 0.23.0
 
@@ -58,10 +64,10 @@ Hermes Vault runs natively on Windows -- no WSL required.
 
 ```powershell
 # Install with uv (recommended)
-uv tool install git+https://github.com/asimons81/hermes-vault.git@v0.23.0
+uv tool install git+https://github.com/asimons81/hermes-vault.git@v0.23.1
 
 # Or with pipx
-pipx install git+https://github.com/asimons81/hermes-vault.git@v0.23.0
+pipx install git+https://github.com/asimons81/hermes-vault.git@v0.23.1
 
 # Or with pip (editable dev install)
 python -m venv .venv
@@ -208,7 +214,7 @@ When `--redact-source` is used, only successfully imported env lines are comment
 
 ## Hermes Vault Console
 
-Hermes Vault Console, introduced in v0.8.0 and expanded through v0.23.0, is the local dashboard for the credential broker. It gives operators one browser view of vault health, credential metadata, policy drift, audit activity, MCP binding, agent context, access requests, recovery posture, and safe operations without turning the browser into a secret viewer.
+Hermes Vault Console, introduced in v0.8.0 and expanded through v0.23.1, is the local dashboard for the credential broker. It gives operators one browser view of vault health, credential metadata, policy drift, audit activity, MCP binding, agent context, access requests, recovery posture, and safe operations without turning the browser into a secret viewer.
 
 Launch it from the same machine that owns the vault:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-vault"
-version = "0.23.0"
+version = "0.23.1"
 description = "Hermes-native local-first credential broker, scanner, and encrypted vault."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/site/index.html
+++ b/site/index.html
@@ -42,7 +42,7 @@
     <!-- Hero Section -->
     <section class="hero section-pad reveal hero-reveal-1">
       <div class="hero-copy">
-        <p class="eyebrow">v0.23.0 &bull; Maintenance &amp; Docs &bull; 45 verifiers, health scores, bulk operations</p>
+        <p class="eyebrow">v0.23.1 &bull; Patch &bull; mcp SDK capped &lt;2.0 for clean pip installs</p>
         <h1>From <span>.env</span> to safe agent access.</h1>
         <p class="lede">
           Bootstrap a messy plaintext env file into an encrypted local vault, explain every access decision, route approvals through an audit trail, bind env handoffs to leases, and prove recovery before the incident. Less key sprawl, fewer auth lies, fewer agent mistakes.
@@ -63,8 +63,8 @@
         <div class="hero-metrics" aria-label="Release and platform notes">
           <div class="metric-card">
             <span>Current Release</span>
-            <strong>0.23.0</strong>
-            <small>Maintenance and documentation update following the Vault Intelligence (v0.22.0) line: post-release verification records, release notes, and version-surface sync. <a href="https://github.com/asimons81/hermes-vault/releases/tag/v0.23.0" target="_blank" rel="noreferrer noopener">View release</a></small>
+            <strong>0.23.1</strong>
+            <small>Patch release capping the MCP SDK below 2.0 — mcp 2.0.0 removed <code>Server.list_tools</code>, which broke <code>import hermes_vault.mcp_server</code> on fresh pip installs of 0.23.0. <a href="https://github.com/asimons81/hermes-vault/releases/tag/v0.23.1" target="_blank" rel="noreferrer noopener">View release</a></small>
           </div>
           <div class="metric-card">
             <span>Operator Loop</span>
@@ -376,7 +376,7 @@
                 <span>Production Install</span>
                 <button class="copy-button" type="button" data-copy-target="users-code">Copy</button>
               </div>
-              <pre><code id="users-code">uv tool install git+https://github.com/asimons81/hermes-vault.git@v0.23.0
+              <pre><code id="users-code">uv tool install git+https://github.com/asimons81/hermes-vault.git@v0.23.1
 hermes-vault bootstrap --from-env .env --agent hermes --dry-run
 hermes-vault audit-verify
 hermes-vault audit-checkpoint show

--- a/src/hermes_vault/__init__.py
+++ b/src/hermes_vault/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.23.0"
+__version__ = "0.23.1"

--- a/tests/test_release_regression.py
+++ b/tests/test_release_regression.py
@@ -25,8 +25,8 @@ def test_release_version_surfaces_align() -> None:
     from hermes_vault.mcp_server import list_resources, list_tools, server
     import asyncio
 
-    assert pyproject["project"]["version"] == "0.23.0"
-    assert hermes_vault.__version__ == "0.23.0"
+    assert pyproject["project"]["version"] == "0.23.1"
+    assert hermes_vault.__version__ == "0.23.1"
     assert server.version == hermes_vault.__version__
     tool_names = {tool.name for tool in asyncio.run(list_tools())}
     assert {
@@ -53,11 +53,11 @@ def test_release_story_mentions_agent_control_plane() -> None:
     dashboard_html = (repo_root / "src" / "hermes_vault" / "dashboard_static" / "index.html").read_text(encoding="utf-8")
 
     assert "Vault Intelligence" in changelog
-    assert "What's New in 0.23.0" in readme
+    assert "What's New in 0.23.1" in readme
     assert "secret-source fetch" in operator_guide
     assert "Vault Intelligence" in readme
-    assert "v0.23.0" in site
-    assert "git@v0.23.0" in site
+    assert "v0.23.1" in site
+    assert "git@v0.23.1" in site
     assert "Command Center" in dashboard_html
 
     assert "policy-explain" in dashboard_html

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "hermes-vault"
-version = "0.23.0"
+version = "0.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
# v0.23.1 — Patch: mcp SDK cap

Patch release fixing the PyPI artifact for the mcp SDK constraint. 0.23.0 shipped with an unbounded `mcp>=1.0.0`; mcp 2.0.0 removed `Server.list_tools`, which broke `import hermes_vault.mcp_server` on fresh pip installs. This release pins `mcp>=1.0.0,<2.0.0` so pip resolves a working SDK.

## Fixed

- **Cap mcp SDK below 2.0**: pin `mcp>=1.0.0,<2.0.0` in runtime and dev dependencies. mcp 2.0.0 removed `Server.list_tools`, which broke `import hermes_vault.mcp_server` (line 853, `@server.list_tools()`) on fresh pip installs of 0.23.0.

## Upgrade notes

- No upgrade or migration steps required. Users on 0.23.0 should reinstall as 0.23.1 (`uv tool install hermes-vault==0.23.1` or reinstall the git URL) so pip resolves mcp < 2.0.0.

## Validation

- 898 tests passed
- ruff clean
- mypy clean (61 files)
- wheel + sdist build OK
- fresh venv install resolves mcp 1.29.0; `import hermes_vault.mcp_server` OK