### PR TITLE
fix(mutations): preserve credentials when audit sealing fails

### DIFF
--- a/src/hermes_vault/mutations.py
+++ b/src/hermes_vault/mutations.py
@@ -36,6 +36,10 @@ from hermes_vault.vault import Vault
 OPERATOR_AGENT_ID = "operator"
 
 
+class AuditRollbackError(AuditIntegrityError):
+    """The protected audit append failed and its compensating write also failed."""
+
+
 class VaultMutations:
     """Policy-checked, audit-backed mutation service for vault credentials.
 
@@ -128,12 +132,20 @@ class VaultMutations:
                 record=record,
                 before_image=before_image,
             )
+        except AuditRollbackError as exc:
+            return MutationResult(
+                allowed=False,
+                service=service,
+                agent_id=agent_id,
+                action="add_credential",
+                reason=f"audit integrity: {exc}. ROLLBACK FAILED; the prior credential may be lost. Restore from a trusted backup.",
+                record=None,
+                metadata={},
+            )
         except AuditIntegrityError as exc:
             # The credential was committed but the integrity chain refused to seal
-            # the audit row. `_record_mutation` has already rolled back the write:
-            # a genuine new add is deleted, a replace is restored to its
-            # before-image. Surface a clean denial result so the caller gets the
-            # same shape as every other rejection path.
+            # the audit row. `_record_mutation` has already completed the
+            # compensating write. Surface a clean denial result.
             return MutationResult(
                 allowed=False,
                 service=service,
@@ -190,6 +202,16 @@ class VaultMutations:
                 f"rotated credential for service '{service}' alias '{updated.alias}'",
                 record=updated,
                 before_image=current,
+            )
+        except AuditRollbackError as exc:
+            return MutationResult(
+                allowed=False,
+                service=service,
+                agent_id=agent_id,
+                action="rotate_credential",
+                reason=f"audit integrity: {exc}. ROLLBACK FAILED; the prior credential may be lost. Restore from a trusted backup.",
+                record=None,
+                metadata={},
             )
         except AuditIntegrityError as exc:
             return MutationResult(
@@ -258,11 +280,20 @@ class VaultMutations:
                 metadata={"credential_id": record_id},
                 before_image=current,
             )
+        except AuditRollbackError as exc:
+            return MutationResult(
+                allowed=False,
+                service=service,
+                agent_id=agent_id,
+                action="delete_credential",
+                reason=f"audit integrity: {exc}. ROLLBACK FAILED; the prior credential may be lost. Restore from a trusted backup.",
+                record=None,
+                metadata={},
+            )
         except AuditIntegrityError as exc:
             # The delete committed but the integrity chain refused to seal
-            # the audit row. `_record_mutation` restored the deleted
-            # credential from its before-image so the vault does not end up
-            # in a desynced state. Surface a clean denial result.
+            # the audit row. `_record_mutation` completed the compensating
+            # write from its before-image. Surface a clean denial result.
             return MutationResult(
                 allowed=False,
                 service=service,
@@ -372,7 +403,7 @@ class VaultMutations:
                     self.vault.restore_credential(before_image)
                 except Exception as rollback_exc:
                     # Surface both errors so the operator knows the rollback failed
-                    raise AuditIntegrityError(
+                    raise AuditRollbackError(
                         f"{exc}. Rollback of credential '{before_image.id}' also failed: {rollback_exc}"
                     ) from exc
             elif record is not None and action == "add_credential":
@@ -382,7 +413,7 @@ class VaultMutations:
                     self.vault.delete(record.id)
                 except Exception as rollback_exc:
                     # Surface both errors so the operator knows the rollback failed
-                    raise AuditIntegrityError(
+                    raise AuditRollbackError(
                         f"{exc}. Rollback of credential '{record.id}' also failed: {rollback_exc}"
                     ) from exc
             raise

--- a/src/hermes_vault/mutations.py
+++ b/src/hermes_vault/mutations.py
@@ -89,6 +89,17 @@ class VaultMutations:
                     agent_id, service, "add_credential", False, svc_reason
                 )
 
+        # Capture the before-image of an existing row so an audit-failure
+        # rollback can restore the original ciphertext instead of deleting
+        # the only copy (issue #56). Mirrors the lookup inside
+        # ``vault.add_credential`` (vault.py) for replace_existing=True.
+        before_image: CredentialRecord | None = None
+        if replace_existing:
+            try:
+                before_image = self.vault.resolve_credential(service, alias=alias)
+            except KeyError:
+                before_image = None
+
         try:
             record = self.vault.add_credential(
                 service=service,
@@ -115,18 +126,20 @@ class VaultMutations:
                 True,
                 f"credential {record.id} added for service '{service}' alias '{alias}'",
                 record=record,
+                before_image=before_image,
             )
         except AuditIntegrityError as exc:
             # The credential was committed but the integrity chain refused to seal
-            # the audit row. `_record_mutation` has already rolled back the
-            # credential via `vault.delete()`. Surface a clean denial result
-            # so the caller gets the same shape as every other rejection path.
+            # the audit row. `_record_mutation` has already rolled back the write:
+            # a genuine new add is deleted, a replace is restored to its
+            # before-image. Surface a clean denial result so the caller gets the
+            # same shape as every other rejection path.
             return MutationResult(
                 allowed=False,
                 service=service,
                 agent_id=agent_id,
                 action="add_credential",
-                reason=f"audit integrity: {exc}. Run `hermes-vault audit-verify` to inspect the chain; the credential was not persisted.",
+                reason=f"audit integrity: {exc}. Run `hermes-vault audit-verify` to inspect the chain; the write was rolled back and any prior credential preserved.",
                 record=None,
                 metadata={},
             )
@@ -176,6 +189,7 @@ class VaultMutations:
                 True,
                 f"rotated credential for service '{service}' alias '{updated.alias}'",
                 record=updated,
+                before_image=current,
             )
         except AuditIntegrityError as exc:
             return MutationResult(
@@ -234,14 +248,30 @@ class VaultMutations:
                 "delete returned False (credential may not exist)",
             )
 
-        return self._record_mutation(
-            agent_id,
-            service,
-            "delete_credential",
-            True,
-            f"deleted credential '{record_id}' for service '{service}'",
-            metadata={"credential_id": record_id},
-        )
+        try:
+            return self._record_mutation(
+                agent_id,
+                service,
+                "delete_credential",
+                True,
+                f"deleted credential '{record_id}' for service '{service}'",
+                metadata={"credential_id": record_id},
+                before_image=current,
+            )
+        except AuditIntegrityError as exc:
+            # The delete committed but the integrity chain refused to seal
+            # the audit row. `_record_mutation` restored the deleted
+            # credential from its before-image so the vault does not end up
+            # in a desynced state. Surface a clean denial result.
+            return MutationResult(
+                allowed=False,
+                service=service,
+                agent_id=agent_id,
+                action="delete_credential",
+                reason=f"audit integrity: {exc}. Run `hermes-vault audit-verify` to inspect the chain; the credential was restored.",
+                record=None,
+                metadata={},
+            )
 
     def get_metadata(
         self,
@@ -302,6 +332,7 @@ class VaultMutations:
         reason: str,
         record: CredentialRecord | None = None,
         metadata: dict | None = None,
+        before_image: CredentialRecord | None = None,
     ) -> MutationResult:
         """Write the audit entry and build the result.
 
@@ -310,8 +341,15 @@ class VaultMutations:
         of the same logical operation. If the integrity chain refuses to
         seal the audit row, the credential write is rolled back so the
         vault never ends up in a desynced state (credential exists, audit
-        row missing). The integrity exception is re-raised as an
-        :class:`AuditIntegrityError` with an operator-actionable message.
+        row missing).
+
+        The rollback restores ``before_image`` (the pre-mutation row,
+        captured by the caller) whenever one exists — rotate, replace, and
+        delete must preserve the prior ciphertext (issue #56). ``delete``
+        is only used for a genuine new-record add, where the row did not
+        exist before this mutation. The integrity exception is re-raised
+        as an :class:`AuditIntegrityError` with an operator-actionable
+        message.
         """
         try:
             self.audit.record(
@@ -326,8 +364,20 @@ class VaultMutations:
         except AuditIntegrityError as exc:
             # If a credential was just written, roll it back so the vault
             # doesn't desync from its audit chain. This is best-effort: the
-            # vault connection has already committed, so we issue a delete.
-            if record is not None and action in ("add_credential", "rotate_credential"):
+            # vault connection has already committed, so we issue a
+            # compensating write — restore the before-image (rotate, replace,
+            # delete) or delete a brand-new row (genuine add).
+            if before_image is not None:
+                try:
+                    self.vault.restore_credential(before_image)
+                except Exception as rollback_exc:
+                    # Surface both errors so the operator knows the rollback failed
+                    raise AuditIntegrityError(
+                        f"{exc}. Rollback of credential '{before_image.id}' also failed: {rollback_exc}"
+                    ) from exc
+            elif record is not None and action == "add_credential":
+                # Genuine new-record add: the row is new; deleting it undoes
+                # the write.
                 try:
                     self.vault.delete(record.id)
                 except Exception as rollback_exc:

--- a/src/hermes_vault/vault.py
+++ b/src/hermes_vault/vault.py
@@ -664,6 +664,62 @@ class Vault:
             conn.commit()
         return cursor.rowcount > 0
 
+    def restore_credential(self, record: CredentialRecord) -> None:
+        """Idempotently restore a complete credential row by id (upsert).
+
+        Used to roll back a state-changing mutation when the audit chain
+        refuses to seal the audit append. Because ``(service, alias)`` has
+        no unique constraint, restoring by ``id`` is unambiguous. Safe to
+        call repeatedly: a second application is a no-op write of the same
+        row.
+
+        The row is written verbatim from ``record`` using the same column
+        set as ``add_credential``'s INSERT/UPDATE, so the original
+        ciphertext and metadata are preserved exactly.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO credentials (
+                    id, service, alias, credential_type, encrypted_payload, status, scopes,
+                    tags, notes, created_at, updated_at, last_verified_at, imported_from, expiry, crypto_version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    service = excluded.service,
+                    alias = excluded.alias,
+                    credential_type = excluded.credential_type,
+                    encrypted_payload = excluded.encrypted_payload,
+                    status = excluded.status,
+                    scopes = excluded.scopes,
+                    tags = excluded.tags,
+                    notes = excluded.notes,
+                    created_at = excluded.created_at,
+                    updated_at = excluded.updated_at,
+                    last_verified_at = excluded.last_verified_at,
+                    imported_from = excluded.imported_from,
+                    expiry = excluded.expiry,
+                    crypto_version = excluded.crypto_version
+                """,
+                (
+                    record.id,
+                    record.service,
+                    record.alias,
+                    record.credential_type,
+                    record.encrypted_payload,
+                    record.status.value,
+                    json.dumps(record.scopes),
+                    json.dumps(record.tags),
+                    record.notes,
+                    record.created_at.isoformat(),
+                    record.updated_at.isoformat(),
+                    record.last_verified_at.isoformat() if record.last_verified_at else None,
+                    record.imported_from,
+                    record.expiry.isoformat() if record.expiry else None,
+                    record.crypto_version,
+                ),
+            )
+            conn.commit()
+
     def _row_to_record(self, row: sqlite3.Row) -> CredentialRecord:
         payload = dict(row)
         payload["scopes"] = json.loads(payload["scopes"])

--- a/tests/test_audit_failure_rollback.py
+++ b/tests/test_audit_failure_rollback.py
@@ -180,6 +180,35 @@ def test_rotate_audit_failure_deterministic_append_error(tmp_path: Path, monkeyp
     )
 
 
+def test_rollback_failure_is_reported_without_false_reassurance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed compensating write must not claim the prior row survived."""
+    vault, logger, mutations = make_mutations(tmp_path)
+    _add_original(vault, logger, mutations)
+
+    def _audit_boom(record: object) -> None:
+        raise AuditIntegrityError("deterministic append failure")
+
+    def _restore_boom(record: object) -> None:
+        raise RuntimeError("restore unavailable")
+
+    assert logger.integrity is not None
+    monkeypatch.setattr(logger.integrity, "append", _audit_boom)
+    monkeypatch.setattr(vault, "restore_credential", _restore_boom)
+
+    result = mutations.rotate_credential(
+        agent_id="operator",
+        service_or_id="test-service",
+        new_secret="rotated-secret",
+        alias="rollback-test",
+    )
+
+    assert result.allowed is False
+    assert "ROLLBACK FAILED" in result.reason
+    assert "prior credential may be lost" in result.reason
+
+
 def test_restore_credential_idempotent(tmp_path: Path) -> None:
     """restore_credential is an idempotent upsert by id: applying the same
     before-image twice must not duplicate or corrupt the row."""

--- a/tests/test_audit_failure_rollback.py
+++ b/tests/test_audit_failure_rollback.py
@@ -1,0 +1,208 @@
+"""Regression tests for #56 Slice A — preserve credentials on audit failure.
+
+The pre-fix behavior in ``VaultMutations._record_mutation`` rolled back any
+state-changing mutation whose protected audit append failed by deleting the
+credential row. That is only correct for a brand-new add. Rotate, replace
+(replace_existing), and delete destroyed the prior credential even though the
+caller-visible message claimed the credential was preserved.
+
+The fix adds ``Vault.restore_credential(record)`` (idempotent upsert by id)
+and uses the captured before-image of the row to restore the original
+ciphertext when the integrity chain refuses to seal the audit row. Delete is
+kept only for genuine new-record adds.
+
+Each test is red-capable: it fails on the pre-fix code (the credential row is
+deleted or the audit error propagates) and passes once the before-image
+restore path exists.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.audit_integrity.service import AuditIntegrityError
+from hermes_vault.mutations import VaultMutations
+from hermes_vault.policy import PolicyEngine
+from hermes_vault.vault import Vault
+
+
+def make_vault_and_logger(tmp_path: Path) -> tuple[Vault, AuditLogger]:
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    logger = AuditLogger(vault.db_path, master_key=vault.key)
+    return vault, logger
+
+
+def make_mutations(tmp_path: Path) -> tuple[Vault, AuditLogger, VaultMutations]:
+    vault, logger = make_vault_and_logger(tmp_path)
+    mutations = VaultMutations(vault=vault, policy=PolicyEngine(), audit=logger)
+    return vault, logger, mutations
+
+
+def _corrupt_checkpoint(logger: AuditLogger) -> None:
+    """Break the authenticated checkpoint so verify() returns failed.
+
+    Mirrors the injection used by test_audit_integrity_toctou.py: a checkpoint
+    with an invalid signature makes ``append()`` raise AuditIntegrityError.
+    """
+    checkpoint_path = logger.db_path.with_name("audit.checkpoint.json")
+    checkpoint_path.write_bytes(
+        b'{"format": "hermes-vault-audit-checkpoint", "version": "audit-checkpoint-v1", "signature": "bogus"}'
+    )
+
+
+def _add_original(vault: Vault, logger: AuditLogger, mutations: VaultMutations) -> str:
+    result = mutations.add_credential(
+        agent_id="operator",
+        service="test-service",
+        secret="original-secret",
+        credential_type="api_key",
+        alias="rollback-test",
+    )
+    assert result.allowed is True
+    assert result.record is not None
+    return result.record.id
+
+
+def test_rotate_audit_failure_preserves_prior_credential(tmp_path: Path) -> None:
+    """Rotate with a broken integrity chain must deny and keep the ORIGINAL
+    ciphertext. Pre-fix the rollback deleted the only row (data loss)."""
+    vault, logger, mutations = make_mutations(tmp_path)
+    record_id = _add_original(vault, logger, mutations)
+    _corrupt_checkpoint(logger)
+
+    result = mutations.rotate_credential(
+        agent_id="operator",
+        service_or_id="test-service",
+        new_secret="rotated-secret",
+        alias="rollback-test",
+    )
+
+    assert result.allowed is False, "rotate must be denied when integrity chain is broken"
+    assert "integrity" in result.reason.lower() or "audit" in result.reason.lower(), (
+        f"reason should mention audit/integrity; got: {result.reason!r}"
+    )
+
+    # The credential row must survive and still decrypt to the ORIGINAL secret.
+    surviving = vault.resolve_credential(record_id)
+    assert surviving is not None, "rotated credential row was destroyed by audit-failure rollback"
+    secret = vault.get_secret(record_id)
+    assert secret is not None and secret.secret == "original-secret", (
+        "rotated credential must keep its original secret after audit failure"
+    )
+
+
+def test_replace_audit_failure_preserves_prior_credential(tmp_path: Path) -> None:
+    """add_credential(replace_existing=True) with a broken chain must deny and
+    keep the ORIGINAL ciphertext. Pre-fix the rollback deleted the row."""
+    vault, logger, mutations = make_mutations(tmp_path)
+    record_id = _add_original(vault, logger, mutations)
+    _corrupt_checkpoint(logger)
+
+    result = mutations.add_credential(
+        agent_id="operator",
+        service="test-service",
+        secret="replacement-secret",
+        credential_type="api_key",
+        alias="rollback-test",
+        replace_existing=True,
+    )
+
+    assert result.allowed is False, "replace must be denied when integrity chain is broken"
+    assert "integrity" in result.reason.lower() or "audit" in result.reason.lower(), (
+        f"reason should mention audit/integrity; got: {result.reason!r}"
+    )
+
+    surviving = vault.resolve_credential(record_id)
+    assert surviving is not None, "replaced credential row was destroyed by audit-failure rollback"
+    secret = vault.get_secret(record_id)
+    assert secret is not None and secret.secret == "original-secret", (
+        "replaced credential must keep its original secret after audit failure"
+    )
+
+
+def test_delete_audit_failure_preserves_credential(tmp_path: Path) -> None:
+    """delete_credential with a broken chain must deny and restore the row.
+    Pre-fix the audit error propagated out of delete_credential and the row
+    stayed deleted with no audit record."""
+    vault, logger, mutations = make_mutations(tmp_path)
+    record_id = _add_original(vault, logger, mutations)
+    _corrupt_checkpoint(logger)
+
+    result = mutations.delete_credential(
+        agent_id="operator",
+        service_or_id="test-service",
+        alias="rollback-test",
+    )
+
+    assert result.allowed is False, "delete must be denied when integrity chain is broken"
+    assert "integrity" in result.reason.lower() or "audit" in result.reason.lower(), (
+        f"reason should mention audit/integrity; got: {result.reason!r}"
+    )
+
+    surviving = vault.resolve_credential(record_id)
+    assert surviving is not None, "deleted credential was not restored after audit failure"
+    secret = vault.get_secret(record_id)
+    assert secret is not None and secret.secret == "original-secret", (
+        "deleted credential must be restored with its original secret"
+    )
+
+
+def test_rotate_audit_failure_deterministic_append_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same guarantee driven by a deterministic append failure instead of the
+    checkpoint-corruption trick: monkeypatch AuditIntegrityService.append to
+    raise AuditIntegrityError and verify the original secret survives."""
+    vault, logger, mutations = make_mutations(tmp_path)
+    record_id = _add_original(vault, logger, mutations)
+
+    def _boom(record: object) -> None:
+        raise AuditIntegrityError("deterministic append failure")
+
+    assert logger.integrity is not None
+    monkeypatch.setattr(logger.integrity, "append", _boom)
+
+    result = mutations.rotate_credential(
+        agent_id="operator",
+        service_or_id="test-service",
+        new_secret="rotated-secret",
+        alias="rollback-test",
+    )
+
+    assert result.allowed is False, "rotate must be denied when append raises"
+    assert "integrity" in result.reason.lower() or "audit" in result.reason.lower()
+
+    surviving = vault.resolve_credential(record_id)
+    assert surviving is not None, "rotated credential row was destroyed by audit-failure rollback"
+    secret = vault.get_secret(record_id)
+    assert secret is not None and secret.secret == "original-secret", (
+        "rotated credential must keep its original secret after audit failure"
+    )
+
+
+def test_restore_credential_idempotent(tmp_path: Path) -> None:
+    """restore_credential is an idempotent upsert by id: applying the same
+    before-image twice must not duplicate or corrupt the row."""
+    vault, _logger = make_vault_and_logger(tmp_path)
+    record = vault.add_credential(
+        service="openai",
+        secret="sk-idempotent",
+        credential_type="api_key",
+        alias="primary",
+        tags=["a", "b"],
+        notes="keep me",
+    )
+
+    assert vault.delete(record.id) is True
+    assert vault.get_credential(record.id) is None
+
+    vault.restore_credential(record)
+    vault.restore_credential(record)  # second application must be a no-op
+
+    restored = vault.get_credential(record.id)
+    assert restored is not None
+    secret = vault.get_secret(record.id)
+    assert secret is not None and secret.secret == "sk-idempotent"
+    assert restored.tags == ["a", "b"]
+    assert restored.notes == "keep me"
+    assert restored.crypto_version == record.crypto_version


### PR DESCRIPTION
## Summary

Fixes #56

Preserve an existing credential when a mutation succeeds but audit sealing fails, and report a compensating rollback failure honestly.

## Root cause

The mutation rollback path treated every post-mutation audit failure as if the record were a new add. For replace, rotate, and delete, that could delete the original credential instead of restoring its complete before-image.

## Fix

- Capture complete before-images for replace, rotate, and delete operations.
- Add an idempotent `restore_credential()` upsert by credential ID that preserves the complete row.
- Restore the before-image after ordinary audit-sealing failure.
- Keep deletion as the fallback only for genuine new-record adds.
- Add `AuditRollbackError` and explicit `ROLLBACK FAILED` reporting when compensation itself fails.
- Add failure-injection coverage for audit sealing, restoration fidelity, idempotence, and compensating-restore failure.

## Validation

Local validation on `fix/audit-failure-rollback` against `master` `e589fc9`:

- Full core + secret-source plugin suite: **925 passed**
- Ruff: passed
- Mypy: passed across 62 source files
- Package build: passed (sdist + wheel)
- `git diff --check`: passed

Remote CI has not been claimed as green; it is the next gate after this PR is opened.

## Risk and rollback

Medium security/data-integrity surface. The change is isolated to audited mutation compensation and its tests. Reverting both commits restores the previous rollback behavior; no live vault was used during validation.

## Test plan

- [x] Added audit-failure regression tests
- [x] Added compensating-rollback failure regression
- [x] Existing tests pass locally
- [x] Ruff and mypy pass locally
- [x] Package build passes locally
- [ ] Remote CI
- [ ] Independent maintainer security review
