### PR TITLE
fix(oauth): isolate callback state per login

### DIFF
--- a/src/hermes_vault/mcp_server.py
+++ b/src/hermes_vault/mcp_server.py
@@ -1435,9 +1435,7 @@ def _handle_oauth_login(arguments: dict[str, Any], broker: Broker, agent_id: str
         "profile_name": settings.profile_name,
     }
 
-    # Attach auto-exchange handler onto CallbackServer's result mechanism.
-    # Because CallbackServer uses class-level static state, we spin a
-    # background thread that waits for the callback, then completes the flow.
+    # Wait for the callback in a background thread, then complete the flow.
     def _wait_and_exchange() -> None:
         try:
             result = callback_server.wait()

--- a/src/hermes_vault/oauth/callback.py
+++ b/src/hermes_vault/oauth/callback.py
@@ -8,6 +8,7 @@ from http.server import BaseHTTPRequestHandler
 import socketserver
 import threading
 from dataclasses import dataclass
+from typing import cast
 from urllib.parse import parse_qs, urlparse
 
 
@@ -22,8 +23,6 @@ class CallbackResult:
 
 class CallbackHandler(BaseHTTPRequestHandler):
     """HTTP handler for the OAuth callback route."""
-    result: CallbackResult | None = None
-    event: threading.Event | None = None
 
     @staticmethod
     def _first(seq):
@@ -47,62 +46,82 @@ class CallbackHandler(BaseHTTPRequestHandler):
             return
 
         qs = parse_qs(parsed.query)
-        CallbackHandler.result = CallbackResult(
+        server = cast("CallbackHTTPServer", self.server)
+        server.result = CallbackResult(
             code=self._first(qs.get("code")),
             state=self._first(qs.get("state")),
             error=self._first(qs.get("error")),
             error_description=self._first(qs.get("error_description")),
         )
         self._send_html(200, "Authorization received. You may close this window.")
-        if CallbackHandler.event is not None:
-            CallbackHandler.event.set()
+        server.event.set()
 
     def log_message(self, format, *args):
         """Suppress default HTTP access logging to avoid leaking state/code."""
 
 
+class CallbackHTTPServer(socketserver.TCPServer):
+    """Loopback callback server with state isolated to this instance."""
+
+    def __init__(self, server_address: tuple[str, int], event: threading.Event):
+        self.event = event
+        self.result: CallbackResult | None = None
+        super().__init__(server_address, CallbackHandler)
+
+
 class CallbackServer:
     """Ephemeral TCPServer bound to 127.0.0.1, port 0 auto-assigned."""
-    result: CallbackResult | None = None
 
     def __init__(self, host: str = "127.0.0.1", port: int = 0, timeout: int = 120):
         self.host = host
         self.port = port
         self.timeout = timeout
-        self._server: socketserver.TCPServer | None = None
+        self._server: CallbackHTTPServer | None = None
         self._result: CallbackResult | None = None
-        self._event: threading.Event | None = None
+        self._thread: threading.Thread | None = None
+        self._shutdown_lock = threading.Lock()
 
     def start(self) -> int:
         """Start the server in a background thread. Returns the actual port."""
-        self._event = threading.Event()
-        self._result = CallbackResult()
-        CallbackHandler.event = self._event
-        CallbackHandler.result = None
-        self._server = socketserver.TCPServer((self.host, self.port), CallbackHandler)
-        actual_port = self._server.server_address[1]
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
-        self._thread.start()
+        with self._shutdown_lock:
+            self._result = CallbackResult()
+            server = CallbackHTTPServer((self.host, self.port), threading.Event())
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            self._server = server
+            self._thread = thread
+            actual_port = server.server_address[1]
+            thread.start()
         return actual_port
 
     def wait(self) -> CallbackResult:
         """Block until callback result or timeout."""
-        event = self._event
         result = self._result
-        if event is None or result is None:
+        server = self._server
+        if result is None or server is None:
             raise RuntimeError("Callback server must be started before wait().")
-        if not event.wait(timeout=self.timeout):
+        if not server.event.wait(timeout=self.timeout):
             result.error = "timeout"
             result.error_description = f"Timed out after {self.timeout}s. No callback received."
             self.shutdown()
             return result
         self.shutdown()
-        if CallbackHandler.result is not None:
-            return CallbackHandler.result
+        if server.result is not None:
+            return server.result
         return result
 
     def shutdown(self) -> None:
         """Signal the server to shut down and clean up resources."""
-        if self._server:
-            self._server.shutdown()
-            self._server.server_close()
+        with self._shutdown_lock:
+            server = self._server
+            thread = self._thread
+            if server is None and thread is None:
+                return
+
+            if server is not None:
+                server.shutdown()
+                server.server_close()
+            if thread is not None and thread is not threading.current_thread():
+                thread.join()
+
+            self._server = None
+            self._thread = None

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -142,6 +142,62 @@ class TestCallbackServer:
         assert "user denied" in result.error_description
         server.shutdown()
 
+    def test_concurrent_servers_receive_only_their_own_callback(self):
+        from urllib.request import urlopen
+
+        server_a = CallbackServer(timeout=5)
+        server_b = CallbackServer(timeout=5)
+        port_a = server_a.start()
+        port_b = server_b.start()
+        server_thread_a = server_a._thread
+        server_thread_b = server_b._thread
+        assert server_thread_a is not None
+        assert server_thread_b is not None
+        a_waiting = threading.Event()
+        b_waiting = threading.Event()
+        a_result = []
+        b_result = []
+
+        def wait_for_callback(server, waiting, results):
+            waiting.set()
+            results.append(server.wait())
+
+        a_thread = threading.Thread(target=wait_for_callback, args=(server_a, a_waiting, a_result))
+        b_thread = threading.Thread(target=wait_for_callback, args=(server_b, b_waiting, b_result))
+        a_thread.start()
+        b_thread.start()
+
+        try:
+            assert a_waiting.wait(timeout=1)
+            assert b_waiting.wait(timeout=1)
+            with urlopen(f"http://127.0.0.1:{port_a}/callback?code=code-a&state=state-a", timeout=1):
+                pass
+
+            a_thread.join(timeout=1)
+            assert not a_thread.is_alive()
+            assert not server_thread_a.is_alive()
+            assert b_thread.is_alive()
+            assert server_thread_b.is_alive()
+            assert a_result[0].code == "code-a"
+            assert a_result[0].state == "state-a"
+
+            with urlopen(f"http://127.0.0.1:{port_b}/callback?code=code-b&state=state-b", timeout=1):
+                pass
+            b_thread.join(timeout=1)
+            assert not b_thread.is_alive()
+            assert not server_thread_b.is_alive()
+            assert server_a._server is None
+            assert server_a._thread is None
+            assert server_b._server is None
+            assert server_b._thread is None
+            assert b_result[0].code == "code-b"
+            assert b_result[0].state == "state-b"
+        finally:
+            server_a.shutdown()
+            server_b.shutdown()
+            a_thread.join(timeout=6)
+            b_thread.join(timeout=6)
+
 
 # ── Provider registry ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #61.

## Summary

OAuth callback result and event state now live on each callback server instance instead of global `CallbackHandler` class attributes.

Two simultaneous browser login flows can receive callbacks independently without waking or consuming each other's code/state.

Shutdown now closes each HTTP server, joins its internal server thread, clears the instance state, and remains safe when called repeatedly.

## Changed areas

- [ ] CLI
- [ ] Vault storage / crypto / backup
- [ ] Policy / broker / mutations
- [ ] Scanner / detectors
- [ ] Verifier
- [ ] MCP server
- [x] OAuth
- [ ] Dashboard
- [ ] Docs only
- [ ] Tests only
- [ ] Packaging / release workflow

## Tests run

```text
uv run python -m pytest tests plugins/hermes-vault-secret-source/tests -q --tb=short
920 passed in 78.23s

uv run python -m pytest tests/test_oauth.py -q --tb=short
27 passed

uv run ruff check . --output-format=concise
All checks passed!

uv run mypy src/hermes_vault
Success: no issues found in 61 source files
```

The regression test starts two real loopback callback servers, delivers separate callbacks, proves each waiter receives only its own code/state, and verifies both internal server threads terminate.

## Docs

- [ ] README/docs updated
- [ ] Changelog updated when user-facing behavior changed
- [x] Not needed, because: the public callback API and documented login flow are unchanged.

## Security and secret handling

- [x] No real tokens, passphrases, vault databases, provider responses, or unredacted `.env` contents are included
- [x] Audit output and logs do not include raw secrets
- [x] Browser/dashboard responses do not expose raw secrets, raw OAuth tokens, or encrypted payloads
- [x] Policy, broker, and mutation paths were not bypassed
- [x] Security-sensitive changes are called out below

Security notes: loopback-only binding, OAuth state validation, suppressed access logging, and callback response content are unchanged.

## Compatibility

No CLI flags, provider configuration, OAuth state format, callback URL, or MCP schema changes.

## Reviewer notes

Please review the instance-owned `CallbackHTTPServer.event` and `.result` lifecycle, plus the concurrent two-port regression test cleanup.
