### PR TITLE
fix(oauth): enforce isolated first-callback-wins handling

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -181,7 +181,7 @@ class StateManager:
 
 ### 4.3 `callback.py` -- CallbackServer
 
-An ephemeral `HTTPServer` bound to `127.0.0.1` only. Handles exactly one GET request on `/callback`, extracts query parameters, then signals the main thread and shuts down.
+An ephemeral `HTTPServer` bound to `127.0.0.1` only. Handles exactly one GET request on `/callback`, extracts query parameters, then signals the main thread and shuts down. Each `CallbackServer` instance owns its result and event state, so concurrent login flows are isolated, and the first accepted callback is immutable — later callbacks get a non-success response and cannot overwrite it.
 
 #### Port selection strategy
 
@@ -205,16 +205,20 @@ class CallbackResult:
     error: str | None = None
     error_description: str | None = None
 
-class CallbackHandler(http.server.BaseHTTPRequestHandler):
-    # Shared mutable state -- set by the server factory before each run
-    result: CallbackResult | None = None
-    event: threading.Event | None = None
+class CallbackHTTPServer(socketserver.TCPServer):
+    # Per-instance state: result and event live on the server, not the handler
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.result: CallbackResult | None = None
+        self.event: threading.Event | None = None
+        self._accept_lock = threading.Lock()
 
+class CallbackHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         # Parse query string
-        # Populate CallbackHandler.result
-        # Send 200 OK with a simple HTML success / failure page
-        # Set CallbackHandler.event to unblock the main thread
+        # With the server instance lock: if result already accepted,
+        # reply 409 and return (first callback wins).
+        # Otherwise populate server.result and set server.event.
         pass
 
     def log_message(self, format, *args):
@@ -226,33 +230,37 @@ class CallbackServer:
         self.host = host
         self.port = port
         self.timeout = timeout
-        self.result: CallbackResult = CallbackResult()
-        self._event = threading.Event()
-        self._server: socketserver.TCPServer | None = None
+        self._server: CallbackHTTPServer | None = None
         self._thread: threading.Thread | None = None
 
     def start(self) -> int:
-        """Start the server in a background thread. Returns the actual port."""
-        CallbackHandler.result = self.result
-        CallbackHandler.event = self._event
-        self._server = socketserver.TCPServer((self.host, self.port), CallbackHandler)
-        actual_port = self._server.server_address[1]
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        server = CallbackHTTPServer((self.host, self.port), CallbackHandler)
+        server.event = threading.Event()
+        server.result = None
+        self._server = server
+        actual_port = server.server_address[1]
+        self._thread = threading.Thread(target=server.serve_forever, daemon=True)
         self._thread.start()
         return actual_port
 
     def wait(self) -> CallbackResult:
-        """Block until callback or timeout. Returns the result."""
-        if not self._event.wait(timeout=self.timeout):
-            self.result.error = "timeout"
-            self.result.error_description = f"No callback received within {self.timeout}s"
+        if not self._server.event.wait(timeout=self.timeout):
+            return CallbackResult(error="timeout", error_description="No callback received.")
+        accepted = self._server.result
         self.shutdown()
-        return self.result
+        return accepted or CallbackResult(error="timeout", error_description="No callback received.")
 
     def shutdown(self) -> None:
-        if self._server:
-            self._server.shutdown()
-            self._server.server_close()
+        server = self._server
+        if server is not None:
+            server.shutdown()
+            server.server_close()
+            server.result = None
+            server.event = None
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
 ```
 
 #### HTML response pages

--- a/src/hermes_vault/oauth/callback.py
+++ b/src/hermes_vault/oauth/callback.py
@@ -1,13 +1,17 @@
 """Ephemeral OAuth callback server.
 
 Handles exactly one GET request on /callback, extracts query parameters, then
-signals the main thread and shuts down.
+signals the main thread and shuts down. Each callback server instance owns its
+result and event state, so concurrent login flows stay isolated. The first
+accepted callback is immutable: later callbacks cannot overwrite it and receive
+a non-success response.
 
 """
 from http.server import BaseHTTPRequestHandler
 import socketserver
 import threading
 from dataclasses import dataclass
+from typing import cast
 from urllib.parse import parse_qs, urlparse
 
 
@@ -20,10 +24,23 @@ class CallbackResult:
     error_description: str | None = None
 
 
+class CallbackHTTPServer(socketserver.TCPServer):
+    """TCPServer carrying per-login callback result and event state.
+
+    ``result`` and ``event`` live on the server instance (not on the handler
+    class) so two simultaneous login flows cannot observe or consume each
+    other's callback state.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.result: CallbackResult | None = None
+        self.event: threading.Event | None = None
+        self._accept_lock = threading.Lock()
+
+
 class CallbackHandler(BaseHTTPRequestHandler):
     """HTTP handler for the OAuth callback route."""
-    result: CallbackResult | None = None
-    event: threading.Event | None = None
 
     @staticmethod
     def _first(seq):
@@ -39,23 +56,43 @@ class CallbackHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(f"<html><body><h1>{status_code}</h1><p>{message}</p></body></html>".encode("utf-8"))
 
+    @property
+    def callback_server(self) -> CallbackHTTPServer:
+        """The CallbackHTTPServer instance that spawned this handler."""
+        return cast(CallbackHTTPServer, self.server)
+
     def do_GET(self):
-        """Handle GET requests."""
+        """Handle GET requests.
+
+        Only the first accepted /callback request may populate the result.
+        Later callbacks to the same server receive a non-success response and
+        cannot overwrite the accepted code, state, or error.
+        """
         parsed = urlparse(self.path)
         if parsed.path != "/callback":
             self._send_html(404, "Not found")
             return
 
+        server = self.callback_server
         qs = parse_qs(parsed.query)
-        CallbackHandler.result = CallbackResult(
-            code=self._first(qs.get("code")),
-            state=self._first(qs.get("state")),
-            error=self._first(qs.get("error")),
-            error_description=self._first(qs.get("error_description")),
-        )
+
+        # Serialize acceptance; the first callback wins atomically.
+        with server._accept_lock:
+            if server.result is not None:
+                # A result is already accepted — never replace it.
+                self._send_html(409, "Callback already received. Close this window.")
+                return
+            server.result = CallbackResult(
+                code=self._first(qs.get("code")),
+                state=self._first(qs.get("state")),
+                error=self._first(qs.get("error")),
+                error_description=self._first(qs.get("error_description")),
+            )
+            event = server.event
+
         self._send_html(200, "Authorization received. You may close this window.")
-        if CallbackHandler.event is not None:
-            CallbackHandler.event.set()
+        if event is not None:
+            event.set()
 
     def log_message(self, format, *args):
         """Suppress default HTTP access logging to avoid leaking state/code."""
@@ -63,46 +100,56 @@ class CallbackHandler(BaseHTTPRequestHandler):
 
 class CallbackServer:
     """Ephemeral TCPServer bound to 127.0.0.1, port 0 auto-assigned."""
-    result: CallbackResult | None = None
 
     def __init__(self, host: str = "127.0.0.1", port: int = 0, timeout: int = 120):
         self.host = host
         self.port = port
         self.timeout = timeout
-        self._server: socketserver.TCPServer | None = None
-        self._result: CallbackResult | None = None
-        self._event: threading.Event | None = None
+        self._server: CallbackHTTPServer | None = None
+        self._thread: threading.Thread | None = None
 
     def start(self) -> int:
         """Start the server in a background thread. Returns the actual port."""
-        self._event = threading.Event()
-        self._result = CallbackResult()
-        CallbackHandler.event = self._event
-        CallbackHandler.result = None
-        self._server = socketserver.TCPServer((self.host, self.port), CallbackHandler)
-        actual_port = self._server.server_address[1]
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        server = CallbackHTTPServer((self.host, self.port), CallbackHandler)
+        server.event = threading.Event()
+        server.result = None
+        self._server = server
+        actual_port = server.server_address[1]
+        self._thread = threading.Thread(target=server.serve_forever, daemon=True)
         self._thread.start()
         return actual_port
 
     def wait(self) -> CallbackResult:
         """Block until callback result or timeout."""
-        event = self._event
-        result = self._result
-        if event is None or result is None:
+        server = self._server
+        if server is None or server.event is None:
             raise RuntimeError("Callback server must be started before wait().")
-        if not event.wait(timeout=self.timeout):
-            result.error = "timeout"
-            result.error_description = f"Timed out after {self.timeout}s. No callback received."
+        if not server.event.wait(timeout=self.timeout):
+            result = CallbackResult(
+                error="timeout",
+                error_description=f"Timed out after {self.timeout}s. No callback received.",
+            )
             self.shutdown()
             return result
+        accepted = server.result
         self.shutdown()
-        if CallbackHandler.result is not None:
-            return CallbackHandler.result
-        return result
+        if accepted is not None:
+            return accepted
+        return CallbackResult(error="timeout", error_description="No callback received.")
 
     def shutdown(self) -> None:
-        """Signal the server to shut down and clean up resources."""
-        if self._server:
-            self._server.shutdown()
-            self._server.server_close()
+        """Signal the server to shut down, join its thread, and clear state.
+
+        Safe to call repeatedly.
+        """
+        server = self._server
+        if server is not None:
+            server.shutdown()
+            server.server_close()
+            server.result = None
+            server.event = None
+            self._server = None
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=5)
+            self._thread = None

--- a/src/hermes_vault/oauth/callback.py
+++ b/src/hermes_vault/oauth/callback.py
@@ -29,8 +29,11 @@ class CallbackHTTPServer(socketserver.TCPServer):
 
     ``result`` and ``event`` live on the server instance (not on the handler
     class) so two simultaneous login flows cannot observe or consume each
-    other's callback state.
+    other's callback state. Reusing an explicitly configured loopback port after
+    shutdown is safe because the server opts into ``SO_REUSEADDR``.
     """
+
+    allow_reuse_address = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import socket
 import threading
 from pathlib import Path
 
@@ -172,6 +173,24 @@ class TestCallbackServer:
         assert status_later >= 400, "later callback must receive a non-success response"
         assert result.code == "first"
         assert result.state == "expected"
+
+    def test_explicit_port_can_be_reused_after_shutdown(self):
+        """An explicit loopback port can be rebound after a completed callback."""
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
+
+        first = CallbackServer(port=port, timeout=5)
+        assert first.start() == port
+        self._fetch_status(f"http://127.0.0.1:{port}/callback?code=first")
+        assert first.wait().code == "first"
+        first.shutdown()
+
+        second = CallbackServer(port=port, timeout=5)
+        assert second.start() == port
+        self._fetch_status(f"http://127.0.0.1:{port}/callback?code=second")
+        assert second.wait().code == "second"
+        second.shutdown()
 
     def test_concurrent_servers_are_isolated(self):
         """Issue #61/#64: two simultaneous logins must not share callback state.

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -142,6 +142,74 @@ class TestCallbackServer:
         assert "user denied" in result.error_description
         server.shutdown()
 
+    @staticmethod
+    def _fetch_status(url: str) -> int:
+        """Fetch a callback URL and return the HTTP status (non-2xx included)."""
+        from urllib.error import HTTPError
+        from urllib.request import urlopen
+        try:
+            with urlopen(url, timeout=5) as resp:
+                resp.read()
+                return resp.status
+        except HTTPError as e:
+            return e.code
+
+    def test_first_callback_wins(self):
+        """Issue #65: a later callback to the same server must not overwrite the first.
+
+        The second request arrives before the waiter shuts the listener down, so the
+        narrow window described in the issue is exercised deterministically.
+        """
+        server = CallbackServer(timeout=5)
+        server.start()
+        port = server._server.server_address[1]
+        base = f"http://127.0.0.1:{port}/callback"
+        status_first = self._fetch_status(f"{base}?code=first&state=expected")
+        status_later = self._fetch_status(f"{base}?code=second&state=other")
+        result = server.wait()
+        server.shutdown()
+        assert status_first == 200
+        assert status_later >= 400, "later callback must receive a non-success response"
+        assert result.code == "first"
+        assert result.state == "expected"
+
+    def test_concurrent_servers_are_isolated(self):
+        """Issue #61/#64: two simultaneous logins must not share callback state.
+
+        Each waiter must receive only its own code/state even though both servers
+        are accepting callbacks at the same time.
+        """
+        server_a = CallbackServer(timeout=2)
+        server_b = CallbackServer(timeout=2)
+        port_a = server_a.start()
+        port_b = server_b.start()
+        assert port_a != port_b
+        status_a = self._fetch_status(f"http://127.0.0.1:{port_a}/callback?code=aaa&state=stateA")
+        status_b = self._fetch_status(f"http://127.0.0.1:{port_b}/callback?code=bbb&state=stateB")
+        result_a = server_a.wait()
+        result_b = server_b.wait()
+        server_a.shutdown()
+        server_b.shutdown()
+        assert status_a == 200
+        assert status_b == 200
+        assert result_a.code == "aaa"
+        assert result_a.state == "stateA"
+        assert result_b.code == "bbb"
+        assert result_b.state == "stateB"
+
+    def test_server_terminates_internal_thread_after_wait(self):
+        """The serving thread must exit after wait()/shutdown cleanup."""
+        server = CallbackServer(timeout=5)
+        server.start()
+        thread = server._thread
+        port = server._server.server_address[1]
+        self._fetch_status(f"http://127.0.0.1:{port}/callback?code=one")
+        server.wait()
+        server.shutdown()
+        assert thread is not None
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
 
 # ── Provider registry ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes #61
Fixes #65

Supersedes the unreviewed fork PR #64 with a focused branch owned by `asimons81`.

This patch makes OAuth callback state instance-owned, enforces first-callback-wins semantics, and allows explicit loopback callback ports to be reused after shutdown.

## Root cause

Callback result/event state was too broadly shared, and a single callback server accepted multiple successful callbacks. A later callback could overwrite the first result. Explicit port reuse could also fail after a server shutdown.

## Fix

- Own callback result, completion event, and acceptance lock per callback-server instance.
- Atomically claim the first valid callback.
- Return HTTP 409 for later callbacks without overwriting the first result.
- Preserve the existing state/CSRF validation path.
- Make shutdown idempotent and join the serving thread.
- Allow explicit loopback ports to be rebound after shutdown.
- Update the narrow architecture note to describe instance-owned state and first-callback-wins behavior.

## Validation

Local validation on `fix/oauth-callback-safety` against `master` `e589fc9`:

- Full core + secret-source plugin suite: **923 passed**
- Ruff: passed
- Mypy: passed across 61 source files
- Package build: passed (sdist + wheel)
- `git diff --check`: passed

Remote CI has not been claimed as green; it is the next gate after this PR is opened.

## Risk and rollback

Low-to-medium auth-correctness change, isolated to the callback server and its tests. Reverting the two commits restores the prior implementation; no credentials or provider configuration are changed.

## Test plan

- [x] Added duplicate-callback first-wins regression
- [x] Added explicit-port reuse regression
- [x] Existing OAuth and plugin tests pass locally
- [x] Ruff and mypy pass locally
- [x] Package build passes locally
- [ ] Remote CI
- [ ] Independent maintainer review
