### PR TITLE
v0.23.2 — fix audit chain wedge + export fail-closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.23.2 -- Patch: audit chain wedge + export fail-closed (2026-08-01)
+
+### Fixed
+
+- **Audit chain wedge (HIGH)**: six CLI write paths (`set-expiry`, `clear-expiry`, `backup-verify`, `restore --dry-run`, `rotate-master-key` pre-rotation logger, and `recovery drill`) constructed `AuditLogger` without a master key, so their audit rows were written through the legacy unprotected INSERT branch. The next integrity-protected append then failed with `AuditIntegrityError: An audit row is not protected by an integrity record`, wedging the entire chain so `delete`, `add`, lease issuance, and access requests crashed. All six sites now pass `master_key=vault.key` (matching `build_services`), keeping the chain protected after every operator action.
+- **Export fail-closed (MEDIUM)**: `export --with-secrets` with a wrong passphrase used to exit 0 and write `"secret": null` for every credential because decrypt exceptions were swallowed. It now fails with a clear error and non-zero exit instead of emitting null secrets.
+
+### Added
+
+- Regression tests (`tests/test_audit_chain_regression.py`) that reproduce the smoke-test sequence for each of the six commands — seed the chain with a protected `add`, run the command, then assert `audit-verify` stays healthy and a subsequent mutation still succeeds — plus fail-closed export coverage.
+
+### Upgrade notes
+
+- No upgrade or migration steps required. Users on 0.23.0/0.23.1 should reinstall as 0.23.2 (`uv tool install hermes-vault==0.23.2` or reinstall the git URL).
+
 ## 0.23.1 -- Patch: mcp SDK cap (2026-08-01)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@
 
 Hermes Vault is a local-first credential broker and encrypted vault for Hermes agents. It scans for risky plaintext secrets, stores credentials locally, verifies them before re-auth claims, and turns agent access into explainable, lease-aware operator workflows.
 
-v0.23.1 is the current release — a patch on the **Vault Intelligence** (v0.22.0) line that caps the MCP SDK below 2.0 so pip-based installs import cleanly. Hermes Vault keeps its credential health intelligence: 45 built-in verifiers, verification coverage metrics, A-F health scores, bulk import/export/filtering, and the setup wizard.
+v0.23.2 is the current release — a patch on the **Vault Intelligence** (v0.22.0) line that fixes an audit-integrity chain wedge (six CLI write paths now protect their audit rows) and makes `export --with-secrets` fail closed on a wrong passphrase. Hermes Vault keeps its credential health intelligence: 45 built-in verifiers, verification coverage metrics, A-F health scores, bulk import/export/filtering, and the setup wizard.
+
+## What's New in 0.23.2
+
+v0.23.2 is a patch release fixing an audit chain wedge and a fail-open export.
+
+- **Audit chain wedge (HIGH)**: `set-expiry`, `clear-expiry`, `backup-verify`, `restore --dry-run`, `rotate-master-key`, and `recovery drill` now pass the master key to their audit loggers, so every audit row stays protected and the chain never wedges (previously the next protected write crashed with `AuditIntegrityError`)
+- **Export fail-closed (MEDIUM)**: `export --with-secrets` with a wrong passphrase now fails with a clear error instead of exiting 0 with `"secret": null` for every credential
 
 ## What's New in 0.23.1
 
@@ -64,10 +71,10 @@ Hermes Vault runs natively on Windows -- no WSL required.
 
 ```powershell
 # Install with uv (recommended)
-uv tool install git+https://github.com/asimons81/hermes-vault.git@v0.23.1
+uv tool install git+https://github.com/asimons81/hermes-vault.git@v0.23.2
 
 # Or with pipx
-pipx install git+https://github.com/asimons81/hermes-vault.git@v0.23.1
+pipx install git+https://github.com/asimons81/hermes-vault.git@v0.23.2
 
 # Or with pip (editable dev install)
 python -m venv .venv
@@ -214,7 +221,7 @@ When `--redact-source` is used, only successfully imported env lines are comment
 
 ## Hermes Vault Console
 
-Hermes Vault Console, introduced in v0.8.0 and expanded through v0.23.1, is the local dashboard for the credential broker. It gives operators one browser view of vault health, credential metadata, policy drift, audit activity, MCP binding, agent context, access requests, recovery posture, and safe operations without turning the browser into a secret viewer.
+Hermes Vault Console, introduced in v0.8.0 and expanded through v0.23.2, is the local dashboard for the credential broker. It gives operators one browser view of vault health, credential metadata, policy drift, audit activity, MCP binding, agent context, access requests, recovery posture, and safe operations without turning the browser into a secret viewer.
 
 Launch it from the same machine that owns the vault:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-vault"
-version = "0.23.1"
+version = "0.23.2"
 description = "Hermes-native local-first credential broker, scanner, and encrypted vault."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/release-readiness/v0.23.2/readiness-report.md
+++ b/release-readiness/v0.23.2/readiness-report.md
@@ -1,0 +1,71 @@
+# Hermes Vault v0.23.2 — Release Readiness Report
+
+Date: 2026-08-01
+Prepared by: Hermes (kanban task t_e5992bea)
+Release: v0.23.2 "Patch: audit chain wedge + export fail-closed"
+Base: master @ 73e9ceb (v0.23.1 merge)
+
+## What ships
+
+- **HIGH fix — audit chain wedge.** Six CLI write paths (`set-expiry`, `clear-expiry`,
+  `backup-verify`, `restore --dry-run`, `rotate-master-key` pre-rotation logger,
+  `recovery drill`) constructed `AuditLogger(settings.db_path)` without
+  `master_key`, so their audit rows went in via the legacy unprotected INSERT
+  branch. The next integrity-protected append raised
+  `AuditIntegrityError: An audit row is not protected by an integrity record`,
+  wedging the whole chain (delete/add/lease/request all crash). All six sites
+  now pass `master_key=vault.key`, matching `build_services`.
+- **MEDIUM fix — export fail-closed.** `export --with-secrets` with a wrong
+  passphrase previously exited 0 and emitted `"secret": null` for every
+  credential (decrypt exceptions swallowed in import_export.py). It now fails
+  with a clear error, no output file content, and exit code 1.
+
+## Quality gates
+
+| Gate | Result |
+|---|---|
+| Full test suite | **905 passed in ~42s** (898 prior + 7 new regression tests) |
+| Plugin tests | 14 passed |
+| Ruff | All checks passed (src/ + tests/) |
+| Mypy | Success: no issues in 61 source files |
+| Build | `hermes_vault-0.23.2.tar.gz` + `hermes_vault-0.23.2-py3-none-any.whl` built clean |
+| Clean-venv wheel smoke | Installed wheel in fresh venv; full repro sequence passed (see below) |
+
+## Regression tests (tests/test_audit_chain_regression.py)
+
+Each of the six commands is exercised against the smoke-test sequence:
+seed the chain with a protected `hermes-vault add`, run the command, assert
+`audit-verify --format json` returns `status: healthy`, then assert a
+subsequent `delete --yes` mutation succeeds. Verified these tests FAIL on the
+pre-fix code (`missing_integrity_record`, exit 3) and PASS with the fix.
+Export test asserts wrong-passphrase `--with-secrets` raises ValueError for
+both json and env formats and that the correct passphrase still exports the
+real secret.
+
+## Clean-venv wheel smoke (installed 0.23.2 wheel)
+
+1. `add openai --secret sk-fake-0232` → chain init OK
+2. `set-expiry openai --days 30` → exit 0, row protected
+3. `audit-verify --format json` → **status: healthy**
+4. `clear-expiry openai`, `backup-verify --input backup.json`,
+   `restore --input backup.json --dry-run`, `recovery drill --backup backup.json`
+   → all exit 0
+5. `rotate-master-key` (old→new passphrase) → success, audit-verify healthy
+6. `delete openai --yes` → succeeds (mutation after all six, no wedge)
+7. `export --with-secrets` with wrong passphrase → exit 1,
+   `Failed to decrypt secret for github/default (InvalidTag). Export --with-secrets requires the correct vault passphrase; no secret was exported.`
+8. `export --with-secrets` with correct passphrase → real secret present
+
+## Version surfaces
+
+pyproject.toml 0.23.2, `__init__.py` 0.23.2, README header/What's New/install pins,
+site/index.html eyebrow/release card/install code, tests/test_release_regression.py
+assertions, CHANGELOG 0.23.2 section. No stray 0.23.1 refs outside historical
+CHANGELOG/README context.
+
+## Rollback
+
+Tag on feature-branch head per repo workflow; master advances by squash merge
+(PR). v0.23.1 tag and PyPI release remain untouched; 0.23.2 is a pure
+bug-fix patch with no schema/API changes, so downgrade is safe (no migration
+steps).

--- a/site/index.html
+++ b/site/index.html
@@ -42,7 +42,7 @@
     <!-- Hero Section -->
     <section class="hero section-pad reveal hero-reveal-1">
       <div class="hero-copy">
-        <p class="eyebrow">v0.23.1 &bull; Patch &bull; mcp SDK capped &lt;2.0 for clean pip installs</p>
+        <p class="eyebrow">v0.23.2 &bull; Patch &bull; audit chain integrity fixed</p>
         <h1>From <span>.env</span> to safe agent access.</h1>
         <p class="lede">
           Bootstrap a messy plaintext env file into an encrypted local vault, explain every access decision, route approvals through an audit trail, bind env handoffs to leases, and prove recovery before the incident. Less key sprawl, fewer auth lies, fewer agent mistakes.
@@ -63,8 +63,8 @@
         <div class="hero-metrics" aria-label="Release and platform notes">
           <div class="metric-card">
             <span>Current Release</span>
-            <strong>0.23.1</strong>
-            <small>Patch release capping the MCP SDK below 2.0 — mcp 2.0.0 removed <code>Server.list_tools</code>, which broke <code>import hermes_vault.mcp_server</code> on fresh pip installs of 0.23.0. <a href="https://github.com/asimons81/hermes-vault/releases/tag/v0.23.1" target="_blank" rel="noreferrer noopener">View release</a></small>
+            <strong>0.23.2</strong>
+            <small>Patch release fixing an audit chain wedge (six CLI write paths now protect their audit rows) and making <code>export --with-secrets</code> fail closed on a wrong passphrase. <a href="https://github.com/asimons81/hermes-vault/releases/tag/v0.23.2" target="_blank" rel="noreferrer noopener">View release</a></small>
           </div>
           <div class="metric-card">
             <span>Operator Loop</span>
@@ -376,7 +376,7 @@
                 <span>Production Install</span>
                 <button class="copy-button" type="button" data-copy-target="users-code">Copy</button>
               </div>
-              <pre><code id="users-code">uv tool install git+https://github.com/asimons81/hermes-vault.git@v0.23.1
+              <pre><code id="users-code">uv tool install git+https://github.com/asimons81/hermes-vault.git@v0.23.2
 hermes-vault bootstrap --from-env .env --agent hermes --dry-run
 hermes-vault audit-verify
 hermes-vault audit-checkpoint show

--- a/src/hermes_vault/__init__.py
+++ b/src/hermes_vault/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.23.1"
+__version__ = "0.23.2"

--- a/src/hermes_vault/cli.py
+++ b/src/hermes_vault/cli.py
@@ -1421,7 +1421,7 @@ def set_expiry(
 
     vault, policy, broker, mutations = build_services(prompt=True)
     settings = get_settings()
-    audit = AuditLogger(settings.db_path)
+    audit = AuditLogger(settings.db_path, master_key=vault.key)
 
     # Resolve target to get canonical service name
     try:
@@ -1477,7 +1477,7 @@ def clear_expiry(
 
     vault, policy, broker, mutations = build_services(prompt=True)
     settings = get_settings()
-    audit = AuditLogger(settings.db_path)
+    audit = AuditLogger(settings.db_path, master_key=vault.key)
 
     # Resolve target to get canonical service name
     try:
@@ -1662,7 +1662,11 @@ def export_cmd(
         records = [r for r in records if tag in r.tags]
     if unverified:
         records = [r for r in records if r.last_verified_at is None]
-    content = export_credentials(records, fmt=fmt, include_secrets=with_secrets, vault=vault)
+    try:
+        content = export_credentials(records, fmt=fmt, include_secrets=with_secrets, vault=vault)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
     if output:
         output.write_text(content, encoding="utf-8")
         output.chmod(0o600)
@@ -2644,7 +2648,7 @@ def rotate_master_key(
 
     settings = get_settings()
     vault, _, _, _ = build_services(prompt=True)
-    audit = AuditLogger(settings.db_path)
+    audit = AuditLogger(settings.db_path, master_key=vault.key)
 
     console.print("[bold]Master Key Rotation[/bold]")
     console.print(f"  Vault: {settings.db_path}")
@@ -2814,7 +2818,7 @@ def recovery_drill(
     from hermes_vault.recovery import run_recovery_drill
 
     report = run_recovery_drill(backup_path=backup, vault=vault, policy=policy)
-    audit = AuditLogger(get_settings().db_path)
+    audit = AuditLogger(get_settings().db_path, master_key=vault.key)
     audit.record(
         AccessLogRecord(
             agent_id=OPERATOR_AGENT_ID,
@@ -2904,7 +2908,7 @@ def restore_vault(
 
         report = restore_dry_run(input, vault)
         _print_backup_report(report, format=format)
-        audit = AuditLogger(get_settings().db_path)
+        audit = AuditLogger(get_settings().db_path, master_key=vault.key)
         audit.record(
             AccessLogRecord(
                 agent_id=OPERATOR_AGENT_ID,
@@ -2953,7 +2957,7 @@ def backup_verify(
 
     report = verify_backup_file(input, vault)
     _print_backup_report(report, format=format)
-    audit = AuditLogger(get_settings().db_path)
+    audit = AuditLogger(get_settings().db_path, master_key=vault.key)
     audit.record(
         AccessLogRecord(
             agent_id=OPERATOR_AGENT_ID,

--- a/src/hermes_vault/import_export.py
+++ b/src/hermes_vault/import_export.py
@@ -162,10 +162,13 @@ def export_credentials(
             if include_secrets and vault is not None:
                 try:
                     cs = vault.get_secret(r.id)
-                    if cs:
-                        entry["secret"] = cs.secret
-                except Exception:
-                    entry["secret"] = None
+                except Exception as exc:
+                    raise ValueError(
+                        f"Failed to decrypt secret for {r.service}/{r.alias or 'default'} "
+                        f"({type(exc).__name__}). Export --with-secrets requires the correct "
+                        "vault passphrase; no secret was exported."
+                    ) from exc
+                entry["secret"] = cs.secret if cs else None
             out.append(entry)
         return json.dumps(out, indent=2, sort_keys=True)
 
@@ -197,8 +200,12 @@ def export_credentials(
                 try:
                     cs = vault.get_secret(r.id)
                     secret = cs.secret if cs else ""
-                except Exception:
-                    secret = ""
+                except Exception as exc:
+                    raise ValueError(
+                        f"Failed to decrypt secret for {r.service}/{r.alias or 'default'} "
+                        f"({type(exc).__name__}). Export --with-secrets requires the correct "
+                        "vault passphrase; no secret was exported."
+                    ) from exc
             else:
                 secret = "REDACTED_USE_EXPORT_WITH_SECRETS"
             env_key = _service_to_env_var(r.service)

--- a/tests/test_audit_chain_regression.py
+++ b/tests/test_audit_chain_regression.py
@@ -1,0 +1,165 @@
+"""Regression tests for the 0.23.2 audit chain wedge fix.
+
+Six CLI write paths (set-expiry, clear-expiry, backup-verify,
+restore --dry-run, rotate-master-key pre-rotation, recovery drill) used to
+construct AuditLogger WITHOUT a master key. Their audit.record() calls took
+the legacy unprotected INSERT branch, and the next protected append raised
+AuditIntegrityError, wedging the whole chain (delete/add/lease/request all
+crashed). These tests reproduce the smoke-test repro sequence: initialize
+the chain with a protected row via `hermes-vault add`, run the vulnerable
+command, then assert audit-verify stays healthy and a subsequent mutation
+still succeeds.
+
+Also covers the export --with-secrets fail-closed fix: a wrong passphrase
+must raise instead of silently emitting "secret": null.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from hermes_vault.cli import _hermes_group
+from hermes_vault.vault import Vault
+
+
+PASSPHRASE = "test-passphrase"
+NEW_PASSPHRASE = "new-passphrase"
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _set_env(tmp_path: Path, passphrase: str = PASSPHRASE) -> None:
+    os.environ["HERMES_VAULT_PASSPHRASE"] = passphrase
+    os.environ["HERMES_VAULT_HOME"] = str(tmp_path)
+
+
+def _init_vault(tmp_path: Path, runner: CliRunner) -> Vault:
+    """Create a vault and seed the audit chain via the real `add` CLI path.
+
+    The `add` command writes a *protected* audit row through
+    build_services' AuditLogger (master_key present), which is what the
+    smoke-test repro uses to initialize the integrity chain.
+    """
+    _set_env(tmp_path)
+    result = runner.invoke(
+        _hermes_group, ["add", "openai", "--secret", "sk-test-123"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    return Vault(tmp_path / "vault.db", tmp_path / "master_key_salt.bin", PASSPHRASE)
+
+
+def _backup(tmp_path: Path, vault: Vault) -> Path:
+    backup_path = tmp_path / "backup.json"
+    backup_path.write_text(json.dumps(vault.export_backup(), indent=2, sort_keys=True), encoding="utf-8")
+    return backup_path
+
+
+def _assert_chain_healthy(runner: CliRunner) -> None:
+    result = runner.invoke(_hermes_group, ["audit-verify", "--format", "json"], catch_exceptions=False)
+    assert result.exit_code == 0, f"audit-verify failed:\n{result.output}"
+    payload = json.loads(result.output)
+    assert payload["status"] == "healthy", f"audit chain not healthy:\n{payload}"
+
+
+def _assert_mutation_succeeds(runner: CliRunner) -> None:
+    result = runner.invoke(_hermes_group, ["delete", "openai", "--yes"], catch_exceptions=False)
+    assert result.exit_code == 0, f"delete crashed after wedge:\n{result.output}"
+
+
+def test_set_expiry_keeps_chain_healthy(tmp_path: Path, runner: CliRunner) -> None:
+    _init_vault(tmp_path, runner)
+    result = runner.invoke(_hermes_group, ["set-expiry", "openai", "--days", "30"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    _assert_chain_healthy(runner)
+    _assert_mutation_succeeds(runner)
+
+
+def test_clear_expiry_keeps_chain_healthy(tmp_path: Path, runner: CliRunner) -> None:
+    vault = _init_vault(tmp_path, runner)
+    vault.set_expiry("openai", datetime.now(timezone.utc) + timedelta(days=30))
+    result = runner.invoke(_hermes_group, ["clear-expiry", "openai"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    _assert_chain_healthy(runner)
+    _assert_mutation_succeeds(runner)
+
+
+def test_backup_verify_keeps_chain_healthy(tmp_path: Path, runner: CliRunner) -> None:
+    vault = _init_vault(tmp_path, runner)
+    backup_path = _backup(tmp_path, vault)
+    result = runner.invoke(_hermes_group, ["backup-verify", "--input", str(backup_path)], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    _assert_chain_healthy(runner)
+    _assert_mutation_succeeds(runner)
+
+
+def test_restore_dry_run_keeps_chain_healthy(tmp_path: Path, runner: CliRunner) -> None:
+    vault = _init_vault(tmp_path, runner)
+    backup_path = _backup(tmp_path, vault)
+    result = runner.invoke(_hermes_group, ["restore", "--input", str(backup_path), "--dry-run"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    _assert_chain_healthy(runner)
+    _assert_mutation_succeeds(runner)
+
+
+def test_rotate_master_key_keeps_chain_healthy(tmp_path: Path, runner: CliRunner, monkeypatch) -> None:
+    _init_vault(tmp_path, runner)
+
+    answers = iter([PASSPHRASE, NEW_PASSPHRASE, NEW_PASSPHRASE])
+
+    def fake_getpass(prompt: str = "") -> str:
+        return next(answers)
+
+    monkeypatch.setattr("getpass.getpass", fake_getpass)
+    result = runner.invoke(_hermes_group, ["rotate-master-key"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    # Rotation re-derives the master key; subsequent commands need the new passphrase.
+    os.environ["HERMES_VAULT_PASSPHRASE"] = NEW_PASSPHRASE
+
+    _assert_chain_healthy(runner)
+    _assert_mutation_succeeds(runner)
+
+
+def test_recovery_drill_keeps_chain_healthy(tmp_path: Path, runner: CliRunner) -> None:
+    vault = _init_vault(tmp_path, runner)
+    backup_path = _backup(tmp_path, vault)
+    result = runner.invoke(_hermes_group, ["recovery", "drill", "--backup", str(backup_path)], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    _assert_chain_healthy(runner)
+    _assert_mutation_succeeds(runner)
+
+
+def test_export_with_secrets_wrong_passphrase_fails_closed(tmp_path: Path) -> None:
+    """Wrong passphrase must abort export instead of emitting secret:null."""
+    from hermes_vault.import_export import export_credentials
+
+    _set_env(tmp_path)
+    vault = Vault(tmp_path / "vault.db", tmp_path / "master_key_salt.bin", PASSPHRASE)
+    vault.add_credential("openai", "sk-test-123", "api_key")
+    rec = vault.list_credentials()[0]
+    wrong_vault = Vault(vault.db_path, vault.salt_path, "wrong-passphrase")
+
+    with pytest.raises(ValueError, match="Failed to decrypt"):
+        export_credentials([rec], fmt="json", include_secrets=True, vault=wrong_vault)
+
+    with pytest.raises(ValueError, match="Failed to decrypt"):
+        export_credentials([rec], fmt="env", include_secrets=True, vault=wrong_vault)
+
+    # Sanity: correct passphrase still exports the real secret.
+    out = export_credentials([rec], fmt="json", include_secrets=True, vault=vault)
+    parsed = json.loads(out)
+    assert parsed[0]["secret"] == "sk-test-123"

--- a/tests/test_release_regression.py
+++ b/tests/test_release_regression.py
@@ -25,8 +25,8 @@ def test_release_version_surfaces_align() -> None:
     from hermes_vault.mcp_server import list_resources, list_tools, server
     import asyncio
 
-    assert pyproject["project"]["version"] == "0.23.1"
-    assert hermes_vault.__version__ == "0.23.1"
+    assert pyproject["project"]["version"] == "0.23.2"
+    assert hermes_vault.__version__ == "0.23.2"
     assert server.version == hermes_vault.__version__
     tool_names = {tool.name for tool in asyncio.run(list_tools())}
     assert {
@@ -53,11 +53,11 @@ def test_release_story_mentions_agent_control_plane() -> None:
     dashboard_html = (repo_root / "src" / "hermes_vault" / "dashboard_static" / "index.html").read_text(encoding="utf-8")
 
     assert "Vault Intelligence" in changelog
-    assert "What's New in 0.23.1" in readme
+    assert "What's New in 0.23.2" in readme
     assert "secret-source fetch" in operator_guide
     assert "Vault Intelligence" in readme
-    assert "v0.23.1" in site
-    assert "git@v0.23.1" in site
+    assert "v0.23.2" in site
+    assert "git@v0.23.2" in site
     assert "Command Center" in dashboard_html
 
     assert "policy-explain" in dashboard_html

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "hermes-vault"
-version = "0.23.1"
+version = "0.23.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Patch release 0.23.2 fixing two bugs found in the post-release smoke test of 0.23.1 (kanban task t_7bd34049).

### HIGH — Audit chain wedge
Six CLI write paths (`set-expiry`, `clear-expiry`, `backup-verify`, `restore --dry-run`, `rotate-master-key` pre-rotation logger, `recovery drill`) constructed `AuditLogger` without a master key. Their `audit.record()` calls took the legacy unprotected INSERT branch, and the next integrity-protected append raised `AuditIntegrityError: An audit row is not protected by an integrity record` — wedging the chain so delete/add/lease/request all crashed.

**Fix:** pass `master_key=vault.key` at all six sites, matching `build_services`.

### MEDIUM — Export fail-open
`export --with-secrets` with a wrong passphrase exited 0 and wrote `"secret": null` for every credential because decrypt exceptions were swallowed. Now fails closed with a clear error and exit 1.

### Tests
- New `tests/test_audit_chain_regression.py`: for each of the six commands, seed the chain with a protected `add`, run the command, assert `audit-verify` stays healthy and a subsequent delete succeeds. Verified these fail on pre-fix code (`missing_integrity_record`) and pass with the fix.
- Export fail-closed coverage (json + env).
- Full suite: **905 passed**, ruff clean, mypy clean, wheel builds.
- Clean-venv wheel smoke passed end-to-end (all six commands + export).

Release readiness: `release-readiness/v0.23.2/readiness-report.md`