### PR TITLE
fix(mcp): redact lease secrets at the MCP boundary

### DIFF
--- a/src/hermes_vault/mcp_server.py
+++ b/src/hermes_vault/mcp_server.py
@@ -63,6 +63,27 @@ def _mask_secret_value(value: str, prefix_len: int = 5, suffix_len: int = 4) -> 
         return "***"
     return f"{value[:prefix_len]}...{value[-suffix_len:]}"
 
+
+def _redacted_env_payload(
+    env: dict[str, Any],
+    ttl_seconds: int | None,
+    expires_at: str | None,
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    """Serialize an ephemeral environment without exposing secret values.
+
+    Single transport-level redaction path shared by ``get_ephemeral_env`` and
+    ``lease_checkout``. Preserves key names, TTL/expiry, metadata, and secret
+    lengths so callers retain usable context without raw credential material.
+    """
+    return {
+        "env": {key: _mask_secret_value(str(value)) for key, value in env.items()},
+        "ttl_seconds": ttl_seconds,
+        "expires_at": expires_at,
+        "metadata": metadata,
+        "_secret_lengths": {key: len(str(value)) for key, value in env.items()},
+    }
+
 # ── tool schemas ───────────────────────────────────────────────────────────────
 
 _TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
@@ -1185,14 +1206,12 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
             expires_at = None
             if env_result.ttl_seconds is not None:
                 expires_at = (datetime.now(timezone.utc) + timedelta(seconds=env_result.ttl_seconds)).isoformat()
-            masked_env = {k: _mask_secret_value(str(v)) for k, v in env_result.env.items()}
-            return [TextContent(type="text", text=_json_text({
-                "env": masked_env,
-                "ttl_seconds": env_result.ttl_seconds,
-                "expires_at": expires_at,
-                "metadata": env_result.metadata,
-                "_secret_lengths": {k: len(str(v)) for k, v in env_result.env.items()},
-            }))]
+            return [TextContent(type="text", text=_json_text(_redacted_env_payload(
+                env_result.env,
+                env_result.ttl_seconds,
+                expires_at,
+                env_result.metadata,
+            )))]
 
         if name == "lease_issue":
             agent_id = binding.effective_agent_id or ""
@@ -1323,12 +1342,12 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
             expires_at = None
             if checkout_result.ttl_seconds is not None:
                 expires_at = (datetime.now(timezone.utc) + timedelta(seconds=checkout_result.ttl_seconds)).isoformat()
-            return [TextContent(type="text", text=_json_text({
-                "env": checkout_result.env,
-                "ttl_seconds": checkout_result.ttl_seconds,
-                "expires_at": expires_at,
-                "metadata": checkout_result.metadata,
-            }))]
+            return [TextContent(type="text", text=_json_text(_redacted_env_payload(
+                checkout_result.env,
+                checkout_result.ttl_seconds,
+                expires_at,
+                checkout_result.metadata,
+            )))]
 
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1229,7 +1229,7 @@ def test_policy_explain_tool_returns_policy_explain(vault_with_policy, tmp_path)
     assert data["service"] == "openai"
 
 
-def test_lease_checkout_tool_returns_env_through_broker(vault_with_policy, tmp_path):
+def test_lease_checkout_tool_returns_redacted_env_through_broker(vault_with_policy, tmp_path):
     import hermes_vault.mcp_server as mcp_mod
 
     os.environ["HERMES_VAULT_HOME"] = str(tmp_path)
@@ -1242,10 +1242,51 @@ def test_lease_checkout_tool_returns_env_through_broker(vault_with_policy, tmp_p
         "purpose": "deploy",
         "ttl_seconds": 60,
     }))
-    data = _json(result)
+    serialized_output = _text(result)
+    data = json.loads(serialized_output)
 
-    assert data["env"]["OPENAI_API_KEY"] == "test-openai-key"
+    # Tool results must never contain raw secret values — Issue #57.
+    assert "OPENAI_API_KEY" in data["env"]
+    assert data["env"]["OPENAI_API_KEY"] == "test-...-key"
+    assert data["_secret_lengths"]["OPENAI_API_KEY"] == len("test-openai-key")
+    assert "test-openai-key" not in serialized_output
     assert data["metadata"]["lease_checkout"]["lease_issued"] is True
+
+
+def test_lease_checkout_denied_does_not_leak_secret(vault_with_policy, tmp_path):
+    import hermes_vault.mcp_server as mcp_mod
+
+    os.environ["HERMES_VAULT_HOME"] = str(tmp_path)
+    mcp_mod._broker = vault_with_policy
+
+    result = _run_async(call_tool("lease_checkout", {
+        "agent_id": "restricted-agent",
+        "service": "github",
+        "alias": "primary",
+        "ttl_seconds": 60,
+    }))
+    text = _text(result)
+
+    assert "Denied:" in text
+    assert "gh-test-token" not in text
+
+
+def test_redacted_env_payload_masks_values_and_preserves_metadata():
+    from hermes_vault.mcp_server import _redacted_env_payload
+
+    payload = _redacted_env_payload(
+        env={"OPENAI_API_KEY": "test-openai-key", "EMPTY": ""},
+        ttl_seconds=60,
+        expires_at="2026-01-01T00:00:00+00:00",
+        metadata={"lease_checkout": {"lease_id": "lease-1", "lease_issued": True}},
+    )
+
+    assert payload["env"]["OPENAI_API_KEY"] == "test-...-key"
+    assert payload["env"]["EMPTY"] == "***"
+    assert payload["_secret_lengths"] == {"OPENAI_API_KEY": 15, "EMPTY": 0}
+    assert payload["ttl_seconds"] == 60
+    assert payload["expires_at"] == "2026-01-01T00:00:00+00:00"
+    assert payload["metadata"]["lease_checkout"]["lease_id"] == "lease-1"
 
 
 def test_lease_issue_denied_returns_decision_shape(vault_with_policy, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #57

Supersedes the unreviewed fork PR #63 with a focused branch owned by `asimons81`.

`lease_checkout` must never return raw environment secrets to an MCP caller. This patch keeps the broker handoff intact and redacts only at the agent-visible response boundary.

## Root cause

The MCP lease checkout response serialized the ephemeral environment mapping directly, allowing secret values to cross into the model-visible tool result.

## Fix

- Route lease checkout environment values through the existing redaction serializer.
- Preserve environment keys, metadata, expiry/TTL information, and secret lengths needed by callers.
- Keep the broker issuance and internal environment materialization paths unchanged.
- Add regression coverage proving the raw secret does not appear in the MCP response.

## Validation

Local validation on `fix/mcp-lease-redaction` against `master` `e589fc9`:

- Full core + secret-source plugin suite: **921 passed**
- Ruff: passed
- Mypy: passed across 61 source files
- Package build: passed (sdist + wheel)
- `git diff --check`: passed

Remote CI has not been claimed as green; it is the next gate after this PR is opened.

## Risk and rollback

Low implementation surface. The rollback is deleting this branch/PR or reverting the single commit; no credential data or policy files are changed.

## Test plan

- [x] Added/updated regression tests
- [x] Existing tests pass locally
- [x] Ruff and mypy pass locally
- [x] Package build passes locally
- [ ] Remote CI
- [ ] Independent maintainer review
