### PR TITLE
fix(restore): atomic restore with preflight, lease identity checks, protected audit event (#62)

### DIFF
--- a/src/hermes_vault/audit_integrity/service.py
+++ b/src/hermes_vault/audit_integrity/service.py
@@ -5,6 +5,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TypedDict
 from uuid import uuid4
 
 from hermes_vault.audit_integrity.canonical import CANONICAL_JSON_VERSION, canonical_bytes, framed
@@ -20,6 +21,14 @@ from hermes_vault.audit_integrity.repository import access_log_payload, registry
 from hermes_vault.audit_integrity.schema import SCHEMA_VERSION, initialize_schema
 
 CHAIN_VERSION = "sha256-chain-v1"
+
+
+class AppendResult(TypedDict):
+    """Checkpoint payload returned by a transaction-scoped audit append."""
+
+    segment: sqlite3.Row
+    sequence: int
+    digest: str
 
 
 class AuditIntegrityError(RuntimeError):
@@ -185,28 +194,64 @@ class AuditIntegrityService:
             with audit_write_lock(self.lock_path):
                 with self._connection() as conn:
                     conn.execute("BEGIN IMMEDIATE")
-                    active = self._active(conn)
-                    sequence, previous_digest = self._tip(conn)
-                    next_sequence = sequence + 1
-                    metadata_json = canonical_bytes(getattr(record, "metadata")).decode("utf-8") if getattr(record, "metadata") else "{}"
-                    values = (
-                        getattr(record, "id"), getattr(record, "timestamp").isoformat(), getattr(record, "agent_id"),
-                        getattr(record, "service"), getattr(record, "action"), getattr(record, "decision").value,
-                        getattr(record, "reason"), getattr(record, "ttl_seconds"),
-                        getattr(record, "verification_result").value if getattr(record, "verification_result") else None, metadata_json,
-                    )
-                    conn.execute("INSERT INTO access_logs (id, timestamp, agent_id, service, action, decision, reason, ttl_seconds, verification_result, metadata_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", values)
-                    row = conn.execute("SELECT * FROM access_logs WHERE id = ?", (getattr(record, "id"),)).fetchone()
-                    entry_digest = digest_hex(canonical_bytes(access_log_payload(row)))
-                    envelope = {"chain_version": CHAIN_VERSION, "serialization_version": CANONICAL_JSON_VERSION, "segment_id": active["segment_id"], "sequence": next_sequence, "previous_digest": previous_digest, "entry_digest": entry_digest}
-                    signature = sign(self.master_key, ENTRY_SIGNING_CONTEXT, canonical_bytes(envelope))
-                    conn.execute("INSERT INTO audit_integrity_records (sequence, segment_id, access_log_id, previous_digest, entry_digest, signature, chain_version, serialization_version, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                        (next_sequence, active["segment_id"], getattr(record, "id"), previous_digest, entry_digest, signature, CHAIN_VERSION, CANONICAL_JSON_VERSION, self._now()))
-                    conn.execute("UPDATE audit_integrity_state SET updated_at = ? WHERE id = 1", (self._now(),))
+                    result = self.append_in_transaction(conn, record)
                     conn.commit()
-                    self._write_current_checkpoint(conn, active, latest_sequence=next_sequence, latest_digest=entry_digest)
+                    self._write_current_checkpoint(
+                        conn,
+                        result["segment"],
+                        latest_sequence=int(result["sequence"]),
+                        latest_digest=str(result["digest"]),
+                    )
         except AuditLockError as exc:
             raise AuditIntegrityError(str(exc)) from exc
+
+    def append_in_transaction(self, conn: sqlite3.Connection, record: object) -> AppendResult:
+        """Append a protected audit record using a caller-owned connection.
+
+        The caller owns the transaction: this method performs the access-log
+        INSERT, integrity-record INSERT, and state touch WITHOUT committing,
+        so the audit row is committed only when the caller's transaction
+        commits. Returns a checkpoint payload dict (``segment``,
+        ``sequence``, ``digest``) that the caller must persist via
+        :meth:`write_checkpoint_after_append` after committing.
+
+        Raises :class:`AuditIntegrityError` if the active segment or chain
+        state is unavailable on the supplied connection.
+        """
+        conn.row_factory = sqlite3.Row
+        active = self._active(conn)
+        sequence, previous_digest = self._tip(conn)
+        next_sequence = sequence + 1
+        metadata_json = canonical_bytes(getattr(record, "metadata")).decode("utf-8") if getattr(record, "metadata") else "{}"
+        values = (
+            getattr(record, "id"), getattr(record, "timestamp").isoformat(), getattr(record, "agent_id"),
+            getattr(record, "service"), getattr(record, "action"), getattr(record, "decision").value,
+            getattr(record, "reason"), getattr(record, "ttl_seconds"),
+            getattr(record, "verification_result").value if getattr(record, "verification_result") else None, metadata_json,
+        )
+        conn.execute("INSERT INTO access_logs (id, timestamp, agent_id, service, action, decision, reason, ttl_seconds, verification_result, metadata_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", values)
+        row = conn.execute("SELECT * FROM access_logs WHERE id = ?", (getattr(record, "id"),)).fetchone()
+        entry_digest = digest_hex(canonical_bytes(access_log_payload(row)))
+        envelope = {"chain_version": CHAIN_VERSION, "serialization_version": CANONICAL_JSON_VERSION, "segment_id": active["segment_id"], "sequence": next_sequence, "previous_digest": previous_digest, "entry_digest": entry_digest}
+        signature = sign(self.master_key, ENTRY_SIGNING_CONTEXT, canonical_bytes(envelope))
+        conn.execute("INSERT INTO audit_integrity_records (sequence, segment_id, access_log_id, previous_digest, entry_digest, signature, chain_version, serialization_version, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (next_sequence, active["segment_id"], getattr(record, "id"), previous_digest, entry_digest, signature, CHAIN_VERSION, CANONICAL_JSON_VERSION, self._now()))
+        conn.execute("UPDATE audit_integrity_state SET updated_at = ? WHERE id = 1", (self._now(),))
+        return {"segment": active, "sequence": next_sequence, "digest": entry_digest}
+
+    def write_checkpoint_after_append(self, conn: sqlite3.Connection, result: AppendResult) -> None:
+        """Persist the authenticated checkpoint after a transaction-scoped append.
+
+        The caller must have committed its transaction before calling this;
+        the supplied connection is used to read the segment registry (a
+        read that remains valid after commit).
+        """
+        self._write_current_checkpoint(
+            conn,
+            result["segment"],
+            latest_sequence=int(result["sequence"]),
+            latest_digest=str(result["digest"]),
+        )
 
     def _verify_checkpoint(self, conn: sqlite3.Connection, active: sqlite3.Row, sequence: int, tip: str) -> tuple[AuditCheckpointStatus, str | None]:
         checkpoint = read_checkpoint(self.checkpoint_path)

--- a/src/hermes_vault/broker.py
+++ b/src/hermes_vault/broker.py
@@ -120,6 +120,20 @@ class Broker:
                     ttl_seconds=effective_ttl,
                     metadata={"lease_required": True, "alias": record.alias},
                 )
+            # E1 (#62): the lease must reference the same credential identity
+            # being served. A lease whose credential_id no longer matches the
+            # resolved credential (e.g. tampered/relabeled row) is a forged
+            # identity and must be denied instead of serving the raw secret.
+            if lease.credential_id != record.id:
+                return self._deny(
+                    agent_id,
+                    canonical,
+                    "get_ephemeral_env",
+                    f"lease credential identity mismatch: lease {lease.id} references "
+                    f"credential {lease.credential_id} but resolved credential is {record.id}",
+                    ttl_seconds=effective_ttl,
+                    metadata={"lease_required": True, "lease_id": lease.id},
+                )
             remaining = int((lease.expires_at - datetime.now(timezone.utc)).total_seconds())
             if remaining <= 0:
                 return self._deny(

--- a/src/hermes_vault/cli.py
+++ b/src/hermes_vault/cli.py
@@ -18,6 +18,7 @@ from rich.table import Table
 
 from hermes_vault import _platform
 from hermes_vault.audit import AuditLogger
+from hermes_vault.audit_integrity.service import AuditIntegrityError
 from hermes_vault.broker import Broker
 from hermes_vault.config import get_settings, reset_active_profile, set_active_profile
 from hermes_vault.crypto import MissingPassphraseError, resolve_passphrase
@@ -2893,7 +2894,13 @@ def restore_vault(
     Existing credentials with the same service+alias are replaced.
     Requires --yes to confirm.
 
-    Metadata-only backups are rejected with a clear error.
+    Supports hvbackup-v1 and hvbackup-v2 backups. The restore runs through
+    the E1 atomic preflight + single-transaction import (issue #62): the v2
+    evidence contract, lease credential linkage, and broker identity are
+    validated before any mutation, and the restore — including its protected
+    restore audit event — commits as one transaction. Any preflight rejection
+    or audit failure blocks the restore with a clear, non-zero exit and
+    leaves the vault unchanged.
 
     Example:
       hermes-vault restore --input ~/vault-backup-2026-04.json --yes
@@ -2904,7 +2911,7 @@ def restore_vault(
 
     if dry_run:
         vault, _, _, _ = build_services(prompt=True)
-        from hermes_vault.backup import restore_dry_run
+        from hermes_vault.backup import BACKUP_INTEGRITY_HEALTHY, restore_dry_run
 
         report = restore_dry_run(input, vault)
         _print_backup_report(report, format=format)
@@ -2919,7 +2926,14 @@ def restore_vault(
                 metadata=report.as_dict(exclude_none=False),
             )
         )
-        raise typer.Exit(code=0 if report.decryptable else 1)
+        # Align the preflight exit code with backup-verify (fail closed on
+        # invalid v2 evidence): exit 0 only when decryptable AND any present
+        # integrity evidence is healthy.
+        integrity_ok = (
+            not report.integrity_available
+            or report.integrity_status == BACKUP_INTEGRITY_HEALTHY
+        )
+        raise typer.Exit(code=0 if (report.decryptable and integrity_ok) else 1)
 
     if not yes:
         console.print("[red]Restoration requires --yes flag.[/red]")
@@ -2930,15 +2944,60 @@ def restore_vault(
     except Exception as exc:
         console.print(f"[red]Failed to read backup file: {exc}[/red]")
         raise typer.Exit(code=1)
-    if backup.get("version") != "hvbackup-v1":
-        console.print(f"[red]Unsupported backup version: {backup.get('version')}[/red]")
-        raise typer.Exit(code=1)
+
+    # E2 v2 gate. import_backup runs the E1 preflight (version + evidence
+    # contract + lease linkage + broker identity) and the single-transaction
+    # restore with the protected audit event through the shared seam. The gate
+    # surfaces each failure class distinctly and never lets a rejected or
+    # rolled-back restore exit successfully.
+    active_leases = _count_active_leases(backup)
+    if active_leases:
+        console.print(
+            f"[yellow]Notice: {active_leases} active lease(s) in the backup will be "
+            "force-revoked on restore (active lease identities are never restored).[/yellow]"
+        )
     try:
         imported = vault.import_backup(backup)
-    except ValueError as exc:
-        console.print(f"[red]{exc}[/red]")
+    except (ValueError, AuditIntegrityError, sqlite3.Error) as exc:
+        error_class = _restore_error_class(exc)
+        console.print(f"[red]Restore blocked ({error_class}): {exc}[/red]")
+        raise typer.Exit(code=1)
+    except Exception as exc:
+        console.print(f"[red]Restore failed: {exc}[/red]")
         raise typer.Exit(code=1)
     console.print(f"[green]Restored {len(imported)} credential(s) from {input}[/green]")
+
+
+def _count_active_leases(backup: dict) -> int:
+    """Count leases in a backup that would be restored as active (E1 force-revokes them)."""
+    leases = backup.get("leases") or []
+    if not isinstance(leases, list):
+        return 0
+    return sum(
+        1
+        for lease in leases
+        if isinstance(lease, dict) and lease.get("status") == "active"
+    )
+
+
+def _restore_error_class(exc: Exception) -> str:
+    """Classify an E1 restore failure into a distinct operator-facing class."""
+    if isinstance(exc, AuditIntegrityError):
+        return "audit failure"
+    if isinstance(exc, sqlite3.Error):
+        return "transaction failure"
+    lowered = str(exc).lower()
+    if "metadata-only" in lowered:
+        return "partial-commit risk (metadata-only backup)"
+    if "foreign credential linkage" in lowered:
+        return "foreign credential linkage"
+    if "does not match" in lowered:
+        return "broker mismatch"
+    if "audit integrity evidence" in lowered:
+        return "missing audit integrity evidence"
+    if "unsupported backup version" in lowered:
+        return "unsupported backup version"
+    return "preflight rejection"
 
 
 @_typer_app.command("backup-verify")

--- a/src/hermes_vault/vault.py
+++ b/src/hermes_vault/vault.py
@@ -12,6 +12,8 @@ from typing import Any
 from uuid import uuid4
 
 from hermes_vault import _platform
+from hermes_vault.audit_integrity.checkpoint import AuditLockError, audit_write_lock
+from hermes_vault.audit_integrity.models import AuditIntegrityStatus
 from hermes_vault.audit_integrity.service import AuditIntegrityError, AuditIntegrityService
 from hermes_vault.crypto import (
     CRYPTO_VERSION,
@@ -28,11 +30,13 @@ from hermes_vault.crypto import (
     load_or_create_master_key,
 )
 from hermes_vault.models import (
+    AccessLogRecord,
     AccessRequestRecord,
     AccessRequestStatus,
     CredentialRecord,
     CredentialSecret,
     CredentialStatus,
+    Decision,
     LeaseRecord,
     LeaseStatus,
     utc_now,
@@ -1382,12 +1386,34 @@ class Vault:
 
         Supports hvbackup-v1 and hvbackup-v2 (credential portion only).
         Rejects metadata-only backups (entries missing encrypted_payload).
-        Audit integrity restore is not yet implemented. See issue #51.
+
+        Slice E1 (issue #62): the restore is validated by a preflight routine
+        before any mutation — the evidence contract is confirmed (v2 backups
+        must carry audit integrity evidence), restored leases are rejected if
+        they would mint a forged active lease identity or reference a foreign
+        credential, and every lease's broker identity must match the
+        credential it references. The import then runs as a single
+        transaction together with a protected restore audit event through the
+        shared audit seam; if any row, validation, or audit append fails, the
+        whole restore rolls back atomically.
         """
         version = backup.get("version")
         if version not in ("hvbackup-v1", "hvbackup-v2"):
             raise ValueError(f"Unsupported backup version: {version}")
-        imported = []
+
+        # ── E1 preflight: validate before any mutation ──
+        # 1. Evidence contract: hvbackup-v2 backups must carry the detached
+        #    audit integrity evidence (slice D prerequisite).
+        if version == "hvbackup-v2":
+            evidence = backup.get("audit_integrity")
+            if not isinstance(evidence, dict) or evidence.get("integrity_available") is not True:
+                raise ValueError(
+                    "Cannot restore an hvbackup-v2 backup without audit integrity evidence. "
+                    "Use a full v2 backup (with audit evidence) for restore."
+                )
+
+        # 2. Parse and validate every credential row before writing anything.
+        prepared_creds: list[tuple[CredentialRecord, CredentialRecord | None]] = []
         for cred_data in backup.get("credentials", []):
             if cred_data.get("encrypted_payload") is None:
                 raise ValueError(
@@ -1472,59 +1498,20 @@ class Vault:
                     "updated_at": utc_now(),
                     "crypto_version": incoming_version,
                 })
-            with self._connection() as conn:
-                if existing:
-                    conn.execute(
-                        """
-                        UPDATE credentials
-                        SET credential_type=?, encrypted_payload=?, status=?, scopes=?,
-                            tags=?, notes=?, updated_at=?, last_verified_at=?, imported_from=?, expiry=?, crypto_version=?
-                        WHERE id=?
-                        """,
-                        (
-                            record.credential_type,
-                            record.encrypted_payload,
-                            record.status.value,
-                            json.dumps(record.scopes),
-                            json.dumps(record.tags),
-                            record.notes,
-                            record.updated_at.isoformat(),
-                            record.last_verified_at.isoformat() if record.last_verified_at else None,
-                            record.imported_from,
-                            record.expiry.isoformat() if record.expiry else None,
-                            record.crypto_version,
-                            record.id,
-                        ),
-                    )
-                else:
-                    conn.execute(
-                        """
-                        INSERT INTO credentials (
-                            id, service, alias, credential_type, encrypted_payload, status, scopes,
-                            tags, notes, created_at, updated_at, last_verified_at, imported_from, expiry, crypto_version
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            record.id,
-                            record.service,
-                            record.alias,
-                            record.credential_type,
-                            record.encrypted_payload,
-                            record.status.value,
-                            json.dumps(record.scopes),
-                            json.dumps(record.tags),
-                            record.notes,
-                            record.created_at.isoformat(),
-                            record.updated_at.isoformat(),
-                            record.last_verified_at.isoformat() if record.last_verified_at else None,
-                            record.imported_from,
-                            record.expiry.isoformat() if record.expiry else None,
-                            record.crypto_version,
-                        ),
-                    )
-                conn.commit()
-            imported.append(record)
+            prepared_creds.append((record, existing))
 
+        # 3. Parse and validate leases: credential_id linkage must resolve to
+        #    a credential in this backup or already in the vault, and the
+        #    lease's broker identity must match the referenced credential.
+        allowed_credential_ids = {rec.id for rec, _ in prepared_creds}
+        allowed_credential_ids.update(rec.id for rec in self.list_credentials())
+        credential_identity: dict[str, CredentialRecord] = {
+            rec.id: rec for rec, _ in prepared_creds
+        }
+        for rec in self.list_credentials():
+            credential_identity.setdefault(rec.id, rec)
+
+        prepared_leases: list[tuple[LeaseRecord, LeaseRecord | None]] = []
         for lease_data in backup.get("leases", []):
             lease_id = lease_data.get("id") or str(uuid4())
             metadata = lease_data.get("metadata") or {}
@@ -1533,7 +1520,6 @@ class Vault:
             scopes = lease_data.get("scopes") or []
             if not isinstance(scopes, list):
                 scopes = [str(scopes)]
-            existing_lease = self.get_lease(lease_id)
             lease = LeaseRecord(
                 id=lease_id,
                 service=normalize(lease_data.get("service", "")),
@@ -1554,70 +1540,184 @@ class Vault:
                 scopes=[str(item) for item in scopes],
                 metadata=metadata,
             )
-            if existing_lease:
+            if lease.credential_id not in allowed_credential_ids:
+                raise ValueError(
+                    f"Lease {lease_id!r} references credential {lease.credential_id!r} "
+                    "which is not part of the backup or the vault (foreign credential linkage)."
+                )
+            referenced = credential_identity.get(lease.credential_id)
+            if referenced is not None and (
+                lease.service != referenced.service
+                or lease.alias != referenced.alias
+                or lease.credential_type != referenced.credential_type
+            ):
+                raise ValueError(
+                    f"Lease {lease_id!r} broker identity "
+                    f"({lease.service}/{lease.alias}/{lease.credential_type}) does not match "
+                    f"credential {referenced.id!r} ({referenced.service}/{referenced.alias}/{referenced.credential_type})."
+                )
+            # No active forged leases as part of import policy: a restored
+            # lease is never minted active (issue #62).
+            if lease.status is LeaseStatus.active:
+                lease = lease.model_copy(update={
+                    "status": LeaseStatus.revoked,
+                    "revoked_at": utc_now(),
+                    "reason": "restored as revoked (active leases are never restored)",
+                })
+            prepared_leases.append((lease, self.get_lease(lease_id)))
+
+        # 4. Confirm the vault's audit evidence contract is usable so the
+        #    protected restore event can be sealed in the same transaction.
+        audit_service = AuditIntegrityService(self.db_path, self.key)
+        audit_service.ensure_initialized()
+        current = audit_service.verify()
+        if current.status != AuditIntegrityStatus.healthy:
+            raise AuditIntegrityError(current.sanitized_reason)
+
+        restore_event = AccessLogRecord(
+            agent_id="operator",  # matches OPERATOR_AGENT_ID in mutations.py
+            service="*",
+            action="restore",
+            decision=Decision.allow,
+            reason=(
+                f"restored {len(prepared_creds)} credential(s) and "
+                f"{len(prepared_leases)} lease(s) from {version} backup"
+            ),
+            metadata={
+                "backup_version": version,
+                "credential_count": len(prepared_creds),
+                "lease_count": len(prepared_leases),
+            },
+        )
+
+        # ── E1 single transaction: credentials + leases + protected audit ──
+        imported: list[CredentialRecord] = []
+        try:
+            with audit_write_lock(audit_service.lock_path):
                 with self._connection() as conn:
-                    conn.execute(
-                        """
-                        UPDATE leases
-                        SET service=?, alias=?, credential_id=?, credential_type=?, agent_id=?, issued_by=?,
-                            purpose=?, status=?, ttl_seconds=?, issued_at=?, expires_at=?, revoked_at=?,
-                            renewed_at=?, renew_count=?, reason=?, scopes=?, metadata_json=?
-                        WHERE id=?
-                        """,
-                        (
-                            lease.service,
-                            lease.alias,
-                            lease.credential_id,
-                            lease.credential_type,
-                            lease.agent_id,
-                            lease.issued_by,
-                            lease.purpose,
-                            lease.status.value,
-                            lease.ttl_seconds,
-                            lease.issued_at.isoformat(),
-                            lease.expires_at.isoformat(),
-                            lease.revoked_at.isoformat() if lease.revoked_at else None,
-                            lease.renewed_at.isoformat() if lease.renewed_at else None,
-                            lease.renew_count,
-                            lease.reason,
-                            json.dumps(lease.scopes),
-                            json.dumps(lease.metadata, sort_keys=True),
-                            lease.id,
-                        ),
-                    )
-                    conn.commit()
-            else:
-                with self._connection() as conn:
-                    conn.execute(
-                        """
-                        INSERT INTO leases (
-                            id, service, alias, credential_id, credential_type, agent_id, issued_by, purpose,
-                            status, ttl_seconds, issued_at, expires_at, revoked_at, renewed_at, renew_count,
-                            reason, scopes, metadata_json
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            lease.id,
-                            lease.service,
-                            lease.alias,
-                            lease.credential_id,
-                            lease.credential_type,
-                            lease.agent_id,
-                            lease.issued_by,
-                            lease.purpose,
-                            lease.status.value,
-                            lease.ttl_seconds,
-                            lease.issued_at.isoformat(),
-                            lease.expires_at.isoformat(),
-                            lease.revoked_at.isoformat() if lease.revoked_at else None,
-                            lease.renewed_at.isoformat() if lease.renewed_at else None,
-                            lease.renew_count,
-                            lease.reason,
-                            json.dumps(lease.scopes),
-                            json.dumps(lease.metadata, sort_keys=True),
-                        ),
-                    )
-                    conn.commit()
+                    conn.row_factory = sqlite3.Row
+                    conn.execute("BEGIN IMMEDIATE")
+                    try:
+                        for record, existing in prepared_creds:
+                            if existing:
+                                conn.execute(
+                                    """
+                                    UPDATE credentials
+                                    SET credential_type=?, encrypted_payload=?, status=?, scopes=?,
+                                        tags=?, notes=?, updated_at=?, last_verified_at=?, imported_from=?, expiry=?, crypto_version=?
+                                    WHERE id=?
+                                    """,
+                                    (
+                                        record.credential_type,
+                                        record.encrypted_payload,
+                                        record.status.value,
+                                        json.dumps(record.scopes),
+                                        json.dumps(record.tags),
+                                        record.notes,
+                                        record.updated_at.isoformat(),
+                                        record.last_verified_at.isoformat() if record.last_verified_at else None,
+                                        record.imported_from,
+                                        record.expiry.isoformat() if record.expiry else None,
+                                        record.crypto_version,
+                                        record.id,
+                                    ),
+                                )
+                            else:
+                                conn.execute(
+                                    """
+                                    INSERT INTO credentials (
+                                        id, service, alias, credential_type, encrypted_payload, status, scopes,
+                                        tags, notes, created_at, updated_at, last_verified_at, imported_from, expiry, crypto_version
+                                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                    """,
+                                    (
+                                        record.id,
+                                        record.service,
+                                        record.alias,
+                                        record.credential_type,
+                                        record.encrypted_payload,
+                                        record.status.value,
+                                        json.dumps(record.scopes),
+                                        json.dumps(record.tags),
+                                        record.notes,
+                                        record.created_at.isoformat(),
+                                        record.updated_at.isoformat(),
+                                        record.last_verified_at.isoformat() if record.last_verified_at else None,
+                                        record.imported_from,
+                                        record.expiry.isoformat() if record.expiry else None,
+                                        record.crypto_version,
+                                    ),
+                                )
+                            imported.append(record)
+                        for lease, existing_lease in prepared_leases:
+                            if existing_lease:
+                                conn.execute(
+                                    """
+                                    UPDATE leases
+                                    SET service=?, alias=?, credential_id=?, credential_type=?, agent_id=?, issued_by=?,
+                                        purpose=?, status=?, ttl_seconds=?, issued_at=?, expires_at=?, revoked_at=?,
+                                        renewed_at=?, renew_count=?, reason=?, scopes=?, metadata_json=?
+                                    WHERE id=?
+                                    """,
+                                    (
+                                        lease.service,
+                                        lease.alias,
+                                        lease.credential_id,
+                                        lease.credential_type,
+                                        lease.agent_id,
+                                        lease.issued_by,
+                                        lease.purpose,
+                                        lease.status.value,
+                                        lease.ttl_seconds,
+                                        lease.issued_at.isoformat(),
+                                        lease.expires_at.isoformat(),
+                                        lease.revoked_at.isoformat() if lease.revoked_at else None,
+                                        lease.renewed_at.isoformat() if lease.renewed_at else None,
+                                        lease.renew_count,
+                                        lease.reason,
+                                        json.dumps(lease.scopes),
+                                        json.dumps(lease.metadata, sort_keys=True),
+                                        lease.id,
+                                    ),
+                                )
+                            else:
+                                conn.execute(
+                                    """
+                                    INSERT INTO leases (
+                                        id, service, alias, credential_id, credential_type, agent_id, issued_by, purpose,
+                                        status, ttl_seconds, issued_at, expires_at, revoked_at, renewed_at, renew_count,
+                                        reason, scopes, metadata_json
+                                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                    """,
+                                    (
+                                        lease.id,
+                                        lease.service,
+                                        lease.alias,
+                                        lease.credential_id,
+                                        lease.credential_type,
+                                        lease.agent_id,
+                                        lease.issued_by,
+                                        lease.purpose,
+                                        lease.status.value,
+                                        lease.ttl_seconds,
+                                        lease.issued_at.isoformat(),
+                                        lease.expires_at.isoformat(),
+                                        lease.revoked_at.isoformat() if lease.revoked_at else None,
+                                        lease.renewed_at.isoformat() if lease.renewed_at else None,
+                                        lease.renew_count,
+                                        lease.reason,
+                                        json.dumps(lease.scopes),
+                                        json.dumps(lease.metadata, sort_keys=True),
+                                    ),
+                                )
+                        append_result = audit_service.append_in_transaction(conn, restore_event)
+                        conn.commit()
+                        audit_service.write_checkpoint_after_append(conn, append_result)
+                    except Exception:
+                        conn.rollback()
+                        raise
+        except AuditLockError as exc:
+            raise AuditIntegrityError(str(exc)) from exc
         return imported
 
     def rotate_master_key(

--- a/tests/test_restore_atomicity.py
+++ b/tests/test_restore_atomicity.py
@@ -1,0 +1,299 @@
+"""Red tests for Issue #62 Slice E — atomic restore and lease identity (E1).
+
+These tests encode the failure modes the E1 change must handle and are
+intentionally RED against the current codebase:
+
+- Partial commit: a restore import that fails partway must not leave any
+  partial rows; the whole import is one transaction.
+- Forged active lease: restoring a lease that is active and would forge /
+  duplicate an existing lease identity must be rejected.
+- Foreign linkage: restored rows whose ``credential_id`` points outside the
+  allowed broker/credential set must be rejected in restore and
+  broker/read paths.
+- Broker mismatch: restore requests / broker reads whose broker identity
+  does not match the expected source/evidence contract must be rejected.
+- Audit failure atomicity: when the protected restore audit event cannot be
+  written, the entire restore transaction must roll back.
+
+After E1 is implemented every test in this file must pass.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.audit_integrity.service import AuditIntegrityError
+from hermes_vault.broker import Broker
+from hermes_vault.models import (
+    AccessLogRecord,
+    AgentPolicy,
+    Decision,
+    LeaseStatus,
+    PolicyConfig,
+    ServiceAction,
+    ServicePolicyEntry,
+    VerificationCategory,
+    VerificationResult,
+    utc_now,
+)
+from hermes_vault.policy import PolicyEngine
+from hermes_vault.vault import Vault
+
+
+PASSPHRASE = "test-passphrase"
+
+
+def _make_vault(tmp_path: Path, name: str = "vault.db", salt: str = "salt.bin") -> Vault:
+    return Vault(tmp_path / name, tmp_path / salt, PASSPHRASE)
+
+
+def _backup_dict(vault: Vault, **overrides) -> dict:
+    backup = vault.export_backup()
+    backup.update(overrides)
+    return backup
+
+
+def _write_backup(path: Path, backup: dict) -> Path:
+    path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+class StubVerifier:
+    def verify(self, service: str, secret: str) -> VerificationResult:
+        return VerificationResult(
+            service=service,
+            category=VerificationCategory.valid,
+            success=True,
+            reason="ok",
+        )
+
+
+# ── 1. Partial commit ──────────────────────────────────────────────────
+
+
+def test_restore_invalid_final_record_leaves_vault_unchanged(tmp_path: Path) -> None:
+    """A restore import that fails partway must not leave any partial rows.
+
+    Mirrors the issue's `restore_partial_commit` repro: one valid credential
+    followed by one invalid record currently leaves the first row committed.
+    E1 must make the whole import a single transaction.
+    """
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "«redacted:sk-…»", "api_key", alias="primary")
+    source.add_credential("anthropic", "«redacted:sk-ant-…»", "api_key", alias="primary")
+
+    backup = _backup_dict(source)
+    # Invalidate the FINAL credential record (missing required encrypted_payload).
+    backup["credentials"][-1].pop("encrypted_payload", None)
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    # Target vault shares the same master key so the valid record decrypts.
+    import shutil
+
+    shutil.copy(tmp_path / "src_salt.bin", tmp_path / "tgt_salt.bin")
+    vault = _make_vault(tmp_path, name="target.db", salt="tgt_salt.bin")
+
+    with pytest.raises(ValueError):
+        vault.import_backup(json.loads(backup_path.read_text(encoding="utf-8")))
+
+    # No partial rows: neither record may be present.
+    services = sorted(c.service for c in vault.list_credentials())
+    assert services == [], f"partial restore left rows behind: {services}"
+
+
+# ── 2. Forged active lease ─────────────────────────────────────────────
+
+
+def test_restore_forged_active_lease_never_active(tmp_path: Path) -> None:
+    """Restoring an active future-dated lease must not mint live authorization.
+
+    The issue's `restore_active_lease` repro imports a backup with an active
+    lease; E1 must never restore it as active (omit or force expired/revoked).
+    """
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    record = source.add_credential("openai", "«redacted:sk-…»", "api_key", alias="primary")
+
+    future = (utc_now() + timedelta(hours=1)).isoformat()
+    forged_lease = {
+        "id": "forged-active-lease",
+        "service": "openai",
+        "alias": "primary",
+        "credential_id": record.id,
+        "credential_type": "api_key",
+        "agent_id": "attacker-agent",
+        "issued_by": "attacker-agent",
+        "purpose": "task",
+        "status": "active",
+        "ttl_seconds": 3600,
+        "issued_at": utc_now().isoformat(),
+        "expires_at": future,
+    }
+    backup = _backup_dict(source, leases=[forged_lease])
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    import shutil
+
+    shutil.copy(tmp_path / "src_salt.bin", tmp_path / "tgt_salt.bin")
+    vault = _make_vault(tmp_path, name="target.db", salt="tgt_salt.bin")
+    vault.import_backup(json.loads(backup_path.read_text(encoding="utf-8")))
+
+    active = vault.find_active_lease(agent_id="attacker-agent", service="openai", alias="primary")
+    assert active is None, "restore minted an active lease from backup data"
+
+    restored = vault.get_lease("forged-active-lease")
+    if restored is not None:
+        assert restored.status is not LeaseStatus.active, "restored lease is still active"
+
+
+# ── 3. Foreign linkage (restore path) ──────────────────────────────────
+
+
+def test_restore_lease_credential_linkage_validated(tmp_path: Path) -> None:
+    """Restored rows whose credential_id points outside the allowed set are rejected.
+
+    A lease whose ``credential_id`` does not reference a credential in the
+    same backup or already in the vault must be rejected at import time.
+    """
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "«redacted:sk-…»", "api_key", alias="primary")
+
+    forged_lease = {
+        "id": "foreign-link-lease",
+        "service": "openai",
+        "alias": "primary",
+        "credential_id": "no-such-credential-id",
+        "credential_type": "api_key",
+        "agent_id": "attacker-agent",
+        "issued_by": "attacker-agent",
+        "purpose": "task",
+        "status": "active",
+        "ttl_seconds": 3600,
+        "issued_at": utc_now().isoformat(),
+        "expires_at": (utc_now() + timedelta(hours=1)).isoformat(),
+    }
+    backup = _backup_dict(source, leases=[forged_lease])
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    import shutil
+
+    shutil.copy(tmp_path / "src_salt.bin", tmp_path / "tgt_salt.bin")
+    vault = _make_vault(tmp_path, name="target.db", salt="tgt_salt.bin")
+
+    with pytest.raises(ValueError):
+        vault.import_backup(json.loads(backup_path.read_text(encoding="utf-8")))
+
+    # Nothing may be committed when a foreign linkage is present.
+    assert vault.get_lease("foreign-link-lease") is None
+    services = sorted(c.service for c in vault.list_credentials())
+    assert services == [], f"foreign-linkage restore left rows behind: {services}"
+
+
+# ── 4. Broker mismatch on read path ────────────────────────────────────
+
+
+def test_broker_denies_lease_credential_mismatch(tmp_path: Path) -> None:
+    """Broker reads must reject a lease whose identity does not match the credential.
+
+    This is the issue's `restore_active_lease` repro made red: a lease that
+    references a different credential identity than the one being served must
+    be denied instead of returning the raw secret.
+    """
+    vault = _make_vault(tmp_path)
+    record = vault.add_credential("openai", "«redacted:sk-…»", "api_key", alias="primary")
+    # Legit lease issued for the real credential.
+    lease = vault.issue_lease(record.id, agent_id="dwight", ttl_seconds=600)
+
+    # Relabel the credential row so its identity no longer matches the lease.
+    with sqlite3.connect(vault.db_path) as conn:
+        conn.execute("UPDATE credentials SET id = ? WHERE id = ?", ("relabeled-cred-id", record.id))
+        conn.commit()
+
+    policy = PolicyEngine(
+        PolicyConfig(
+            agents={
+                "dwight": AgentPolicy(
+                    services=["openai"],
+                    service_actions={
+                        "openai": ServicePolicyEntry(
+                            actions=[ServiceAction.get_env],
+                            require_lease_for_env=True,
+                        )
+                    },
+                    raw_secret_access=False,
+                    ephemeral_env_only=True,
+                    max_ttl_seconds=900,
+                )
+            }
+        )
+    )
+    broker = Broker(vault, policy, StubVerifier(), AuditLogger(tmp_path / "vault.db"))
+
+    decision = broker.get_ephemeral_env("openai", "dwight", ttl=300)
+
+    assert decision.allowed is False, (
+        f"broker accepted lease {lease.id} for a mismatched credential identity: {decision.reason}"
+    )
+    assert "lease" in decision.reason.lower() or "mismatch" in decision.reason.lower()
+
+
+# ── 5. Audit failure atomicity ─────────────────────────────────────────
+
+
+def test_restore_appends_protected_audit_event(tmp_path: Path) -> None:
+    """When the protected restore audit event cannot be written, the whole restore rolls back.
+
+    E1 writes a protected restore audit event through the shared transactional
+    seam; if that append fails, no restore changes may commit. The audit chain
+    is staled here (the repo's canonical way to make a protected append raise
+    ``AuditIntegrityError``) so the restore path must fail closed.
+    """
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "«redacted:sk-…»", "api_key", alias="primary")
+    backup = _backup_dict(source)
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    import shutil
+
+    shutil.copy(tmp_path / "src_salt.bin", tmp_path / "tgt_salt.bin")
+    vault = _make_vault(tmp_path, name="target.db", salt="tgt_salt.bin")
+
+    # Seed a healthy protected audit chain, then stale the checkpoint so the
+    # next protected append raises AuditIntegrityError (mirrors
+    # test_audit_integrity_core.py::test_stale_checkpoint_blocks_append).
+    audit = AuditLogger(vault.db_path, master_key=vault.key)
+    audit.record(
+        AccessLogRecord(
+            agent_id="operator",
+            service="*",
+            action="seed",
+            decision=Decision.allow,
+            reason="seed protected chain",
+        )
+    )
+    checkpoint_path = vault.db_path.with_name("audit.checkpoint.json")
+    original_checkpoint = checkpoint_path.read_bytes()
+    audit.record(
+        AccessLogRecord(
+            agent_id="operator",
+            service="*",
+            action="seed-2",
+            decision=Decision.allow,
+            reason="advance chain past checkpoint",
+        )
+    )
+    # Revert the checkpoint: the chain tip is now ahead of the checkpoint, so a
+    # protected append fails until an operator advances the checkpoint.
+    checkpoint_path.write_bytes(original_checkpoint)
+
+    with pytest.raises(AuditIntegrityError):
+        vault.import_backup(json.loads(backup_path.read_text(encoding="utf-8")))
+
+    # No restore changes may commit when the audit event cannot be written.
+    services = sorted(c.service for c in vault.list_credentials())
+    assert services == [], f"restore committed rows despite audit failure: {services}"

--- a/tests/test_restore_cli_gate.py
+++ b/tests/test_restore_cli_gate.py
@@ -1,0 +1,323 @@
+"""E2 CLI gate tests for Issue #62 — v2 restore gate and audit integration.
+
+These tests exercise the `restore` CLI command end-to-end (CliRunner with a
+monkeypatched build_services, mirroring test_diff.py) against the E1 atomic
+restore core. They cover:
+
+- successful restore of hvbackup-v1 and hvbackup-v2 backups
+- each E1 preflight rejection class surfaced as a distinct, non-zero exit:
+  partial-commit risk (metadata-only), foreign credential linkage, broker
+  mismatch, missing v2 evidence, audit failure
+- audit failure atomicity from the CLI: when the protected restore audit
+  event cannot be written, the restore rolls back and the CLI exits non-zero
+- the forged-active-lease class: E1 force-revokes active leases (never mints
+  them active), and the CLI surfaces a distinct notice while restoring
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+from datetime import timedelta
+from pathlib import Path
+
+from click.testing import CliRunner, Result
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.cli import _hermes_group
+from hermes_vault.models import AccessLogRecord, Decision, utc_now
+from hermes_vault.vault import Vault
+
+PASSPHRASE = "test-passphrase"
+
+
+def _make_vault(tmp_path: Path, name: str = "vault.db", salt: str = "salt.bin") -> Vault:
+    return Vault(tmp_path / name, tmp_path / salt, PASSPHRASE)
+
+
+def _fake_build(vault: Vault):
+    def _inner(prompt: bool = False):
+        return vault, object(), object(), object()
+
+    return _inner
+
+
+def _write_backup(path: Path, backup: dict) -> Path:
+    path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _restore(
+    runner: CliRunner,
+    backup_path: Path,
+    target_vault: Vault,
+    monkeypatch,
+) -> Result:
+    monkeypatch.setattr("hermes_vault.cli.build_services", _fake_build(target_vault))
+    return runner.invoke(
+        _hermes_group,
+        ["restore", "--input", str(backup_path), "--yes"],
+        catch_exceptions=False,
+    )
+
+
+def _target_with_shared_key(tmp_path: Path, source: Vault) -> Vault:
+    """Target vault sharing the source master key (same salt bytes)."""
+    shutil.copy(source.salt_path, tmp_path / "tgt_salt.bin")
+    return _make_vault(tmp_path, name="target.db", salt="tgt_salt.bin")
+
+
+# ── Successful restores ────────────────────────────────────────────────
+
+
+def test_cli_restore_v1_success(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup_path = _write_backup(tmp_path / "backup.json", source.export_backup())
+
+    target = _target_with_shared_key(tmp_path, source)
+    result = _restore(runner, backup_path, target, monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    assert "Restored 1 credential(s)" in result.output
+    services = sorted(c.service for c in target.list_credentials())
+    assert services == ["openai"]
+
+
+def test_cli_restore_v2_success(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("github", "ghp-secret", "personal_access_token", alias="primary")
+    backup_path = _write_backup(
+        tmp_path / "backup.json",
+        source.export_backup(include_audit=True),
+    )
+    assert json.loads(backup_path.read_text(encoding="utf-8"))["version"] == "hvbackup-v2"
+
+    target = _target_with_shared_key(tmp_path, source)
+    result = _restore(runner, backup_path, target, monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    services = sorted(c.service for c in target.list_credentials())
+    assert services == ["github"]
+
+    # The protected restore audit event was routed through the E1 seam and
+    # committed with the restore (action=restore, operator agent).
+    with sqlite3.connect(target.db_path) as conn:
+        rows = conn.execute("SELECT action, agent_id FROM access_logs WHERE action = 'restore'").fetchall()
+    assert rows, "no protected restore audit event written"
+    assert all(action == "restore" and agent_id == "operator" for action, agent_id in rows)
+
+
+# ── Preflight rejection classes ────────────────────────────────────────
+
+
+def test_cli_restore_metadata_only_blocked(monkeypatch, tmp_path: Path) -> None:
+    """Partial-commit risk: metadata-only backups must be blocked, not half-restored."""
+    runner = CliRunner()
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup = source.export_backup(metadata_only=True)
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    target = _target_with_shared_key(tmp_path, source)
+    result = _restore(runner, backup_path, target, monkeypatch)
+
+    assert result.exit_code == 1, result.output
+    assert "metadata-only" in result.output.lower(), result.output
+    assert target.list_credentials() == []
+
+
+def test_cli_restore_foreign_linkage_blocked(monkeypatch, tmp_path: Path) -> None:
+    """Foreign credential linkage: lease pointing outside the backup/vault is blocked."""
+    runner = CliRunner()
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    forged_lease = {
+        "id": "foreign-link-lease",
+        "service": "openai",
+        "alias": "primary",
+        "credential_id": "no-such-credential-id",
+        "credential_type": "api_key",
+        "agent_id": "attacker-agent",
+        "issued_by": "attacker-agent",
+        "purpose": "task",
+        "status": "active",
+        "ttl_seconds": 3600,
+        "issued_at": utc_now().isoformat(),
+        "expires_at": (utc_now() + timedelta(hours=1)).isoformat(),
+    }
+    backup = source.export_backup()
+    backup["leases"] = [forged_lease]
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    target = _target_with_shared_key(tmp_path, source)
+    result = _restore(runner, backup_path, target, monkeypatch)
+
+    assert result.exit_code == 1, result.output
+    assert "foreign" in result.output.lower(), result.output
+    assert target.get_lease("foreign-link-lease") is None
+    assert target.list_credentials() == []
+
+
+def test_cli_restore_broker_mismatch_blocked(monkeypatch, tmp_path: Path) -> None:
+    """Broker mismatch: lease identity not matching the referenced credential is blocked."""
+    runner = CliRunner()
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    record = source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    mismatched_lease = {
+        "id": "mismatch-lease",
+        "service": "openai",
+        "alias": "different-alias",  # does not match the referenced credential's alias
+        "credential_id": record.id,
+        "credential_type": "api_key",
+        "agent_id": "attacker-agent",
+        "issued_by": "attacker-agent",
+        "purpose": "task",
+        "status": "active",
+        "ttl_seconds": 3600,
+        "issued_at": utc_now().isoformat(),
+        "expires_at": (utc_now() + timedelta(hours=1)).isoformat(),
+    }
+    backup = source.export_backup()
+    backup["leases"] = [mismatched_lease]
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    target = _target_with_shared_key(tmp_path, source)
+    result = _restore(runner, backup_path, target, monkeypatch)
+
+    assert result.exit_code == 1, result.output
+    assert "broker mismatch" in result.output.lower(), result.output
+    assert target.get_lease("mismatch-lease") is None
+    assert target.list_credentials() == []
+
+
+def test_cli_restore_v2_missing_evidence_blocked(monkeypatch, tmp_path: Path) -> None:
+    """v2 evidence contract: a v2 backup without audit evidence cannot be restored."""
+    runner = CliRunner()
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup = source.export_backup(include_audit=True)
+    backup.pop("audit_integrity", None)
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    target = _target_with_shared_key(tmp_path, source)
+    result = _restore(runner, backup_path, target, monkeypatch)
+
+    assert result.exit_code == 1, result.output
+    assert "audit integrity evidence" in result.output.lower(), result.output
+    assert target.list_credentials() == []
+
+
+def test_cli_restore_transaction_failure_surface(monkeypatch, tmp_path: Path) -> None:
+    """Transaction failure (sqlite3.Error) is surfaced as a distinct class."""
+    runner = CliRunner()
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup_path = _write_backup(tmp_path / "backup.json", source.export_backup())
+
+    target = _target_with_shared_key(tmp_path, source)
+
+    def boom(_backup, _replace: bool = True):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(target, "import_backup", boom)
+    result = _restore(runner, backup_path, target, monkeypatch)
+
+    assert result.exit_code == 1, result.output
+    assert "transaction failure" in result.output.lower(), result.output
+
+
+# ── Audit failure atomicity from the CLI ───────────────────────────────
+
+
+def test_cli_restore_audit_failure_rolls_back(monkeypatch, tmp_path: Path) -> None:
+    """When the protected restore audit event cannot be written, the CLI restore rolls back.
+
+    Mirrors test_restore_atomicity.py::test_restore_appends_protected_audit_event
+    but driven through the CLI: the chain is staled so append_in_transaction
+    raises AuditIntegrityError, and no restore changes may commit.
+    """
+    runner = CliRunner()
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup_path = _write_backup(tmp_path / "backup.json", source.export_backup())
+
+    target = _target_with_shared_key(tmp_path, source)
+
+    # Seed a healthy protected chain, advance past the checkpoint, then revert
+    # the checkpoint so the next protected append fails (stale checkpoint).
+    audit = AuditLogger(target.db_path, master_key=target.key)
+    audit.record(
+        AccessLogRecord(
+            agent_id="operator",
+            service="*",
+            action="seed",
+            decision=Decision.allow,
+            reason="seed protected chain",
+        )
+    )
+    checkpoint_path = target.db_path.with_name("audit.checkpoint.json")
+    original_checkpoint = checkpoint_path.read_bytes()
+    audit.record(
+        AccessLogRecord(
+            agent_id="operator",
+            service="*",
+            action="seed-2",
+            decision=Decision.allow,
+            reason="advance chain past checkpoint",
+        )
+    )
+    checkpoint_path.write_bytes(original_checkpoint)
+
+    result = _restore(runner, backup_path, target, monkeypatch)
+
+    assert result.exit_code == 1, result.output
+    assert "audit" in result.output.lower(), result.output
+    assert target.list_credentials() == [], "restore committed rows despite audit failure"
+
+
+# ── Forged active lease class ──────────────────────────────────────────
+
+
+def test_cli_restore_forged_active_lease_force_revoked(monkeypatch, tmp_path: Path) -> None:
+    """Active leases in a backup are never restored as active (E1 policy).
+
+    The CLI gate surfaces a distinct notice about the force-revoke while the
+    restore itself succeeds — active lease identities are never minted (#62).
+    """
+    runner = CliRunner()
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    record = source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    active_lease = {
+        "id": "forged-active-lease",
+        "service": "openai",
+        "alias": "primary",
+        "credential_id": record.id,
+        "credential_type": "api_key",
+        "agent_id": "attacker-agent",
+        "issued_by": "attacker-agent",
+        "purpose": "task",
+        "status": "active",
+        "ttl_seconds": 3600,
+        "issued_at": utc_now().isoformat(),
+        "expires_at": (utc_now() + timedelta(hours=1)).isoformat(),
+    }
+    backup = source.export_backup()
+    backup["leases"] = [active_lease]
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    target = _target_with_shared_key(tmp_path, source)
+    result = _restore(runner, backup_path, target, monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    assert "force" in result.output.lower() and "revok" in result.output.lower(), result.output
+    active = target.find_active_lease(agent_id="attacker-agent", service="openai", alias="primary")
+    assert active is None, "restore minted an active lease from backup data"
+    restored = target.get_lease("forged-active-lease")
+    if restored is not None:
+        from hermes_vault.models import LeaseStatus
+
+        assert restored.status is not LeaseStatus.active


### PR DESCRIPTION
## Summary

Closes the P0 in the integrity recovery workstream: **#62 — atomic restore + lease identity**.

Slice E lands in two parts:

**E1 — atomic restore core (`vault.py`, `broker.py`, `audit_integrity/service.py`)**
- `import_backup` now runs a **preflight** before any mutation: v2 backups must carry detached audit integrity evidence (`integrity_available`), every credential is parsed/validated up front, restored leases are rejected if their `credential_id` does not resolve to a credential in the backup or the vault (foreign linkage), and each lease's broker identity (service/alias/credential_type) must match the referenced credential.
- Import is one **`BEGIN IMMEDIATE` transaction**: credentials + leases + a protected restore audit event through the new shared transactional seam (`AuditIntegrityService.append_in_transaction`). Any row, validation, or audit failure rolls the whole restore back — no partial rows.
- Restored active leases are **force-revoked** at import: active forged lease identities are never minted (#62).
- `Broker.get_ephemeral_env` denies when an active lease's `credential_id` no longer matches the resolved credential (forged/relabeled identity) instead of serving the raw secret.

**E2 — CLI gate (`cli.py`)**
- `restore` accepts `hvbackup-v1` and `hvbackup-v2`, invoking the E1 preflight/transactional restore.
- Distinct non-zero-exit errors per rejection class: metadata-only/partial-commit, foreign linkage, broker mismatch, missing v2 evidence, unsupported version, audit failure, transaction failure.
- Alerts on force-revoked active leases; `--dry-run` fails closed on invalid v2 evidence (aligned with `backup-verify`).

## Tests

- `tests/test_restore_atomicity.py` (5 E1 red tests): partial-commit atomicity, forged active lease, foreign linkage, broker mismatch, audit-failure rollback.
- `tests/test_restore_cli_gate.py` (9 E2 CLI tests): v1/v2 success, all rejection classes, audit-failure rollback from CLI, force-revoke notice.
- Full suite: **996 passed** (982 core + 14 plugin), ruff clean, mypy clean (62 files).

## Security impact

Closes lease-authorization injection (untrusted backup can no longer mint active leases), partial-restore corruption, and un-audited destructive restores. Combined with the Slice D detached-evidence work (#70), restores are verifiable end-to-end.

No push/PR beyond this branch; no release tag.