### PR TITLE
chore: ignore .env* in site/ (Vercel OIDC token protection)

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,1 +1,2 @@
 .vercel
+.env*


### PR DESCRIPTION
Prevents the Vercel CLI-generated `.env.local` (which contains a `VERCEL_OIDC_TOKEN`) from ever being committed. One-line gitignore change.