### PR TITLE
fix(backup): verify detached audit evidence before healthy

### DIFF
--- a/src/hermes_vault/audit_integrity/detached.py
+++ b/src/hermes_vault/audit_integrity/detached.py
@@ -1,0 +1,206 @@
+"""Detached cryptographic verification of exported audit evidence (Slice D, #59).
+
+Verifies the hvbackup-v2 ``audit_integrity`` evidence exported by
+``AuditIntegrityService.export_evidence`` with NO live database reads:
+registry/checkpoint, record signatures/digests/continuity, checkpoint tip,
+access-log bindings, and segment key material. Used to make backup
+verification and recovery drills fail closed on tampered evidence.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hermes_vault.audit_integrity.canonical import CANONICAL_JSON_VERSION, canonical_bytes, framed
+from hermes_vault.audit_integrity.checkpoint import checkpoint_signature_valid
+from hermes_vault.audit_integrity.crypto import (
+    CHECKPOINT_SIGNING_CONTEXT,
+    ENTRY_SIGNING_CONTEXT,
+    ENTRY_SIGNATURE_VERSION,
+    digest_hex,
+    public_key_b64,
+    verify,
+)
+from hermes_vault.audit_integrity.service import CHAIN_VERSION
+
+# Status strings mirror backup.BACKUP_INTEGRITY_* without importing backup
+# (backup imports this module, so a shared constant would be circular).
+DETACHED_HEALTHY = "healthy"
+DETACHED_LEGACY = "legacy"
+DETACHED_INCOMPLETE = "incomplete"
+DETACHED_FAILED = "failed"
+
+# Public registry fields authenticated by the checkpoint (mirror repository.registry_digest).
+_REGISTRY_KEYS = (
+    "segment_id",
+    "segment_number",
+    "chain_version",
+    "serialization_version",
+    "key_derivation_version",
+    "entry_signature_version",
+    "checkpoint_signature_version",
+    "entry_public_key",
+    "checkpoint_public_key",
+    "sequence_start",
+    "sequence_end",
+    "predecessor_segment_id",
+    "predecessor_tip_digest",
+    "transition_reason",
+    "legacy_count",
+    "legacy_snapshot_digest",
+    "legacy_first_id",
+    "legacy_last_id",
+    "created_at",
+    "closed_at",
+)
+
+# Column order used by the legacy snapshot framing (mirror service._legacy_snapshot).
+_ACCESS_LOG_COLUMNS = (
+    "id",
+    "timestamp",
+    "agent_id",
+    "service",
+    "action",
+    "decision",
+    "reason",
+    "ttl_seconds",
+    "verification_result",
+    "metadata_json",
+)
+
+
+def _registry_digest(segments: list[dict[str, Any]]) -> str:
+    ordered = sorted(segments, key=lambda seg: seg.get("segment_number", 0))
+    public = [{key: seg.get(key) for key in _REGISTRY_KEYS} for seg in ordered]
+    return digest_hex(canonical_bytes(public))
+
+
+def _access_log_payload(row: dict[str, Any]) -> dict[str, Any]:
+    return {key: row.get(key) for key in _ACCESS_LOG_COLUMNS}
+
+
+def _legacy_anchor_digest(access_logs: list[dict[str, Any]], cutoff: int) -> str:
+    ordered = sorted(access_logs, key=lambda row: (str(row.get("timestamp", "")), str(row.get("id", ""))))
+    frames = []
+    for row in ordered[:cutoff]:
+        frames.append(
+            framed(
+                [(b"" if row.get(key) is None else str(row.get(key)).encode("utf-8")) for key in _ACCESS_LOG_COLUMNS]
+            )
+        )
+    return digest_hex(b"".join(frames))
+
+
+def verify_detached_evidence(evidence: dict[str, Any], master_key: bytes) -> tuple[str, str | None]:
+    """Verify exported audit evidence using only *evidence* and the vault master key.
+
+    Returns ``(status, reason)`` where status is one of ``healthy``, ``failed``,
+    ``incomplete``, or ``legacy`` and reason is the failure code (``None`` when
+    healthy). Mirrors ``AuditIntegrityService.verify`` over the exported dicts
+    instead of the live database.
+    """
+    if not evidence.get("integrity_available", False):
+        return DETACHED_LEGACY, "integrity_evidence_not_available"
+
+    state_rows = evidence.get("state")
+    if not state_rows:
+        return DETACHED_INCOMPLETE, "integrity_state_missing"
+    segments = evidence.get("segments")
+    if not segments:
+        return DETACHED_INCOMPLETE, "integrity_segments_missing"
+
+    records = evidence.get("records") or []
+    access_logs = evidence.get("access_logs") or []
+    checkpoint = evidence.get("checkpoint")
+
+    state = state_rows[0]
+    if state.get("migration_state") != "active":
+        return DETACHED_LEGACY, "migration_not_active"
+
+    active_segment_id = state.get("active_segment_id")
+    active = next((seg for seg in segments if seg.get("segment_id") == active_segment_id), None)
+    if active is None:
+        return DETACHED_FAILED, "segment_registry_mismatch"
+    if active.get("chain_version") != CHAIN_VERSION:
+        return DETACHED_FAILED, "unsupported_chain_version"
+    if active.get("serialization_version") != CANONICAL_JSON_VERSION:
+        return DETACHED_FAILED, "unsupported_serialization_version"
+    if active.get("entry_signature_version") != ENTRY_SIGNATURE_VERSION:
+        return DETACHED_FAILED, "unsupported_signature_version"
+    if active.get("entry_public_key") != public_key_b64(master_key, ENTRY_SIGNING_CONTEXT) or active.get(
+        "checkpoint_public_key"
+    ) != public_key_b64(master_key, CHECKPOINT_SIGNING_CONTEXT):
+        return DETACHED_FAILED, "key_mismatch"
+
+    # Legacy anchor: the migration prefix must still match its recorded snapshot.
+    first = min(segments, key=lambda seg: seg.get("segment_number", 0))
+    legacy_count = int(first.get("legacy_count") or 0)
+    if legacy_count:
+        if len(access_logs) < legacy_count or _legacy_anchor_digest(access_logs, legacy_count) != first.get(
+            "legacy_snapshot_digest"
+        ):
+            return DETACHED_FAILED, "legacy_anchor_mismatch"
+
+    access_logs_by_id = {row.get("id"): row for row in access_logs}
+    segments_by_id = {seg.get("segment_id"): seg for seg in segments}
+    ordered_records = sorted(records, key=lambda rec: rec.get("sequence", 0))
+    previous = ""
+    expected_sequence = 1
+    last_sequence = 0
+    last_digest = ""
+    for rec in ordered_records:
+        sequence = rec.get("sequence")
+        if sequence != expected_sequence:
+            return DETACHED_FAILED, "sequence_gap"
+        if rec.get("previous_digest") != previous:
+            return DETACHED_FAILED, "previous_digest_mismatch"
+        log_row = access_logs_by_id.get(rec.get("access_log_id"))
+        if log_row is None:
+            return DETACHED_FAILED, "missing_access_log"
+        if digest_hex(canonical_bytes(_access_log_payload(log_row))) != rec.get("entry_digest"):
+            return DETACHED_FAILED, "entry_digest_mismatch"
+        segment = segments_by_id.get(rec.get("segment_id"))
+        if segment is None:
+            return DETACHED_FAILED, "segment_registry_mismatch"
+        envelope = {
+            "chain_version": rec.get("chain_version"),
+            "serialization_version": rec.get("serialization_version"),
+            "segment_id": rec.get("segment_id"),
+            "sequence": rec.get("sequence"),
+            "previous_digest": rec.get("previous_digest"),
+            "entry_digest": rec.get("entry_digest"),
+        }
+        if not verify(segment.get("entry_public_key", ""), rec.get("signature", ""), canonical_bytes(envelope)):
+            return DETACHED_FAILED, "entry_signature_mismatch"
+        previous = str(rec.get("entry_digest"))
+        expected_sequence += 1
+        last_sequence = int(sequence)
+        last_digest = str(rec.get("entry_digest"))
+
+    # Every exported access-log row must be either legacy-prefix or protected.
+    if len(access_logs) != legacy_count + len(records):
+        return DETACHED_FAILED, "missing_integrity_record"
+
+    # Checkpoint: format, signature, active segment, registry digest, tip.
+    if checkpoint is None:
+        return DETACHED_INCOMPLETE, "checkpoint_missing"
+    if (
+        checkpoint.get("format") != "hermes-vault-audit-checkpoint"
+        or checkpoint.get("version") != "audit-checkpoint-v1"
+    ):
+        return DETACHED_INCOMPLETE, "checkpoint_invalid_format"
+    if not checkpoint_signature_valid(checkpoint, str(active.get("checkpoint_public_key", ""))):
+        return DETACHED_FAILED, "checkpoint_invalid_signature"
+    if checkpoint.get("active_segment_id") != active_segment_id:
+        return DETACHED_FAILED, "checkpoint_segment_mismatch"
+    if checkpoint.get("segment_registry_digest") != _registry_digest(segments):
+        return DETACHED_FAILED, "segment_registry_mismatch"
+    cp_sequence = checkpoint.get("latest_sequence")
+    if not isinstance(cp_sequence, int):
+        return DETACHED_INCOMPLETE, "checkpoint_invalid_format"
+    if cp_sequence < last_sequence or checkpoint.get("latest_entry_digest") != last_digest:
+        return DETACHED_INCOMPLETE, "checkpoint_stale"
+    if cp_sequence > last_sequence:
+        return DETACHED_INCOMPLETE, "checkpoint_ahead"
+
+    return DETACHED_HEALTHY, None

--- a/src/hermes_vault/audit_integrity/service.py
+++ b/src/hermes_vault/audit_integrity/service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
@@ -37,10 +39,15 @@ class AuditIntegrityService:
     def _now() -> str:
         return datetime.now(timezone.utc).isoformat()
 
-    def _connection(self) -> sqlite3.Connection:
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
         conn = sqlite3.connect(self.db_path, timeout=10)
         conn.row_factory = sqlite3.Row
-        return conn
+        try:
+            with conn:
+                yield conn
+        finally:
+            conn.close()
 
     def _failure(
         self, reason: str, checkpoint: AuditCheckpointStatus = AuditCheckpointStatus.valid, *, sequence: int | None = None,

--- a/src/hermes_vault/backup.py
+++ b/src/hermes_vault/backup.py
@@ -126,9 +126,16 @@ def _classify_v2_integrity(integrity: dict[str, Any], vault: Vault) -> tuple[str
                 return BACKUP_INTEGRITY_INCOMPLETE, "record_missing_required_fields"
 
     # Legacy anchor check.
-    if state.get("migration_state") == "active":
-        return BACKUP_INTEGRITY_HEALTHY, None
-    return BACKUP_INTEGRITY_LEGACY, "migration_not_active"
+    if state.get("migration_state") != "active":
+        return BACKUP_INTEGRITY_LEGACY, "migration_not_active"
+
+    # Detached cryptographic verification over the exported evidence (Slice D,
+    # #59). No live-DB reads: recompute registry/entry digests, verify record
+    # signatures and continuity, checkpoint signature/tip, access-log bindings,
+    # and segment key material. Never report healthy unless this passes.
+    from hermes_vault.audit_integrity.detached import verify_detached_evidence
+
+    return verify_detached_evidence(integrity, vault.key)
 
 
 def _verify_v1_backup(report: BackupVerificationReport, backup: dict[str, Any], vault: Vault) -> BackupVerificationReport:

--- a/src/hermes_vault/cli.py
+++ b/src/hermes_vault/cli.py
@@ -2953,22 +2953,30 @@ def backup_verify(
         raise typer.Exit(code=2)
 
     vault, _, _, _ = build_services(prompt=True)
-    from hermes_vault.backup import verify_backup_file
+    from hermes_vault.backup import BACKUP_INTEGRITY_HEALTHY, verify_backup_file
 
     report = verify_backup_file(input, vault)
     _print_backup_report(report, format=format)
+    # Fail closed on tampered evidence: exit 0 only when decryptable AND
+    # (no integrity evidence OR evidence verified healthy). v2 backups with
+    # integrity_available exit nonzero on anything less than healthy (#59).
+    integrity_ok = (
+        not report.integrity_available
+        or report.integrity_status == BACKUP_INTEGRITY_HEALTHY
+    )
+    verified = report.decryptable and integrity_ok
     audit = AuditLogger(get_settings().db_path, master_key=vault.key)
     audit.record(
         AccessLogRecord(
             agent_id=OPERATOR_AGENT_ID,
             service="*",
             action="backup_verify",
-            decision=Decision.allow if report.decryptable else Decision.deny,
-            reason=f"backup verify for {input}: {'ok' if report.decryptable else '; '.join(report.findings)}",
+            decision=Decision.allow if verified else Decision.deny,
+            reason=f"backup verify for {input}: {'ok' if verified else '; '.join(report.findings)}",
             metadata=report.as_dict(exclude_none=False),
         )
     )
-    raise typer.Exit(code=0 if report.decryptable else 1)
+    raise typer.Exit(code=0 if verified else 1)
 
 
 def _print_backup_report(report, *, format: str) -> None:
@@ -2985,6 +2993,10 @@ def _print_backup_report(report, *, format: str) -> None:
     table.add_row("Decryptable", "yes" if report.decryptable else "no")
     table.add_row("Would restore", str(report.would_restore_count))
     table.add_row("Audit included", "yes" if report.audit_included else "no")
+    if report.integrity_available:
+        table.add_row("Integrity status", report.integrity_status or "-")
+        if report.integrity_reason:
+            table.add_row("Integrity reason", report.integrity_reason)
     console.print(table)
     for finding in report.findings:
         console.print(f"[red]{finding}[/red]")

--- a/src/hermes_vault/recovery.py
+++ b/src/hermes_vault/recovery.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from hermes_vault.backup import restore_dry_run, verify_backup_file
+from hermes_vault.backup import BACKUP_INTEGRITY_HEALTHY, restore_dry_run, verify_backup_file
 from hermes_vault.diff import diff_backups
 from hermes_vault.models import utc_now
 from hermes_vault.policy import PolicyEngine
@@ -90,9 +90,14 @@ def run_recovery_drill(
     if policy is not None:
         report.policy_hash = policy.compute_policy_hash()
 
+    integrity_ok = (
+        not verify_report.integrity_available
+        or verify_report.integrity_status == BACKUP_INTEGRITY_HEALTHY
+    )
     report.healthy = (
         verify_report.decryptable
         and restore_report.decryptable
+        and integrity_ok
         and not report.findings
     )
     report.recommended_next_step = (

--- a/src/hermes_vault/vault.py
+++ b/src/hermes_vault/vault.py
@@ -4,9 +4,11 @@ import json
 import os
 import sqlite3
 import sys
-from typing import Any
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 from hermes_vault import _platform
@@ -87,9 +89,18 @@ class Vault:
     def rotation_journal_path(self) -> Path:
         return self.salt_path.with_name(f"{self.salt_path.name}.rotation.json")
 
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                yield conn
+        finally:
+            conn.close()
+
     def initialize(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS credentials (
@@ -321,7 +332,7 @@ class Vault:
     def _first_encrypted_payload(self) -> str | None:
         if not self.db_path.exists():
             return None
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 "SELECT encrypted_payload FROM credentials ORDER BY updated_at DESC LIMIT 1"
             ).fetchone()
@@ -417,7 +428,7 @@ class Vault:
             notes=resolved_notes,
             crypto_version=CRYPTO_VERSION,
         )
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             if existing and replace_existing:
                 conn.execute(
                     """
@@ -472,14 +483,14 @@ class Vault:
         return record
 
     def list_credentials(self) -> list[CredentialRecord]:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute("SELECT * FROM credentials ORDER BY service, alias").fetchall()
         return [self._row_to_record(row) for row in rows]
 
     def get_credential(self, service_or_id: str) -> CredentialRecord | None:
         # Try by raw id first (UUID), then by canonicalized service name
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.row_factory = sqlite3.Row
             row = conn.execute(
                 """
@@ -523,7 +534,7 @@ class Vault:
         """
         if alias is not None:
             normalized = normalize(service_or_id)
-            with sqlite3.connect(self.db_path) as conn:
+            with self._connection() as conn:
                 conn.execute(
                     """
                     UPDATE credentials
@@ -535,7 +546,7 @@ class Vault:
                 conn.commit()
             return
 
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             # Try raw id first
             cursor = conn.execute(
                 """
@@ -597,7 +608,7 @@ class Vault:
         current.imported_from = imported_from or current.imported_from
         current.updated_at = utc_now()
         current.status = CredentialStatus.unknown
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 UPDATE credentials
@@ -625,7 +636,7 @@ class Vault:
         """
         if alias is not None:
             normalized = normalize(service_or_id)
-            with sqlite3.connect(self.db_path) as conn:
+            with self._connection() as conn:
                 cursor = conn.execute(
                     "DELETE FROM credentials WHERE service = ? AND alias = ?",
                     (normalized, alias),
@@ -633,7 +644,7 @@ class Vault:
                 conn.commit()
             return cursor.rowcount > 0
 
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             # Try raw id first
             cursor = conn.execute(
                 "DELETE FROM credentials WHERE id = ?", (service_or_id,)
@@ -699,7 +710,7 @@ class Vault:
             return record
 
         # Try by raw id first (UUID exact match)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.row_factory = sqlite3.Row
             row = conn.execute(
                 "SELECT * FROM credentials WHERE id = ?", (service_or_id,)
@@ -749,7 +760,7 @@ class Vault:
         """
         record = self.resolve_credential(service_or_id, alias=alias)
         updated_at = utc_now()
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 UPDATE credentials
@@ -783,7 +794,7 @@ class Vault:
         """
         record = self.resolve_credential(service_or_id, alias=alias)
         updated_at = utc_now()
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             cursor = conn.execute(
                 """
                 UPDATE credentials
@@ -800,14 +811,14 @@ class Vault:
 
     def _count_by_service(self, service: str) -> int:
         """Count credentials for a normalized service name."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             row = conn.execute(
                 "SELECT COUNT(*) FROM credentials WHERE service = ?", (service,)
             ).fetchone()
             return row[0] if row else 0
 
     def _find_by_service_alias(self, service: str, alias: str) -> CredentialRecord | None:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.row_factory = sqlite3.Row
             row = conn.execute(
                 """
@@ -872,7 +883,7 @@ class Vault:
         return LeaseRecord.model_validate(payload)
 
     def _find_lease(self, lease_id: str) -> LeaseRecord | None:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.row_factory = sqlite3.Row
             self._refresh_expired_leases(conn)
             row = conn.execute("SELECT * FROM leases WHERE id = ?", (lease_id,)).fetchone()
@@ -907,7 +918,7 @@ class Vault:
             scopes=record.scopes,
             metadata=metadata or {},
         )
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 INSERT INTO leases (
@@ -946,7 +957,7 @@ class Vault:
         service: str | None = None,
         status: LeaseStatus | str | None = None,
     ) -> list[LeaseRecord]:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.row_factory = sqlite3.Row
             self._refresh_expired_leases(conn)
             conditions: list[str] = []
@@ -978,7 +989,7 @@ class Vault:
         alias: str = "default",
     ) -> LeaseRecord | None:
         service = normalize(service)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.row_factory = sqlite3.Row
             self._refresh_expired_leases(conn)
             row = conn.execute(
@@ -1025,7 +1036,7 @@ class Vault:
             requested_ttl_seconds=requested_ttl_seconds,
             metadata=metadata or {},
         )
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 INSERT INTO access_requests (
@@ -1061,7 +1072,7 @@ class Vault:
         service: str | None = None,
         status: str | AccessRequestStatus | None = None,
     ) -> list[AccessRequestRecord]:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.row_factory = sqlite3.Row
             conditions: list[str] = []
             params: list[Any] = []
@@ -1083,7 +1094,7 @@ class Vault:
         return [self._row_to_access_request_record(row) for row in rows]
 
     def get_access_request(self, request_id: str) -> AccessRequestRecord | None:
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.row_factory = sqlite3.Row
             row = conn.execute("SELECT * FROM access_requests WHERE id = ?", (request_id,)).fetchone()
         return self._row_to_access_request_record(row) if row else None
@@ -1104,7 +1115,7 @@ class Vault:
             raise ValueError(f"Access request '{request_id}' is already {current.status.value}")
         status_value = status.value if isinstance(status, AccessRequestStatus) else str(status)
         decided_at = utc_now()
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 UPDATE access_requests
@@ -1138,7 +1149,7 @@ class Vault:
             "renewed_at": now,
             "renew_count": lease.renew_count + 1,
         })
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 UPDATE leases
@@ -1169,7 +1180,7 @@ class Vault:
             "revoked_at": now,
             "reason": reason if reason is not None else lease.reason,
         })
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute(
                 """
                 UPDATE leases
@@ -1307,7 +1318,7 @@ class Vault:
                     "last_verified_at": last_verified_at,
                     "updated_at": utc_now(),
                 })
-            with sqlite3.connect(self.db_path) as conn:
+            with self._connection() as conn:
                 if existing:
                     conn.execute(
                         """
@@ -1389,7 +1400,7 @@ class Vault:
                 metadata=metadata,
             )
             if existing_lease:
-                with sqlite3.connect(self.db_path) as conn:
+                with self._connection() as conn:
                     conn.execute(
                         """
                         UPDATE leases
@@ -1421,7 +1432,7 @@ class Vault:
                     )
                     conn.commit()
             else:
-                with sqlite3.connect(self.db_path) as conn:
+                with self._connection() as conn:
                     conn.execute(
                         """
                         INSERT INTO leases (
@@ -1526,7 +1537,7 @@ class Vault:
 
         re_encrypted = 0
         all_records = self.list_credentials()
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connection() as conn:
             conn.execute("BEGIN EXCLUSIVE")
             try:
                 for rec in all_records:

--- a/tests/test_detached_evidence.py
+++ b/tests/test_detached_evidence.py
@@ -1,0 +1,310 @@
+"""Slice D (#59) — detached cryptographic verification of hvbackup-v2 evidence.
+
+These tests are RED against the current classifier (structural-only): a v2
+backup with tampered audit evidence is reported ``healthy`` because
+``_classify_v2_integrity`` never verifies signatures, digests, continuity, the
+checkpoint, access-log bindings, or segment key material. Slice D adds a
+detached verifier over the exported evidence (no live-DB reads) and makes
+``_classify_v2_integrity`` / recovery drill / ``backup-verify`` fail closed.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from hermes_vault.audit_integrity.checkpoint import signed_checkpoint
+from hermes_vault.audit_integrity.service import AuditIntegrityService
+from hermes_vault.backup import verify_backup_file
+from hermes_vault.cli import _hermes_group
+from hermes_vault.models import AccessLogRecord, Decision
+from hermes_vault.recovery import run_recovery_drill
+from hermes_vault.vault import Vault
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_vault_with_chain(tmp_path: Path, count: int = 5) -> Vault:
+    """Vault with credentials plus a healthy protected audit chain."""
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    vault.add_credential("openai", "sk-secret-1234567890", "api_key")
+    svc = AuditIntegrityService(vault.db_path, vault.key)
+    svc.ensure_initialized()
+    for i in range(count):
+        svc.append(
+            AccessLogRecord(
+                id=f"det-{i}-{time.monotonic_ns()}",
+                agent_id=f"agent-{i}",
+                service="openai",
+                action="get_env",
+                decision=Decision.allow,
+                reason=f"detached test record {i}",
+            )
+        )
+    return vault
+
+
+def _write_v2(path: Path, vault: Vault) -> dict:
+    backup = vault.export_backup(include_audit=True)
+    path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+    return backup
+
+
+# ── record tampering ────────────────────────────────────────────────────────
+
+
+def test_v2_tampered_signature_fails_verification(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    backup["audit_integrity"]["records"][2]["signature"] = "not-a-valid-signature"
+    backup_path = tmp_path / "tampered-sig.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = verify_backup_file(backup_path, vault)
+
+    assert report.decryptable is True
+    assert report.integrity_status == "failed"
+    assert report.integrity_reason == "entry_signature_mismatch"
+
+
+def test_v2_tampered_entry_digest_fails_verification(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    backup["audit_integrity"]["records"][2]["entry_digest"] = "0" * 64
+    backup_path = tmp_path / "tampered-digest.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = verify_backup_file(backup_path, vault)
+
+    assert report.decryptable is True
+    assert report.integrity_status == "failed"
+    assert report.integrity_reason == "entry_digest_mismatch"
+
+
+def test_v2_tampered_previous_digest_fails_verification(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    backup["audit_integrity"]["records"][3]["previous_digest"] = "0" * 64
+    backup_path = tmp_path / "tampered-prev.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = verify_backup_file(backup_path, vault)
+
+    assert report.decryptable is True
+    assert report.integrity_status == "failed"
+    assert report.integrity_reason == "previous_digest_mismatch"
+
+
+def test_v2_reordered_records_fail_verification(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    records = backup["audit_integrity"]["records"]
+    records[2]["sequence"], records[3]["sequence"] = records[3]["sequence"], records[2]["sequence"]
+    backup_path = tmp_path / "reordered.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = verify_backup_file(backup_path, vault)
+
+    assert report.decryptable is True
+    assert report.integrity_status == "failed"
+    assert report.integrity_reason in ("previous_digest_mismatch", "entry_signature_mismatch", "sequence_gap")
+
+
+def test_v2_deleted_record_sequence_gap_fails_verification(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    del backup["audit_integrity"]["records"][2]
+    backup_path = tmp_path / "gap.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = verify_backup_file(backup_path, vault)
+
+    assert report.decryptable is True
+    assert report.integrity_status == "failed"
+    assert report.integrity_reason == "sequence_gap"
+
+
+# ── checkpoint tampering ────────────────────────────────────────────────────
+
+
+def test_v2_tampered_checkpoint_signature_fails(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    backup["audit_integrity"]["checkpoint"]["signature"] = "tampered-signature"
+    backup_path = tmp_path / "tampered-cp-sig.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = verify_backup_file(backup_path, vault)
+
+    assert report.decryptable is True
+    assert report.integrity_status == "failed"
+    assert report.integrity_reason == "checkpoint_invalid_signature"
+
+
+def test_v2_tampered_checkpoint_tip_fails(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    # Re-sign a checkpoint whose tip no longer matches the last verified record.
+    cp = backup["audit_integrity"]["checkpoint"]
+    cp.pop("signature", None)
+    cp["latest_entry_digest"] = "0" * 64
+    backup["audit_integrity"]["checkpoint"] = signed_checkpoint(cp, vault.key)
+    backup_path = tmp_path / "tampered-cp-tip.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = verify_backup_file(backup_path, vault)
+
+    assert report.decryptable is True
+    assert report.integrity_status != "healthy"
+    assert report.integrity_reason in ("checkpoint_stale", "checkpoint_ahead", "checkpoint_invalid_signature")
+
+
+# ── access-log bindings ─────────────────────────────────────────────────────
+
+
+def test_v2_tampered_access_log_field_fails(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    backup["audit_integrity"]["access_logs"][2]["reason"] = "tampered reason"
+    backup_path = tmp_path / "tampered-access-log.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = verify_backup_file(backup_path, vault)
+
+    assert report.decryptable is True
+    assert report.integrity_status == "failed"
+    assert report.integrity_reason == "entry_digest_mismatch"
+
+
+def test_v2_missing_access_log_row_fails(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    removed = backup["audit_integrity"]["records"][2]["access_log_id"]
+    backup["audit_integrity"]["access_logs"] = [
+        row for row in backup["audit_integrity"]["access_logs"] if row["id"] != removed
+    ]
+    backup_path = tmp_path / "missing-access-log.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = verify_backup_file(backup_path, vault)
+
+    assert report.decryptable is True
+    assert report.integrity_status == "failed"
+    assert report.integrity_reason == "missing_access_log"
+
+
+# ── segment key material ────────────────────────────────────────────────────
+
+
+def test_v2_tampered_segment_public_key_fails(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path, count=3)
+    vault.rotate_master_key("test-passphrase", "new-passphrase")
+    reopened = Vault(vault.db_path, vault.salt_path, "new-passphrase")
+    svc = AuditIntegrityService(reopened.db_path, reopened.key)
+    svc.append(
+        AccessLogRecord(
+            id=f"det-post-rotation-{time.monotonic_ns()}",
+            agent_id="agent-post",
+            service="openai",
+            action="get_env",
+            decision=Decision.allow,
+            reason="post-rotation record",
+        )
+    )
+    backup = reopened.export_backup(include_audit=True)
+    # Tamper key material on the CLOSED (first) segment. The active segment key
+    # still matches and record signatures are unaffected (records in segment 1
+    # are signed with entry_public_key), so only a registry digest check over
+    # the exported segment registry can catch this.
+    for seg in backup["audit_integrity"]["segments"]:
+        if seg["segment_number"] == 1:
+            seg["checkpoint_public_key"] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    backup_path = tmp_path / "tampered-segment-key.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = verify_backup_file(backup_path, reopened)
+
+    assert report.decryptable is True
+    assert report.integrity_status == "failed"
+    assert report.integrity_reason == "segment_registry_mismatch"
+
+
+# ── valid detached verification ─────────────────────────────────────────────
+
+
+def test_v2_valid_backup_verifies_detached(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    evidence = backup["audit_integrity"]
+
+    from hermes_vault.audit_integrity.detached import verify_detached_evidence
+
+    status, reason = verify_detached_evidence(evidence, vault.key)
+    assert status == "healthy"
+    assert reason is None
+
+    # No live-DB dependency: wipe the database and checkpoint, then verify
+    # again using only the exported evidence plus the master key.
+    vault.db_path.unlink()
+    (tmp_path / "audit.checkpoint.json").unlink()
+    status2, reason2 = verify_detached_evidence(evidence, vault.key)
+    assert status2 == "healthy"
+    assert reason2 is None
+
+
+def test_v2_missing_evidence_stays_legacy(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    backup.pop("audit_integrity", None)
+    backup_path = tmp_path / "no-evidence.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = verify_backup_file(backup_path, vault)
+
+    assert report.decryptable is True
+    assert report.integrity_available is False
+    assert report.integrity_status == "legacy"
+
+
+# ── CLI exit code ───────────────────────────────────────────────────────────
+
+
+def test_backup_verify_exit_nonzero_on_invalid_evidence(monkeypatch, tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    backup["audit_integrity"]["records"][1]["signature"] = "tampered"
+    backup_path = tmp_path / "tampered-v2.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    def fake_build_services(prompt: bool = False):
+        return vault, object(), object(), object()
+
+    monkeypatch.setattr("hermes_vault.cli.build_services", fake_build_services)
+    monkeypatch.setenv("HERMES_VAULT_HOME", str(tmp_path))
+
+    runner = CliRunner()
+    result = runner.invoke(_hermes_group, ["backup-verify", "--input", str(backup_path), "--format", "json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["integrity_status"] == "failed"
+
+
+# ── recovery drill health ───────────────────────────────────────────────────
+
+
+def test_recovery_drill_not_healthy_on_invalid_evidence(tmp_path: Path) -> None:
+    vault = _make_vault_with_chain(tmp_path)
+    backup = vault.export_backup(include_audit=True)
+    backup["audit_integrity"]["records"][0]["signature"] = "tampered"
+    backup_path = tmp_path / "tampered-v2.json"
+    backup_path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+
+    report = run_recovery_drill(backup_path=backup_path, vault=vault)
+
+    assert report.healthy is False
+    assert report.backup_verify["integrity_status"] == "failed"


### PR DESCRIPTION
## Summary

Fixes #59

Make backup verification fail closed when detached v2 audit evidence is missing, inconsistent, or tampered.

## Root cause

The backup path could establish structural/decryptability health without independently validating the exported audit evidence. That allowed a tampered v2 evidence set to look healthy during verification or recovery.

## Fix

- Add detached verification without live-database reads.
- Verify registry and segment key material, record signatures/digests, continuity, sequence, checkpoint signature/tip, legacy anchoring, and access-log bindings.
- Require explicitly healthy detached integrity evidence before recovery reports healthy when evidence is available.
- Handle incomplete segment metadata defensively when calculating registry digests.
- Add tamper, structural, CLI, recovery, and round-trip regression coverage.

## Validation

Local validation on `fix/detached-backup-evidence` against `master` `e589fc9`:

- Full core + secret-source plugin suite: **933 passed**
- Ruff: passed
- Mypy: passed across 62 source files
- Package build: passed (sdist + wheel)
- `git diff --check`: passed

Remote CI has not been claimed as green; it is the next gate after this PR is opened.

## Risk and rollback

Medium backup-assurance surface. The existing `hvbackup-v2` format is retained; no format bump or live restore was performed. Reverting the single commit removes detached verification and its tests.

## Test plan

- [x] Added detached evidence and tamper regressions
- [x] Added CLI/recovery health coverage
- [x] Existing tests pass locally
- [x] Ruff and mypy pass locally
- [x] Package build passes locally
- [ ] Remote CI
- [ ] Independent maintainer security review
