### PR TITLE
fix(mcp): redact secrets from lease checkout

### DIFF
--- a/src/hermes_vault/mcp_server.py
+++ b/src/hermes_vault/mcp_server.py
@@ -63,6 +63,22 @@ def _mask_secret_value(value: str, prefix_len: int = 5, suffix_len: int = 4) -> 
         return "***"
     return f"{value[:prefix_len]}...{value[-suffix_len:]}"
 
+
+def _redacted_env_payload(
+    env: dict[str, Any],
+    ttl_seconds: int | None,
+    expires_at: str | None,
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    """Serialize an ephemeral environment without exposing secret values."""
+    return {
+        "env": {key: _mask_secret_value(str(value)) for key, value in env.items()},
+        "ttl_seconds": ttl_seconds,
+        "expires_at": expires_at,
+        "metadata": metadata,
+        "_secret_lengths": {key: len(str(value)) for key, value in env.items()},
+    }
+
 # ── tool schemas ───────────────────────────────────────────────────────────────
 
 _TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
@@ -1185,14 +1201,12 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
             expires_at = None
             if env_result.ttl_seconds is not None:
                 expires_at = (datetime.now(timezone.utc) + timedelta(seconds=env_result.ttl_seconds)).isoformat()
-            masked_env = {k: _mask_secret_value(str(v)) for k, v in env_result.env.items()}
-            return [TextContent(type="text", text=_json_text({
-                "env": masked_env,
-                "ttl_seconds": env_result.ttl_seconds,
-                "expires_at": expires_at,
-                "metadata": env_result.metadata,
-                "_secret_lengths": {k: len(str(v)) for k, v in env_result.env.items()},
-            }))]
+            return [TextContent(type="text", text=_json_text(_redacted_env_payload(
+                env_result.env,
+                env_result.ttl_seconds,
+                expires_at,
+                env_result.metadata,
+            )))]
 
         if name == "lease_issue":
             agent_id = binding.effective_agent_id or ""
@@ -1323,12 +1337,12 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
             expires_at = None
             if checkout_result.ttl_seconds is not None:
                 expires_at = (datetime.now(timezone.utc) + timedelta(seconds=checkout_result.ttl_seconds)).isoformat()
-            return [TextContent(type="text", text=_json_text({
-                "env": checkout_result.env,
-                "ttl_seconds": checkout_result.ttl_seconds,
-                "expires_at": expires_at,
-                "metadata": checkout_result.metadata,
-            }))]
+            return [TextContent(type="text", text=_json_text(_redacted_env_payload(
+                checkout_result.env,
+                checkout_result.ttl_seconds,
+                expires_at,
+                checkout_result.metadata,
+            )))]
 
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1229,7 +1229,7 @@ def test_policy_explain_tool_returns_policy_explain(vault_with_policy, tmp_path)
     assert data["service"] == "openai"
 
 
-def test_lease_checkout_tool_returns_env_through_broker(vault_with_policy, tmp_path):
+def test_lease_checkout_tool_returns_redacted_env_through_broker(vault_with_policy, tmp_path):
     import hermes_vault.mcp_server as mcp_mod
 
     os.environ["HERMES_VAULT_HOME"] = str(tmp_path)
@@ -1242,9 +1242,13 @@ def test_lease_checkout_tool_returns_env_through_broker(vault_with_policy, tmp_p
         "purpose": "deploy",
         "ttl_seconds": 60,
     }))
-    data = _json(result)
+    serialized_output = _text(result)
+    data = json.loads(serialized_output)
 
-    assert data["env"]["OPENAI_API_KEY"] == "test-openai-key"
+    assert "OPENAI_API_KEY" in data["env"]
+    assert data["env"]["OPENAI_API_KEY"] == "test-...-key"
+    assert data["_secret_lengths"]["OPENAI_API_KEY"] == len("test-openai-key")
+    assert "test-openai-key" not in serialized_output
     assert data["metadata"]["lease_checkout"]["lease_issued"] is True
 
 


### PR DESCRIPTION
Fixes #57.

## Summary

MCP environment responses now share one redaction serializer. `lease_checkout` no longer returns raw credential values in model-visible tool output.

The response retains environment key names, masked values, TTL/expiry metadata, lease metadata, and `_secret_lengths`. Broker lease issuance and reuse are unchanged.

## Changed areas

- [ ] CLI
- [ ] Vault storage / crypto / backup
- [ ] Policy / broker / mutations
- [ ] Scanner / detectors
- [ ] Verifier
- [x] MCP server
- [ ] OAuth
- [ ] Dashboard
- [ ] Docs only
- [ ] Tests only
- [ ] Packaging / release workflow

## Tests run

```text
uv run python -m pytest tests plugins/hermes-vault-secret-source/tests -q --tb=short
919 passed in 76.50s

uv run ruff check . --output-format=concise
All checks passed!

uv run mypy src/hermes_vault
Success: no issues found in 61 source files
```

Focused regression probe:

```text
mcp_lease_checkout: raw_secret_returned=False
```

## Docs

- [ ] README/docs updated
- [ ] Changelog updated when user-facing behavior changed
- [x] Not needed, because: this brings `lease_checkout` into the existing documented MCP redaction boundary.

## Security and secret handling

- [x] No real tokens, passphrases, vault databases, provider responses, or unredacted `.env` contents are included
- [x] Audit output and logs do not include raw secrets
- [x] Browser/dashboard responses do not expose raw secrets, raw OAuth tokens, or encrypted payloads
- [x] Policy, broker, and mutation paths were not bypassed
- [x] Security-sensitive changes are called out below

Security notes: the regression test asserts the complete serialized MCP output does not contain the fake fixture secret.

## Compatibility

The `lease_checkout` MCP response now masks `env` values and adds `_secret_lengths`, matching `get_ephemeral_env`. Tool name and input schema are unchanged.

## Reviewer notes

Please review `_redacted_env_payload()` as the single transport-level redaction path for both MCP environment tools.
