### PR TITLE
feat(rotation): typed rotation-journal-v2 recovery state machine (#58) (#66)

### DIFF
--- a/src/hermes_vault/audit_integrity/service.py
+++ b/src/hermes_vault/audit_integrity/service.py
@@ -18,6 +18,7 @@ from hermes_vault.audit_integrity.crypto import (
 from hermes_vault.audit_integrity.models import AuditCheckpointStatus, AuditIntegrityStatus, AuditVerificationResult
 from hermes_vault.audit_integrity.repository import access_log_payload, registry_digest, registry_rows
 from hermes_vault.audit_integrity.schema import SCHEMA_VERSION, initialize_schema
+from hermes_vault.rotation_journal import JournalPhase, RotationJournalEntry
 
 CHAIN_VERSION = "sha256-chain-v1"
 
@@ -334,6 +335,135 @@ class AuditIntegrityService:
                 except Exception:
                     self.master_key = old_key
                     raise
+
+    def recover_pending_rotation(
+        self,
+        journal: RotationJournalEntry,
+        *,
+        old_master_key: bytes,
+        new_master_key: bytes | None = None,
+    ) -> AuditVerificationResult:
+        """Reconcile the audit chain after an interrupted master-key rotation.
+
+        Implements the Slice C reconciliation seam (INTEGRITY_RECOVERY_PLAN.md
+        lines 341-345): given the typed v2 rotation journal recording the
+        *old* audit segment id, complete the audit-key transition idempotently
+        so that replaying the same journal converges to the same state and an
+        interrupted audit resumes to the same state as a clean rotation.
+
+        The journal must be in the ``db_committed``/``pending`` phase (the
+        state a rotation leaves after the credential DB commit but before the
+        audit transition completes).  Depending on what the audit chain
+        currently holds:
+
+        * active segment is still the journaled *old* segment — the segment
+          rotation never committed: close it and create its successor under
+          ``new_master_key`` with the journaled predecessor linkage, then
+          rewrite the checkpoint (the ``rotate_segment`` body, minus the
+          healthy-verify precondition that cannot hold mid-rotation);
+        * active segment is already the journaled old segment's successor —
+          the rotation committed but the checkpoint rewrite was lost: only
+          rewrite the checkpoint;
+        * anything else — contradiction: fail closed, raise, and retain the
+          journal and durable key material.
+
+        ``new_master_key`` defaults to the service's current key (the vault
+        reopens with the new passphrase).  The destructive
+        ``recover_checkpoint`` / ``_rebuild_integrity_for_key_mismatch``
+        semantics are never used.
+        """
+        self.ensure_initialized()
+        phase = journal.phase()
+        if phase == JournalPhase.started:
+            raise AuditIntegrityError(
+                "contradictory rotation journal: a 'started' journal has no audit transition to reconcile"
+            )
+        if phase == JournalPhase.checkpoint_committed:
+            # Already reconciled; replay converges to the healthy state.
+            return self.verify()
+        # phase == JournalPhase.db_committed_pending
+        if not journal.old_segment_id:
+            raise AuditIntegrityError(
+                "contradictory rotation journal: a pending journal must record the old segment id"
+            )
+        resolved_new_key = new_master_key if new_master_key is not None else self.master_key
+        journaled_old_segment_id = journal.old_segment_id
+        old_entry_pub = public_key_b64(old_master_key, ENTRY_SIGNING_CONTEXT)
+        old_checkpoint_pub = public_key_b64(old_master_key, CHECKPOINT_SIGNING_CONTEXT)
+
+        with audit_write_lock(self.lock_path):
+            with self._connection() as conn:
+                active = self._active(conn)
+                if active["segment_id"] == journaled_old_segment_id:
+                    # Rotation never reached the audit chain: complete it.
+                    if active["entry_public_key"] != old_entry_pub or active["checkpoint_public_key"] != old_checkpoint_pub:
+                        raise AuditIntegrityError(
+                            "contradictory rotation journal: the active segment is not signed by the journaled old key"
+                        )
+                    conn.execute("BEGIN IMMEDIATE")
+                    sequence, tip = self._tip(conn)
+                    now = self._now()
+                    conn.execute(
+                        "UPDATE audit_integrity_segments SET sequence_end = ?, closed_at = ? WHERE segment_id = ?",
+                        (sequence, now, active["segment_id"]),
+                    )
+                    new = self._create_segment(
+                        conn,
+                        master_key=resolved_new_key,
+                        transition_reason="master_key_rotation",
+                        sequence_start=sequence + 1,
+                        predecessor_segment_id=active["segment_id"],
+                        predecessor_tip_digest=tip,
+                    )
+                    conn.execute(
+                        "UPDATE audit_integrity_state SET active_segment_id = ?, updated_at = ? WHERE id = 1",
+                        (new["segment_id"], now),
+                    )
+                    conn.commit()
+                    previous_key = self.master_key
+                    self.master_key = resolved_new_key
+                    try:
+                        self._write_current_checkpoint(conn, new, latest_sequence=sequence, latest_digest=tip)
+                    except Exception:
+                        self.master_key = previous_key
+                        raise
+                elif active["predecessor_segment_id"] == journaled_old_segment_id:
+                    # Rotation already committed; the checkpoint write was lost.
+                    old_segment = conn.execute(
+                        "SELECT * FROM audit_integrity_segments WHERE segment_id = ?",
+                        (journaled_old_segment_id,),
+                    ).fetchone()
+                    if old_segment is None:
+                        raise AuditIntegrityError(
+                            "contradictory rotation journal: the journaled old segment is missing from the registry"
+                        )
+                    if old_segment["entry_public_key"] != old_entry_pub or old_segment["checkpoint_public_key"] != old_checkpoint_pub:
+                        raise AuditIntegrityError(
+                            "contradictory rotation journal: the journaled old segment is not signed by the journaled old key"
+                        )
+                    expected_tip = conn.execute(
+                        "SELECT entry_digest FROM audit_integrity_records WHERE segment_id = ? ORDER BY sequence DESC LIMIT 1",
+                        (journaled_old_segment_id,),
+                    ).fetchone()
+                    expected_tip_digest = str(expected_tip["entry_digest"]) if expected_tip else ""
+                    if active["predecessor_tip_digest"] != expected_tip_digest:
+                        raise AuditIntegrityError(
+                            "contradictory rotation journal: the successor predecessor tip does not match the journaled old segment"
+                        )
+                    sequence, tip = self._tip(conn)
+                    conn.commit()
+                    previous_key = self.master_key
+                    self.master_key = resolved_new_key
+                    try:
+                        self._write_current_checkpoint(conn, active, latest_sequence=sequence, latest_digest=tip)
+                    except Exception:
+                        self.master_key = previous_key
+                        raise
+                else:
+                    raise AuditIntegrityError(
+                        "contradictory rotation journal: the active segment is neither the journaled old segment nor its successor"
+                    )
+        return self.verify()
 
     def recover_checkpoint(self) -> AuditVerificationResult:
         """Start a new explicit segment; handles active_key_mismatch by rebuilding from scratch."""

--- a/src/hermes_vault/rotation_journal.py
+++ b/src/hermes_vault/rotation_journal.py
@@ -1,0 +1,966 @@
+"""Typed rotation-journal-v2 entry types and recovery/transition core (S1 seam; issues #58 / #66).
+
+The rotation journal is the durable record written by
+``Vault.rotate_master_key`` so an interrupted rotation can be recovered on
+reopen.  Version 1 stored both durable forms under the untyped fields
+``old_salt`` / ``new_salt``: a 16-byte PBKDF derivation salt for legacy
+vaults, but the raw DPAPI envelope bytes for DPAPI vaults.  Recovery code
+that always treated those bytes as a salt therefore bricked a Windows DPAPI
+vault after an interrupted rotation (issue #58).
+
+This module is the shared, internal home for the *typed* v2 journal entry
+types and the recovery/transition core (the S1 seam in
+INTEGRITY_RECOVERY_PLAN.md, Slice C):
+
+* :class:`DurableKind` — discriminator for the durable master-key
+  representation on disk (``pbkdf_salt`` | ``dpapi_envelope``).
+* :class:`DurableMaterial` — explicit typed journal entry for one durable
+  mode, discriminated by envelope kind.  A PBKDF entry must carry its
+  16-byte ``salt``; a DPAPI entry carries the ``HVDP``-prefixed envelope and
+  its envelope metadata (``envelope_version``).  Per-kind validation makes a
+  mixed entry (e.g. a DPAPI envelope with PBKDF-only salt fields, or a PBKDF
+  entry missing its required salt) unrepresentable.
+* :class:`OldKeyRecovery` — typed, encrypted recovery material for the
+  pre-rotation audit/master key.  The plaintext key is wrapped with AES-GCM
+  under the *new* master key with AAD bound to the journal id; neither a
+  passphrase nor a plaintext key is ever stored in the journal.  This is the
+  ``old_key_recovery`` field the v2 journal carries through its
+  ``db_committed`` states (issue #66: recovery must not delete the journal
+  until the audit-key transition is reconciled under the new key).
+* :class:`JournalStatus` / :class:`AuditTransitionState` /
+  :class:`JournalPhase` — the v2 state machine enums: journal phase relative
+  to the credential DB commit, audit-key transition progress, and the derived
+  recovery decision state.
+* :class:`RotationJournalEntry` — the typed v2 journal record with explicit
+  state transition helpers (``start`` / ``mark_db_committed`` /
+  ``mark_audit_checkpoint_committed`` / ``phase``).  Legal transitions are
+  enforced: ``started`` journals cannot carry audit fields, and a
+  ``db_committed`` journal with a pending audit transition must carry
+  ``old_key_recovery``.  Journal-level serialize/deserialize and v1 backward
+  reading are layered on by downstream slices; the destructive
+  ``recover_checkpoint`` / ``_rebuild_integrity_for_key_mismatch`` semantics
+  in :mod:`hermes_vault.audit_integrity.service` are deliberately untouched
+  and must not be expanded by this workstream.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+from uuid import uuid4
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from hermes_vault import _platform, dpapi
+from hermes_vault.crypto import AAD_DOMAIN, NONCE_SIZE, SALT_SIZE
+from hermes_vault.models import utc_now
+
+#: Legacy journal version label written by every pre-v2 release.
+JOURNAL_VERSION_V1 = "rotation-journal-v1"
+
+#: Version label for the typed journal produced by this core.
+JOURNAL_VERSION_V2 = "rotation-journal-v2"
+
+#: Version label for the encrypted old-key recovery envelope.
+RECOVERY_ENVELOPE_VERSION = "rotation-journal-old-key-v1"
+
+#: Allowed top-level fields in a legacy ``rotation-journal-v1`` payload.
+_V1_JOURNAL_KEYS = frozenset(
+    {
+        "version",
+        "status",
+        "old_salt",
+        "new_salt",
+        "created_at",
+        "committed_at",
+        "audit_transition_state",
+        "old_segment_id",
+    }
+)
+
+#: Allowed top-level fields in a typed ``rotation-journal-v2`` payload.
+_V2_JOURNAL_KEYS = frozenset(
+    {
+        "version",
+        "journal_id",
+        "status",
+        "old_salt",
+        "new_salt",
+        "old_durable_type",
+        "new_durable_type",
+        "old_envelope_version",
+        "new_envelope_version",
+        "created_at",
+        "committed_at",
+        "audit_transition_state",
+        "old_segment_id",
+        "old_key_recovery",
+    }
+)
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    """Parse an ISO-8601 timestamp from a journal payload.
+
+    ``model_construct`` (used for v1 backward read) skips pydantic's
+    datetime coercion, so timestamps must be normalized here.  Returns
+    ``None`` for an absent field; raises :class:`ValueError` on garbage.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(str(value))
+
+#: AAD kind/version marker for old-key recovery material.  The domain prefix
+#: is shared with credential AAD (:data:`hermes_vault.crypto.AAD_DOMAIN`) so
+#: the recovery ciphertext can never be replayed as credential AAD and vice
+#: versa (AAD reuse prevention, same rule as issue #60).
+RECOVERY_AAD_KIND = "rotation-journal-old-key"
+RECOVERY_AAD_VERSION = "v1"
+
+#: Schema label for a contradiction marker file written beside a journal.
+CONTRADICTION_MARKER_SCHEMA = "rotation-journal-contradiction-v1"
+
+
+class RotationJournalError(ValueError):
+    """Raised for malformed, contradictory, or invalid rotation journals.
+
+    When the failure is a v1/v2 contradiction, the raised instance carries a
+    :class:`ContradictionMarker` on ``marker`` describing the conflict, so
+    callers can record the marker and retain the original journal (Slice C
+    retention rule — a contradictory journal is never truncated or
+    deleted).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        marker: "ContradictionMarker | None" = None,
+    ) -> None:
+        super().__init__(message)
+        self.marker = marker
+
+
+class DurableKind(str, Enum):
+    """Discriminator for the durable master-key representation on disk.
+
+    ``pbkdf_salt`` is the legacy 16-byte derivation salt; ``dpapi_envelope``
+    is the ``HVDP``-prefixed DPAPI-wrapped key envelope.
+    """
+
+    pbkdf_salt = "pbkdf_salt"
+    dpapi_envelope = "dpapi_envelope"
+
+
+class JournalStatus(str, Enum):
+    """Journal phase relative to the credential DB commit."""
+
+    started = "started"
+    db_committed = "db_committed"
+
+
+class AuditTransitionState(str, Enum):
+    """Audit-key transition progress within a ``db_committed`` journal."""
+
+    pending = "pending"
+    checkpoint_committed = "checkpoint_committed"
+
+
+class JournalPhase(str, Enum):
+    """Derived recovery decision state for the whole state machine.
+
+    Mirrors the recovery branches in Slice C of INTEGRITY_RECOVERY_PLAN.md:
+
+    * ``started`` — pre-DB-commit: restore the old durable form, audit is
+      untouched, journal can be deleted once the old form is durable.
+    * ``db_committed_pending`` — new credential key is correct but the audit
+      transition has not committed: reconcile the audit chain under the new
+      key, keep the journal until ``verify()`` is healthy.
+    * ``checkpoint_committed`` — audit transition committed: finalize the
+      durable write, then delete the journal.
+    """
+
+    started = "started"
+    db_committed_pending = "db_committed_pending"
+    checkpoint_committed = "checkpoint_committed"
+
+
+class ContradictionKind(str, Enum):
+    """Machine-readable class of a v1/v2 journal contradiction.
+
+    ``version_conflict`` — the payload mixes v1 and v2 semantics (e.g. a
+    v1 journal carrying v2-only fields, or a v2 journal shaped like v1).
+
+    ``kind_conflict`` — the declared durable kind contradicts the stored
+    bytes (a DPAPI envelope declared as ``pbkdf_salt``, or a 16-byte salt
+    declared as ``dpapi_envelope``).
+
+    ``ambiguous_durable`` — legacy v1 bytes are neither a 16-byte PBKDF
+    salt nor a valid DPAPI envelope, so the durable kind cannot be inferred
+    without guessing.
+
+    ``state_conflict`` — the v1/v2 state fields contradict the journal's
+    phase (a ``started`` journal carrying audit/segment/committed fields,
+    or a ``db_committed`` journal missing required fields).
+    """
+
+    version_conflict = "version_conflict"
+    kind_conflict = "kind_conflict"
+    ambiguous_durable = "ambiguous_durable"
+    state_conflict = "state_conflict"
+
+
+class ContradictionMarker(BaseModel):
+    """Explicit annotation describing a v1/v2 journal contradiction.
+
+    Recorded by the retention path when a legacy v1 journal (or a v2
+    payload that mixes v1/v2 semantics) cannot be ingested without data
+    loss or guesswork.  The marker is written beside the original journal
+    (see :func:`retain_contradiction_marker`) — the original journal file
+    is never truncated or deleted, per Slice C retention rules.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: ContradictionKind
+    message: str
+    #: The journal field(s) at the center of the conflict (e.g. ``old_salt``).
+    field: str | None = None
+    #: The version label the payload declared (``rotation-journal-v1`` / ``v2``).
+    declared_version: str
+    detected_at: datetime = Field(default_factory=utc_now)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialized JSON-safe marker form."""
+        return {
+            "kind": self.kind.value,
+            "message": self.message,
+            "field": self.field,
+            "declared_version": self.declared_version,
+            "detected_at": self.detected_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> ContradictionMarker:
+        """Rebuild a marker from its serialized form."""
+        try:
+            return cls(
+                kind=ContradictionKind(payload["kind"]),
+                message=str(payload["message"]),
+                field=payload.get("field"),
+                declared_version=str(payload.get("declared_version") or JOURNAL_VERSION_V1),
+                detected_at=_parse_timestamp(payload.get("detected_at")) or utc_now(),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RotationJournalError(f"invalid contradiction marker payload: {exc}") from exc
+
+
+def retain_contradiction_marker(journal_path: Path, marker: ContradictionMarker) -> Path:
+    """Retain a contradiction marker beside *journal_path*, never touching the journal.
+
+    Writes a marker file named ``<journal>.contradiction.json`` in the same
+    directory as the original journal.  The original journal file is never
+    truncated, rewritten, or deleted — Slice C retention rule: a contradictory
+    journal is preserved for operator inspection, and the marker records the
+    conflict class, a human-readable description, and the version the payload
+    declared.  Idempotent: repeated retention for the same journal overwrites
+    the marker file (the newest detection wins) but never modifies the
+    journal itself.
+
+    Returns the marker file path.
+    """
+    marker_path = journal_path.with_name(f"{journal_path.name}.contradiction.json")
+    payload = {
+        "schema": CONTRADICTION_MARKER_SCHEMA,
+        "journal_file": journal_path.name,
+        "marker": marker.to_dict(),
+    }
+    _platform.write_text_durable(
+        marker_path,
+        json.dumps(payload, sort_keys=True, separators=(",", ":")),
+    )
+    _platform.fsync_directory(journal_path.parent)
+    return marker_path
+
+
+def load_contradiction_marker(marker_path: Path) -> ContradictionMarker:
+    """Read a contradiction marker file written by :func:`retain_contradiction_marker`.
+
+    Raises :class:`RotationJournalError` if the file is missing, is not the
+    expected schema, or carries an invalid marker payload.
+    """
+    try:
+        payload = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise RotationJournalError(
+            f"contradiction marker file {marker_path} is unreadable: {exc}"
+        ) from exc
+    if not isinstance(payload, dict) or payload.get("schema") != CONTRADICTION_MARKER_SCHEMA:
+        raise RotationJournalError(
+            f"contradiction marker file {marker_path} has an unknown schema"
+        )
+    marker_payload = payload.get("marker")
+    if not isinstance(marker_payload, dict):
+        raise RotationJournalError(
+            f"contradiction marker file {marker_path} carries no marker payload"
+        )
+    return ContradictionMarker.from_dict(marker_payload)
+
+
+def contradiction_error(
+    message: str,
+    *,
+    kind: ContradictionKind,
+    field: str | None = None,
+    declared_version: str,
+) -> RotationJournalError:
+    """Build a contradiction-class :class:`RotationJournalError` with a marker.
+
+    The marker records the machine-readable :class:`ContradictionKind`, the
+    human-readable message, the field at the center of the conflict (when
+    known), and the version label the payload declared.  Callers that ingest a
+    journal and catch this error can pass ``err.marker`` straight to
+    :func:`retain_contradiction_marker` to preserve the original journal and
+    annotate the conflict (Slice C retention rule).
+    """
+    return RotationJournalError(
+        message,
+        marker=ContradictionMarker(
+            kind=kind,
+            message=message,
+            field=field,
+            declared_version=declared_version,
+        ),
+    )
+
+
+def build_recovery_aad(journal_id: str) -> bytes:
+    """Deterministic canonical AAD for old-key recovery material.
+
+    The marker prefix separates the recovery envelope from credential AAD
+    (different kind/version), and the compact, sorted JSON body binds the
+    journal id so a recovery envelope cannot be replayed against a different
+    journal.
+    """
+    marker = f"{AAD_DOMAIN}:{RECOVERY_AAD_KIND}:{RECOVERY_AAD_VERSION}"
+    body = json.dumps(
+        {"journal_id": journal_id},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return f"{marker}:{body}".encode("utf-8")
+
+
+def looks_like_dpapi_envelope(raw: bytes) -> bool:
+    """True iff *raw* is plausibly a DPAPI envelope (not a PBKDF salt).
+
+    Uses the same strict rule as :func:`hermes_vault.dpapi.should_use_dpapi`:
+    the ``HVDP`` magic is required and the payload must be longer than the
+    4-byte header so a 16-byte random salt that happens to start with the
+    magic is never mis-detected.
+    """
+    return len(raw) > len(dpapi.DPAPI_HEADER) and raw.startswith(dpapi.DPAPI_HEADER)
+
+
+class DurableMaterial(BaseModel):
+    """Typed durable master-key material: a PBKDF salt or a DPAPI envelope.
+
+    Validation is strict and per-kind: a ``pbkdf_salt`` material must carry a
+    16-byte ``salt`` and never an envelope or DPAPI envelope metadata; a
+    ``dpapi_envelope`` material must carry an ``HVDP``-prefixed envelope
+    (longer than the header) and never a salt.  This is what makes "mixing
+    envelope kinds" unrepresentable.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: DurableKind
+    salt: bytes | None = None
+    envelope: bytes | None = None
+    #: DPAPI envelope metadata: envelope format version (e.g. ``dpapi-v1``).
+    envelope_version: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_kind_material(self) -> DurableMaterial:
+        if self.kind == DurableKind.pbkdf_salt:
+            if self.salt is None:
+                raise ValueError("pbkdf_salt durable material requires a salt")
+            if self.envelope is not None:
+                raise ValueError("pbkdf_salt durable material must not carry a DPAPI envelope")
+            if self.envelope_version is not None:
+                raise ValueError(
+                    "pbkdf_salt durable material must not carry DPAPI envelope metadata"
+                )
+            if len(self.salt) != SALT_SIZE:
+                raise ValueError(
+                    f"pbkdf salt must be {SALT_SIZE} bytes; got {len(self.salt)}"
+                )
+            return self
+        # dpapi_envelope
+        if self.envelope is None:
+            raise ValueError("dpapi_envelope durable material requires an envelope")
+        if self.salt is not None:
+            raise ValueError("dpapi_envelope durable material must not carry a PBKDF salt")
+        if not looks_like_dpapi_envelope(self.envelope):
+            raise ValueError(
+                "dpapi_envelope durable material must start with the DPAPI header "
+                "and be longer than the header"
+            )
+        if self.envelope_version is None:
+            self.envelope_version = dpapi.DPAPI_ENVELOPE_VERSION
+        return self
+
+    @property
+    def length(self) -> int | None:
+        """Byte length of the carried material (envelope only)."""
+        if self.kind == DurableKind.dpapi_envelope:
+            assert self.envelope is not None  # guaranteed by validation
+            return len(self.envelope)
+        return None
+
+    def to_hex(self) -> str:
+        """Hex of the carried bytes — the v1-compatible ``old_salt`` value."""
+        if self.kind == DurableKind.pbkdf_salt:
+            assert self.salt is not None  # guaranteed by validation
+            return self.salt.hex()
+        assert self.envelope is not None  # guaranteed by validation
+        return self.envelope.hex()
+
+    @classmethod
+    def from_hex(
+        cls,
+        kind: DurableKind | str,
+        hex_value: str,
+        *,
+        envelope_version: str | None = None,
+    ) -> DurableMaterial:
+        """Build a material from its kind discriminator plus v1 hex bytes."""
+        try:
+            raw = bytes.fromhex(hex_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"durable material is not valid hex: {exc}") from exc
+        resolved = DurableKind(kind)
+        if resolved == DurableKind.pbkdf_salt:
+            if envelope_version is not None:
+                raise ValueError(
+                    "pbkdf_salt durable material must not carry DPAPI envelope metadata"
+                )
+            return cls(kind=resolved, salt=raw)
+        return cls(kind=resolved, envelope=raw, envelope_version=envelope_version)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialized form: kind + v1-compatible hex + envelope metadata."""
+        return {
+            "kind": self.kind.value,
+            "hex": self.to_hex(),
+            "envelope_version": self.envelope_version,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> DurableMaterial:
+        try:
+            return cls.from_hex(
+                payload["kind"],
+                payload["hex"],
+                envelope_version=payload.get("envelope_version"),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RotationJournalError(f"invalid durable material payload: {exc}") from exc
+
+
+class OldKeyRecovery(BaseModel):
+    """Typed encrypted old-key recovery material.
+
+    Carries an AES-GCM wrapped copy of the pre-rotation audit/master key.
+    The wrapping key is the *new* master key and the AAD binds the journal id
+    (see :func:`encrypt_old_key_recovery`).  The journal never stores a
+    passphrase or a plaintext key.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: str = RECOVERY_ENVELOPE_VERSION
+    nonce: bytes
+    ciphertext: bytes
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> OldKeyRecovery:
+        if len(self.nonce) != NONCE_SIZE:
+            raise ValueError(
+                f"old-key recovery nonce must be {NONCE_SIZE} bytes; got {len(self.nonce)}"
+            )
+        if not self.ciphertext:
+            raise ValueError("old-key recovery ciphertext must not be empty")
+        return self
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "version": self.version,
+            "nonce": self.nonce.hex(),
+            "ciphertext": self.ciphertext.hex(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> OldKeyRecovery:
+        try:
+            return cls(
+                version=str(payload.get("version") or RECOVERY_ENVELOPE_VERSION),
+                nonce=bytes.fromhex(payload["nonce"]),
+                ciphertext=bytes.fromhex(payload["ciphertext"]),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RotationJournalError(f"invalid old_key_recovery payload: {exc}") from exc
+
+
+def encrypt_old_key_recovery(
+    old_key: bytes,
+    new_key: bytes,
+    journal_id: str,
+) -> OldKeyRecovery:
+    """Wrap *old_key* under *new_key* (KEK) with AAD bound to *journal_id*."""
+    nonce = os.urandom(NONCE_SIZE)
+    ciphertext = AESGCM(new_key).encrypt(nonce, old_key, build_recovery_aad(journal_id))
+    return OldKeyRecovery(nonce=nonce, ciphertext=ciphertext)
+
+
+def decrypt_old_key_recovery(
+    recovery: OldKeyRecovery,
+    new_key: bytes,
+    journal_id: str,
+) -> bytes:
+    """Unwrap *recovery* using *new_key*; raises on AAD/tamper mismatch."""
+    return AESGCM(new_key).decrypt(
+        recovery.nonce,
+        recovery.ciphertext,
+        build_recovery_aad(journal_id),
+    )
+
+
+class RotationJournalEntry(BaseModel):
+    """Typed rotation-journal-v2 record with state transition helpers.
+
+    The serialized shape keeps the v1-compatible ``old_salt`` / ``new_salt``
+    hex fields and adds the typed discriminators, envelope metadata, and
+    recovery material, so older readers keep working on the common fields and
+    rollback of the journal code does not orphan a v2 journal.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: str = JOURNAL_VERSION_V2
+    journal_id: str = Field(default_factory=lambda: str(uuid4()))
+    status: JournalStatus = JournalStatus.started
+    audit_transition_state: AuditTransitionState | None = None
+    old_durable: DurableMaterial
+    new_durable: DurableMaterial
+    old_key_recovery: OldKeyRecovery | None = None
+    old_segment_id: str | None = None
+    created_at: datetime = Field(default_factory=utc_now)
+    committed_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def _validate_state_machine(self) -> RotationJournalEntry:
+        if self.version != JOURNAL_VERSION_V2:
+            raise ValueError(f"unsupported journal version: {self.version!r}")
+        if self.status == JournalStatus.started:
+            if self.audit_transition_state is not None:
+                raise ValueError("a 'started' journal must not carry an audit transition state")
+            if self.old_segment_id:
+                raise ValueError("a 'started' journal must not carry an old segment id")
+            if self.committed_at is not None:
+                raise ValueError("a 'started' journal must not carry a committed_at timestamp")
+        else:  # db_committed
+            if self.audit_transition_state is None:
+                raise ValueError("a 'db_committed' journal requires an audit transition state")
+            if not self.old_segment_id:
+                raise ValueError("a 'db_committed' journal requires an old segment id")
+            if self.committed_at is None:
+                raise ValueError("a 'db_committed' journal requires a committed_at timestamp")
+            if (
+                self.audit_transition_state == AuditTransitionState.pending
+                and self.old_key_recovery is None
+            ):
+                raise ValueError(
+                    "a 'db_committed' journal with a pending audit transition "
+                    "requires old_key_recovery"
+                )
+        return self
+
+    # ── state machine helpers ─────────────────────────────────────────────
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        old_durable: DurableMaterial,
+        new_durable: DurableMaterial,
+        old_key_recovery: OldKeyRecovery | None = None,
+        journal_id: str | None = None,
+        created_at: datetime | None = None,
+    ) -> RotationJournalEntry:
+        """Create the initial ``started`` journal entry."""
+        return cls(
+            journal_id=journal_id or str(uuid4()),
+            status=JournalStatus.started,
+            old_durable=old_durable,
+            new_durable=new_durable,
+            old_key_recovery=old_key_recovery,
+            created_at=created_at or utc_now(),
+        )
+
+    def phase(self) -> JournalPhase:
+        """Derived recovery decision state (see :class:`JournalPhase`)."""
+        if self.status == JournalStatus.started:
+            return JournalPhase.started
+        if self.audit_transition_state == AuditTransitionState.checkpoint_committed:
+            return JournalPhase.checkpoint_committed
+        return JournalPhase.db_committed_pending
+
+    def mark_db_committed(
+        self,
+        *,
+        old_segment_id: str,
+        old_key_recovery: OldKeyRecovery | None = None,
+        committed_at: datetime | None = None,
+    ) -> RotationJournalEntry:
+        """Transition ``started`` -> ``db_committed``/``pending``.
+
+        Requires the encrypted old-key recovery material (the caller typically
+        stores it before the DB commit, per Slice C, so it can be passed here
+        or already present on the ``started`` entry).
+        """
+        if self.status != JournalStatus.started:
+            raise RotationJournalError(
+                f"cannot mark db_committed from phase {self.phase().value!r}"
+            )
+        recovery = old_key_recovery if old_key_recovery is not None else self.old_key_recovery
+        if recovery is None:
+            raise RotationJournalError(
+                "old_key_recovery is required before marking the journal db_committed"
+            )
+        return RotationJournalEntry(
+            version=self.version,
+            journal_id=self.journal_id,
+            status=JournalStatus.db_committed,
+            audit_transition_state=AuditTransitionState.pending,
+            old_durable=self.old_durable,
+            new_durable=self.new_durable,
+            old_key_recovery=recovery,
+            old_segment_id=old_segment_id,
+            created_at=self.created_at,
+            committed_at=committed_at or utc_now(),
+        )
+
+    def mark_audit_checkpoint_committed(
+        self,
+        *,
+        committed_at: datetime | None = None,
+    ) -> RotationJournalEntry:
+        """Transition ``db_committed``/``pending`` -> ``checkpoint_committed``."""
+        if self.phase() != JournalPhase.db_committed_pending:
+            raise RotationJournalError(
+                f"cannot mark audit checkpoint committed from phase {self.phase().value!r}"
+            )
+        return RotationJournalEntry(
+            version=self.version,
+            journal_id=self.journal_id,
+            status=self.status,
+            audit_transition_state=AuditTransitionState.checkpoint_committed,
+            old_durable=self.old_durable,
+            new_durable=self.new_durable,
+            old_key_recovery=self.old_key_recovery,
+            old_segment_id=self.old_segment_id,
+            created_at=self.created_at,
+            committed_at=committed_at or self.committed_at,
+        )
+
+    # ── journal-level serialize/deserialize and validation ─────────────
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialized JSON-safe form: v1-compatible hex plus typed fields.
+
+        Keeps the v1-compatible ``old_salt`` / ``new_salt`` hex values at the
+        top level (pre-v2 readers keep working on the common fields) and adds
+        the typed discriminators (``old_durable_type`` /
+        ``new_durable_type``), envelope metadata, and recovery material.
+        Round-trips exactly through :meth:`from_dict`.
+        """
+        payload: dict[str, Any] = {
+            "version": self.version,
+            "journal_id": self.journal_id,
+            "status": self.status.value,
+            "old_salt": self.old_durable.to_hex(),
+            "new_salt": self.new_durable.to_hex(),
+            "old_durable_type": self.old_durable.kind.value,
+            "new_durable_type": self.new_durable.kind.value,
+            "old_envelope_version": self.old_durable.envelope_version,
+            "new_envelope_version": self.new_durable.envelope_version,
+            "created_at": self.created_at.isoformat(),
+            "committed_at": self.committed_at.isoformat() if self.committed_at is not None else None,
+            "audit_transition_state": (
+                self.audit_transition_state.value
+                if self.audit_transition_state is not None
+                else None
+            ),
+            "old_segment_id": self.old_segment_id,
+            "old_key_recovery": (
+                self.old_key_recovery.to_dict() if self.old_key_recovery is not None else None
+            ),
+        }
+        return payload
+
+    def to_json(self) -> str:
+        """Deterministic JSON form of :meth:`to_dict` (canonical separators)."""
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> RotationJournalEntry:
+        """Deserialize a journal record; accepts v2 and v1 (backward read).
+
+        For ``rotation-journal-v2`` payloads the typed discriminators are
+        required, unknown keys are rejected, and each durable side is rebuilt
+        through :meth:`DurableMaterial.from_hex`, whose per-kind validation
+        rejects envelope-kind mixing (a DPAPI envelope kind over PBKDF-only
+        salt bytes, or a PBKDF entry missing its required salt).
+
+        For ``rotation-journal-v1`` payloads the durable kind is inferred
+        from the stored bytes (``HVDP`` magic + length gate) and the entry is
+        upgraded to v2 in memory; ambiguous bytes fail closed.  A v1
+        ``db_committed`` journal legitimately predates the
+        ``old_key_recovery`` material, so the v2-only state-machine invariant
+        that requires it is not applied to backward-read entries.
+
+        All invalid payloads raise :class:`RotationJournalError`.  Contradiction
+        classes (version/kind/durable/state conflicts between the payload's
+        declared semantics and its contents) raise with a
+        :class:`ContradictionMarker` attached on ``err.marker`` so callers can
+        retain the original journal and record the conflict (Slice C).
+        """
+        try:
+            version = str(payload.get("version") or JOURNAL_VERSION_V1)
+            status = str(payload.get("status") or JournalStatus.started.value)
+            old_salt = str(payload["old_salt"])
+            new_salt = str(payload["new_salt"])
+
+            if version == JOURNAL_VERSION_V2:
+                cls._reject_unknown_keys(payload, _V2_JOURNAL_KEYS, declared_version=version)
+                try:
+                    old_type = DurableKind(payload["old_durable_type"])
+                    new_type = DurableKind(payload["new_durable_type"])
+                except (KeyError, ValueError) as exc:
+                    raise contradiction_error(
+                        f"a v2 journal requires typed durable discriminators "
+                        f"(old_durable_type/new_durable_type): {exc}",
+                        kind=ContradictionKind.version_conflict,
+                        field="old_durable_type",
+                        declared_version=version,
+                    ) from exc
+                try:
+                    old_durable = DurableMaterial.from_hex(
+                        old_type,
+                        old_salt,
+                        envelope_version=payload.get("old_envelope_version"),
+                    )
+                    new_durable = DurableMaterial.from_hex(
+                        new_type,
+                        new_salt,
+                        envelope_version=payload.get("new_envelope_version"),
+                    )
+                except ValueError as exc:
+                    raise contradiction_error(
+                        f"durable material contradicts its declared kind: {exc}",
+                        kind=ContradictionKind.kind_conflict,
+                        field="old_salt",
+                        declared_version=version,
+                    ) from exc
+                recovery_payload = payload.get("old_key_recovery")
+                old_key_recovery = (
+                    OldKeyRecovery.from_dict(recovery_payload)
+                    if recovery_payload is not None
+                    else None
+                )
+                try:
+                    audit_transition_state = (
+                        AuditTransitionState(payload["audit_transition_state"])
+                        if payload.get("audit_transition_state") is not None
+                        else None
+                    )
+                    return cls(
+                        version=JOURNAL_VERSION_V2,
+                        journal_id=str(payload.get("journal_id") or ""),
+                        status=JournalStatus(status),
+                        audit_transition_state=audit_transition_state,
+                        old_durable=old_durable,
+                        new_durable=new_durable,
+                        old_key_recovery=old_key_recovery,
+                        old_segment_id=payload.get("old_segment_id"),
+                        created_at=payload.get("created_at") or utc_now(),
+                        committed_at=payload.get("committed_at"),
+                    )
+                except ValueError as exc:
+                    raise contradiction_error(
+                        f"v2 journal state contradicts its declared phase: {exc}",
+                        kind=ContradictionKind.state_conflict,
+                        field="status",
+                        declared_version=version,
+                    ) from exc
+
+            if version == JOURNAL_VERSION_V1:
+                return cls._from_v1_dict(payload, status, old_salt, new_salt)
+
+            raise contradiction_error(
+                f"unsupported journal version: {version!r}",
+                kind=ContradictionKind.version_conflict,
+                field="version",
+                declared_version=version,
+            )
+        except RotationJournalError:
+            raise
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RotationJournalError(f"invalid rotation journal payload: {exc}") from exc
+
+    @classmethod
+    def _from_v1_dict(
+        cls,
+        payload: Mapping[str, Any],
+        status: str,
+        old_salt: str,
+        new_salt: str,
+    ) -> RotationJournalEntry:
+        """Backward-read a legacy ``rotation-journal-v1`` payload.
+
+        v1 journals have no typed discriminators and no recovery material;
+        the durable kind is inferred from the stored bytes and the entry is
+        upgraded to v2 in memory.  The v2 state-machine shape is still
+        enforced (started vs db_committed field sets), but the
+        ``old_key_recovery``-for-pending invariant is deliberately not
+        applied because the material did not exist in v1 (issue #66's
+        recovery copy is a v2 addition).
+        """
+        cls._reject_unknown_keys(payload, _V1_JOURNAL_KEYS, declared_version=JOURNAL_VERSION_V1)
+        try:
+            old_durable = DurableMaterial.from_hex(cls._infer_v1_kind(old_salt), old_salt)
+            new_durable = DurableMaterial.from_hex(cls._infer_v1_kind(new_salt), new_salt)
+        except ValueError as exc:
+            raise contradiction_error(
+                f"legacy v1 durable bytes are ambiguous (neither a 16-byte "
+                f"PBKDF salt nor a valid DPAPI envelope): {exc}",
+                kind=ContradictionKind.ambiguous_durable,
+                field="old_salt",
+                declared_version=JOURNAL_VERSION_V1,
+            ) from exc
+
+        try:
+            audit_state = payload.get("audit_transition_state")
+            audit_transition_state = (
+                AuditTransitionState(audit_state) if audit_state is not None else None
+            )
+            old_segment_id = payload.get("old_segment_id")
+            committed_at = payload.get("committed_at")
+            journal_status = JournalStatus(status)
+        except ValueError as exc:
+            raise contradiction_error(
+                f"legacy v1 journal state is invalid: {exc}",
+                kind=ContradictionKind.state_conflict,
+                field="status",
+                declared_version=JOURNAL_VERSION_V1,
+            ) from exc
+
+        # Enforce the v1-visible state-machine shape (mirror of the v2
+        # validator, minus the v2-only old_key_recovery requirement).
+        if journal_status == JournalStatus.started:
+            if audit_transition_state is not None or old_segment_id or committed_at is not None:
+                raise contradiction_error(
+                    "a v1 'started' journal must not carry audit/segment/committed fields",
+                    kind=ContradictionKind.state_conflict,
+                    field="audit_transition_state",
+                    declared_version=JOURNAL_VERSION_V1,
+                )
+        else:
+            if audit_transition_state is None or not old_segment_id or committed_at is None:
+                raise contradiction_error(
+                    "a v1 'db_committed' journal requires audit_transition_state, "
+                    "old_segment_id, and committed_at",
+                    kind=ContradictionKind.state_conflict,
+                    field="old_segment_id",
+                    declared_version=JOURNAL_VERSION_V1,
+                )
+
+        try:
+            created_at = _parse_timestamp(payload.get("created_at"))
+            committed_at_dt = _parse_timestamp(committed_at)
+        except ValueError as exc:
+            raise contradiction_error(
+                f"legacy v1 journal carries an invalid timestamp: {exc}",
+                kind=ContradictionKind.state_conflict,
+                field="created_at",
+                declared_version=JOURNAL_VERSION_V1,
+            ) from exc
+
+        # model_construct skips pydantic re-validation: every field below was
+        # validated explicitly above (enums, hex materials, timestamps), and
+        # the v2 state-machine validator's old_key_recovery requirement is
+        # intentionally not applied to legacy journals.
+        return cls.model_construct(
+            version=JOURNAL_VERSION_V2,
+            journal_id=str(payload.get("journal_id") or uuid4()),
+            status=journal_status,
+            audit_transition_state=audit_transition_state,
+            old_durable=old_durable,
+            new_durable=new_durable,
+            old_key_recovery=None,
+            old_segment_id=old_segment_id,
+            created_at=created_at,
+            committed_at=committed_at_dt,
+        )
+
+    @staticmethod
+    def _reject_unknown_keys(
+        payload: Mapping[str, Any],
+        allowed: frozenset[str],
+        *,
+        declared_version: str,
+    ) -> None:
+        unknown = set(payload) - allowed
+        if unknown:
+            raise contradiction_error(
+                f"unknown rotation journal field(s) for {declared_version}: "
+                f"{', '.join(sorted(unknown))}",
+                kind=ContradictionKind.version_conflict,
+                field=sorted(unknown)[0],
+                declared_version=declared_version,
+            )
+
+    @classmethod
+    def from_json(cls, raw: str) -> RotationJournalEntry:
+        """Deserialize from a JSON string (see :meth:`from_dict`)."""
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise RotationJournalError(f"invalid rotation journal JSON: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise RotationJournalError("rotation journal JSON must be an object")
+        return cls.from_dict(payload)
+
+    @staticmethod
+    def _infer_v1_kind(hex_value: str) -> DurableKind:
+        """Infer the durable kind of a v1 journal field from its bytes.
+
+        Uses the same strict rule as :func:`looks_like_dpapi_envelope`: the
+        ``HVDP`` magic is required and the payload must be longer than the
+        4-byte header.  Anything else is treated as a PBKDF salt and the
+        subsequent :meth:`DurableMaterial.from_hex` validation fails closed
+        if the bytes are not a 16-byte salt either.
+        """
+        raw = bytes.fromhex(hex_value)
+        if looks_like_dpapi_envelope(raw):
+            return DurableKind.dpapi_envelope
+        return DurableKind.pbkdf_salt

--- a/tests/test_rotation_journal_contradiction.py
+++ b/tests/test_rotation_journal_contradiction.py
@@ -1,0 +1,332 @@
+"""Focused unit tests for v1 backward compatibility and contradiction retention.
+
+Covers the S1 shared seam from INTEGRITY_RECOVERY_PLAN.md, Slice C
+(issues #58 / #66), as scoped to this card: the v1 backward-compat read
+plus the fail-closed contradiction path that *retains* the original journal
+and records an explicit contradiction marker beside it.
+
+Acceptance covered here:
+
+* A v1 fixture reads without data loss — the legacy ``rotation-journal-v1``
+  fixture under ``tests/testdata/rotation_journal_v1.json`` (the exact shape
+  written by ``Vault.rotate_master_key`` pre-v2) deserializes through
+  ``RotationJournalEntry.from_json`` with every field preserved.
+* A contradiction leaves the original journal intact and records a clear
+  marker — for each contradiction class (version/kind/durable/state) the
+  ``RotationJournalError`` carries a :class:`ContradictionMarker` on
+  ``err.marker``; retaining that marker writes a
+  ``<journal>.contradiction.json`` file beside the original journal without
+  truncating, rewriting, or deleting the journal itself (Slice C retention
+  rule).
+* The marker file round-trips through :func:`load_contradiction_marker` and
+  the marker model serializes deterministically.
+
+The destructive ``recover_checkpoint`` /
+``_rebuild_integrity_for_key_mismatch`` semantics in
+:mod:`hermes_vault.audit_integrity.service` are intentionally not touched by
+this workstream and no test here depends on them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_vault.dpapi import DPAPI_HEADER
+from hermes_vault.rotation_journal import (
+    CONTRADICTION_MARKER_SCHEMA,
+    JOURNAL_VERSION_V1,
+    JOURNAL_VERSION_V2,
+    AuditTransitionState,
+    ContradictionKind,
+    ContradictionMarker,
+    DurableKind,
+    JournalStatus,
+    RotationJournalEntry,
+    RotationJournalError,
+    contradiction_error,
+    load_contradiction_marker,
+    retain_contradiction_marker,
+)
+
+TESTDATA = Path(__file__).resolve().parent / "testdata"
+V1_FIXTURE = TESTDATA / "rotation_journal_v1.json"
+
+
+def _v1_payload(*, old_hex: str, new_hex: str, status: str = "started") -> dict[str, str]:
+    payload: dict[str, str] = {
+        "version": JOURNAL_VERSION_V1,
+        "status": status,
+        "old_salt": old_hex,
+        "new_salt": new_hex,
+        "created_at": "2026-08-05T12:00:00+00:00",
+    }
+    if status == "db_committed":
+        payload["committed_at"] = "2026-08-05T12:01:00+00:00"
+        payload["audit_transition_state"] = "pending"
+        payload["old_segment_id"] = "seg-1"
+    return payload
+
+
+# ── acceptance: a v1 fixture reads without data loss ───────────────────
+
+
+def test_v1_fixture_reads_without_data_loss() -> None:
+    raw = V1_FIXTURE.read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    entry = RotationJournalEntry.from_json(raw)
+
+    # Upgraded in memory but every v1 field survives exactly.
+    assert entry.version == JOURNAL_VERSION_V2
+    assert entry.status == JournalStatus.db_committed
+    assert entry.audit_transition_state == AuditTransitionState.pending
+    assert entry.old_segment_id == payload["old_segment_id"]
+    assert entry.to_dict()["old_salt"] == payload["old_salt"]
+    assert entry.to_dict()["new_salt"] == payload["new_salt"]
+    assert entry.created_at.isoformat() == payload["created_at"]
+    assert entry.committed_at is not None
+    assert entry.committed_at.isoformat() == payload["committed_at"]
+    assert entry.old_durable.kind == DurableKind.pbkdf_salt
+    assert entry.new_durable.kind == DurableKind.pbkdf_salt
+
+
+def test_v1_fixture_ingests_into_state_machine() -> None:
+    raw = V1_FIXTURE.read_text(encoding="utf-8")
+    entry = RotationJournalEntry.from_json(raw)
+    # The upgraded entry participates in the v2 state machine: phase
+    # derivation works, and the pending transition can move forward.
+    from hermes_vault.rotation_journal import JournalPhase
+
+    assert entry.phase() == JournalPhase.db_committed_pending
+    committed = entry.mark_audit_checkpoint_committed()
+    assert committed.audit_transition_state == AuditTransitionState.checkpoint_committed
+    assert committed.phase() == JournalPhase.checkpoint_committed
+    # The v1-sourced entry keeps its original identity and segment linkage.
+    assert committed.old_segment_id == entry.old_segment_id
+    assert committed.created_at == entry.created_at
+
+
+def test_v1_fixture_upgraded_entry_is_not_repersisted_as_v2_without_recovery() -> None:
+    # A v1 db_committed/pending journal predates old_key_recovery, so the
+    # in-memory upgrade carries none; serializing it back as v2 JSON and
+    # re-reading must fail closed (v2 invariant: pending requires recovery
+    # material) rather than silently manufacturing a v2 journal that the
+    # recovery flow would trust.
+    raw = V1_FIXTURE.read_text(encoding="utf-8")
+    entry = RotationJournalEntry.from_json(raw)
+    assert entry.old_key_recovery is None
+    with pytest.raises(RotationJournalError, match="requires old_key_recovery"):
+        RotationJournalEntry.from_json(entry.to_json())
+
+
+# ── contradiction classes carry a marker on the error ──────────────────
+
+
+def test_v1_ambiguous_durable_error_carries_marker() -> None:
+    payload = _v1_payload(old_hex=os.urandom(12).hex(), new_hex=os.urandom(12).hex())
+    with pytest.raises(RotationJournalError) as excinfo:
+        RotationJournalEntry.from_dict(payload)
+    assert excinfo.value.marker is not None
+    assert excinfo.value.marker.kind == ContradictionKind.ambiguous_durable
+    assert excinfo.value.marker.declared_version == JOURNAL_VERSION_V1
+    assert excinfo.value.marker.field == "old_salt"
+
+
+def test_v1_state_conflict_error_carries_marker() -> None:
+    payload = _v1_payload(old_hex=os.urandom(16).hex(), new_hex=os.urandom(16).hex())
+    payload["audit_transition_state"] = "pending"  # illegal on a started journal
+    with pytest.raises(RotationJournalError) as excinfo:
+        RotationJournalEntry.from_dict(payload)
+    assert excinfo.value.marker is not None
+    assert excinfo.value.marker.kind == ContradictionKind.state_conflict
+    assert excinfo.value.marker.declared_version == JOURNAL_VERSION_V1
+
+
+def test_v1_with_v2_only_fields_error_carries_marker() -> None:
+    # A v1 payload carrying a v2-only typed discriminator mixes v1/v2
+    # semantics -> version_conflict with a marker (Slice C retention).
+    payload = _v1_payload(old_hex=os.urandom(16).hex(), new_hex=os.urandom(16).hex())
+    payload["old_durable_type"] = DurableKind.pbkdf_salt.value
+    with pytest.raises(RotationJournalError) as excinfo:
+        RotationJournalEntry.from_dict(payload)
+    assert excinfo.value.marker is not None
+    assert excinfo.value.marker.kind == ContradictionKind.version_conflict
+    assert excinfo.value.marker.declared_version == JOURNAL_VERSION_V1
+    assert excinfo.value.marker.field == "old_durable_type"
+
+
+def test_v2_kind_conflict_error_carries_marker() -> None:
+    payload = {
+        "version": JOURNAL_VERSION_V2,
+        "status": "started",
+        "old_salt": os.urandom(16).hex(),
+        "new_salt": os.urandom(16).hex(),
+        "old_durable_type": DurableKind.dpapi_envelope.value,
+        "new_durable_type": DurableKind.dpapi_envelope.value,
+    }
+    with pytest.raises(RotationJournalError) as excinfo:
+        RotationJournalEntry.from_dict(payload)
+    assert excinfo.value.marker is not None
+    assert excinfo.value.marker.kind == ContradictionKind.kind_conflict
+    assert excinfo.value.marker.declared_version == JOURNAL_VERSION_V2
+
+
+def test_unknown_version_error_carries_marker() -> None:
+    payload = {
+        "version": "rotation-journal-v3",
+        "status": "started",
+        "old_salt": os.urandom(16).hex(),
+        "new_salt": os.urandom(16).hex(),
+        "old_durable_type": DurableKind.pbkdf_salt.value,
+        "new_durable_type": DurableKind.pbkdf_salt.value,
+    }
+    with pytest.raises(RotationJournalError) as excinfo:
+        RotationJournalEntry.from_dict(payload)
+    assert excinfo.value.marker is not None
+    assert excinfo.value.marker.kind == ContradictionKind.version_conflict
+    assert excinfo.value.marker.declared_version == "rotation-journal-v3"
+
+
+def test_contradiction_error_helper_attaches_marker() -> None:
+    err = contradiction_error(
+        "boom",
+        kind=ContradictionKind.state_conflict,
+        field="status",
+        declared_version=JOURNAL_VERSION_V1,
+    )
+    assert isinstance(err, RotationJournalError)
+    assert err.marker is not None
+    assert err.marker.kind == ContradictionKind.state_conflict
+    assert err.marker.field == "status"
+    assert err.marker.declared_version == JOURNAL_VERSION_V1
+    assert "boom" in err.marker.message
+
+
+# ── retention: original journal intact + clear marker written ──────────
+
+
+def test_retain_marker_keeps_journal_byte_identical(tmp_path: Path) -> None:
+    journal_path = tmp_path / "rotation-journal.json"
+    original = json.dumps(
+        _v1_payload(old_hex=os.urandom(12).hex(), new_hex=os.urandom(12).hex()),
+        sort_keys=True,
+    )
+    journal_path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(RotationJournalError) as excinfo:
+        RotationJournalEntry.from_json(original)
+    assert excinfo.value.marker is not None
+
+    marker_path = retain_contradiction_marker(journal_path, excinfo.value.marker)
+
+    # The original journal is untouched — never truncated or deleted.
+    assert journal_path.read_text(encoding="utf-8") == original
+    assert journal_path.exists()
+
+    # The marker file records the conflict beside the journal.
+    assert marker_path == journal_path.with_name(f"{journal_path.name}.contradiction.json")
+    marker_payload = json.loads(marker_path.read_text(encoding="utf-8"))
+    assert marker_payload["schema"] == CONTRADICTION_MARKER_SCHEMA
+    assert marker_payload["journal_file"] == journal_path.name
+    assert marker_payload["marker"]["kind"] == ContradictionKind.ambiguous_durable.value
+    assert marker_payload["marker"]["declared_version"] == JOURNAL_VERSION_V1
+    assert "message" in marker_payload["marker"]
+    assert "detected_at" in marker_payload["marker"]
+
+
+def test_load_marker_round_trip(tmp_path: Path) -> None:
+    marker = ContradictionMarker(
+        kind=ContradictionKind.kind_conflict,
+        message="declared dpapi over pbkdf bytes",
+        field="old_salt",
+        declared_version=JOURNAL_VERSION_V2,
+    )
+    journal_path = tmp_path / "rotation-journal.json"
+    marker_path = retain_contradiction_marker(journal_path, marker)
+    loaded = load_contradiction_marker(marker_path)
+    assert loaded == marker
+    assert loaded.kind == ContradictionKind.kind_conflict
+    assert loaded.field == "old_salt"
+    assert loaded.declared_version == JOURNAL_VERSION_V2
+    assert loaded.message == marker.message
+
+
+def test_marker_dict_round_trip() -> None:
+    marker = ContradictionMarker(
+        kind=ContradictionKind.version_conflict,
+        message="mixed semantics",
+        field="version",
+        declared_version=JOURNAL_VERSION_V1,
+    )
+    restored = ContradictionMarker.from_dict(marker.to_dict())
+    assert restored == marker
+
+
+def test_load_marker_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(RotationJournalError, match="unreadable"):
+        load_contradiction_marker(tmp_path / "nope.json")
+
+
+def test_load_marker_rejects_unknown_schema(tmp_path: Path) -> None:
+    marker_path = tmp_path / "bad.json"
+    marker_path.write_text('{"schema": "something-else"}', encoding="utf-8")
+    with pytest.raises(RotationJournalError, match="unknown schema"):
+        load_contradiction_marker(marker_path)
+
+
+def test_load_marker_rejects_invalid_payload(tmp_path: Path) -> None:
+    marker_path = tmp_path / "bad.json"
+    marker_path.write_text(
+        json.dumps({"schema": CONTRADICTION_MARKER_SCHEMA, "marker": {"kind": "nope"}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(RotationJournalError, match="invalid contradiction marker payload"):
+        load_contradiction_marker(marker_path)
+
+
+# ── retention is idempotent: newest detection wins, journal never touched ─
+
+
+def test_retain_marker_idempotent_overwrites_sidecar_only(tmp_path: Path) -> None:
+    journal_path = tmp_path / "rotation-journal.json"
+    original = json.dumps(
+        _v1_payload(old_hex=os.urandom(12).hex(), new_hex=os.urandom(12).hex()),
+        sort_keys=True,
+    )
+    journal_path.write_text(original, encoding="utf-8")
+
+    first = ContradictionMarker(
+        kind=ContradictionKind.ambiguous_durable,
+        message="first detection",
+        declared_version=JOURNAL_VERSION_V1,
+    )
+    retain_contradiction_marker(journal_path, first)
+    second = ContradictionMarker(
+        kind=ContradictionKind.state_conflict,
+        message="second detection",
+        field="status",
+        declared_version=JOURNAL_VERSION_V1,
+    )
+    marker_path = retain_contradiction_marker(journal_path, second)
+
+    assert journal_path.read_text(encoding="utf-8") == original
+    loaded = load_contradiction_marker(marker_path)
+    assert loaded.kind == ContradictionKind.state_conflict
+    assert loaded.message == "second detection"
+
+
+# ── v1 fixture sanity: DPAPI inference on the fixture's sibling payloads ─
+
+
+def test_v1_dpapi_envelope_bytes_infer_dpapi_kind() -> None:
+    envelope = DPAPI_HEADER + os.urandom(24)
+    salt = os.urandom(16)
+    payload = _v1_payload(old_hex=envelope.hex(), new_hex=salt.hex())
+    entry = RotationJournalEntry.from_dict(payload)
+    assert entry.old_durable.kind == DurableKind.dpapi_envelope
+    assert entry.old_durable.envelope == envelope
+    assert entry.new_durable.kind == DurableKind.pbkdf_salt
+    assert entry.new_durable.salt == salt

--- a/tests/test_rotation_journal_deterministic.py
+++ b/tests/test_rotation_journal_deterministic.py
@@ -1,0 +1,625 @@
+"""Deterministic rotation-journal-v2 tests (Slice C, issues #58 / #66).
+
+This file is the deterministic-test lane for the typed journal-v2 state
+machine: every input is a fixed byte constant or a fixed string — no
+``os.urandom``, no wall-clock dependence, and no OS-specific behavior.
+The DPAPI envelope entries are tested through an *injectable envelope*
+strategy: the journal only validates the envelope *shape* (``HVDP`` magic
+plus a length gate) and never calls the Windows-only ``win32crypt``, so
+tests feed fixed synthetic envelopes and get byte-identical behavior on
+every platform, every run.
+
+Coverage mapped to the card:
+
+* DPAPI envelope entries — typed ``DurableMaterial`` with fixed envelope
+  bytes, hex/dict round trips, envelope-kind rejection.
+* PBKDF salt entries — fixed 16-byte salts, hex/dict round trips, salt
+  size/kind rejection.
+* Encrypted old-key recovery material — fixed old/new keys and journal id,
+  plus an injected fixed nonce so the ciphertext is byte-deterministic;
+  tamper/wrong-journal failures.
+* Legacy v1 read — the checked-in ``rotation_journal_v1.json`` fixture and
+  fixed inline v1 payloads, including DPAPI-envelope inference from bytes.
+* Contradiction retention — fixed contradictory payloads produce a typed
+  ``ContradictionMarker``; retaining the marker never touches the journal.
+* Interrupted-audit reconciliation — fixed master keys drive the real
+  ``AuditIntegrityService``; the replay regression proves replaying the
+  same journal converges to the same state (no duplicate successor), and a
+  lost-checkpoint interrupted audit resumes to the clean-rotation state.
+
+The destructive ``recover_checkpoint`` /
+``_rebuild_integrity_for_key_mismatch`` semantics in
+:mod:`hermes_vault.audit_integrity.service` are intentionally not touched.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.audit_integrity.service import AuditIntegrityError, AuditIntegrityService
+from hermes_vault.dpapi import DPAPI_ENVELOPE_VERSION, DPAPI_HEADER
+from hermes_vault.models import AccessLogRecord, Decision
+from hermes_vault.rotation_journal import (
+    JOURNAL_VERSION_V1,
+    JOURNAL_VERSION_V2,
+    AuditTransitionState,
+    ContradictionKind,
+    DurableKind,
+    DurableMaterial,
+    JournalPhase,
+    JournalStatus,
+    RotationJournalEntry,
+    RotationJournalError,
+    decrypt_old_key_recovery,
+    encrypt_old_key_recovery,
+    load_contradiction_marker,
+    retain_contradiction_marker,
+)
+
+TESTDATA = Path(__file__).resolve().parent / "testdata"
+V1_FIXTURE = TESTDATA / "rotation_journal_v1.json"
+
+# ── Fixed inputs (no os.urandom anywhere in this file) ──────────────────────
+
+#: Fixed 16-byte PBKDF derivation salt.
+SALT_A = bytes.fromhex("00112233445566778899aabbccddeeff")
+#: A second fixed 16-byte PBKDF derivation salt.
+SALT_B = bytes.fromhex("ffeeddccbbaa99887766554433221100")
+#: Fixed DPAPI envelope: 4-byte ``HVDP`` magic + 24 fixed payload bytes.
+ENVELOPE_A = DPAPI_HEADER + bytes(range(24))
+#: A second fixed DPAPI envelope.
+ENVELOPE_B = DPAPI_HEADER + bytes(range(24, 48))
+#: Fixed 32-byte pre-rotation (old) master key.
+OLD_KEY = bytes(range(32))
+#: Fixed 32-byte post-rotation (new) master key.
+NEW_KEY = bytes(range(32, 64))
+#: Fixed 12-byte AES-GCM nonce injected via monkeypatch for ciphertext determinism.
+FIXED_NONCE = bytes(range(12))
+#: Fixed journal id used across deterministic entries.
+JOURNAL_ID = "det-journal-0001"
+#: Fixed audit segment id used by deterministic reconcile fixtures.
+OLD_SEGMENT_ID = "seg-det-0001"
+#: Fixed ISO timestamps so serialized journals are byte-stable.
+CREATED_AT = "2026-08-06T00:00:00+00:00"
+COMMITTED_AT = "2026-08-06T00:01:00+00:00"
+
+
+def _pbkdf_material(salt: bytes = SALT_A) -> DurableMaterial:
+    return DurableMaterial(kind=DurableKind.pbkdf_salt, salt=salt)
+
+
+def _dpapi_material(envelope: bytes = ENVELOPE_A) -> DurableMaterial:
+    return DurableMaterial(kind=DurableKind.dpapi_envelope, envelope=envelope)
+
+
+def _started_entry() -> RotationJournalEntry:
+    return RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+        journal_id=JOURNAL_ID,
+        created_at=__import__("datetime").datetime.fromisoformat(CREATED_AT),
+    )
+
+
+def _recovery() -> object:
+    return encrypt_old_key_recovery(OLD_KEY, NEW_KEY, JOURNAL_ID)
+
+
+# ── DPAPI envelope entries (injectable envelope: fixed bytes, no win32crypt) ─
+
+
+def test_dpapi_envelope_entry_dict_round_trip_deterministic() -> None:
+    material = _dpapi_material(ENVELOPE_A)
+    assert material.kind == DurableKind.dpapi_envelope
+    assert material.envelope == ENVELOPE_A
+    assert material.envelope_version == DPAPI_ENVELOPE_VERSION
+
+    payload = material.to_dict()
+    assert payload == {
+        "kind": "dpapi_envelope",
+        "hex": ENVELOPE_A.hex(),
+        "envelope_version": DPAPI_ENVELOPE_VERSION,
+    }
+    restored = DurableMaterial.from_dict(payload)
+    assert restored == material
+    assert restored.envelope == ENVELOPE_A
+    assert restored.envelope_version == DPAPI_ENVELOPE_VERSION
+
+
+def test_dpapi_envelope_entry_hex_round_trip_deterministic() -> None:
+    material = _dpapi_material(ENVELOPE_B)
+    assert material.to_hex() == ENVELOPE_B.hex()
+    restored = DurableMaterial.from_hex(
+        DurableKind.dpapi_envelope,
+        material.to_hex(),
+        envelope_version=DPAPI_ENVELOPE_VERSION,
+    )
+    assert restored.envelope == ENVELOPE_B
+    assert restored.envelope_version == DPAPI_ENVELOPE_VERSION
+
+
+def test_dpapi_envelope_kind_rejects_pbkdf_salt_bytes() -> None:
+    # A DPAPI envelope kind over a plain 16-byte salt is unrepresentable.
+    with pytest.raises(ValueError, match="must start with the DPAPI header"):
+        DurableMaterial(kind=DurableKind.dpapi_envelope, envelope=SALT_A)
+
+
+def test_dpapi_envelope_kind_rejects_header_only() -> None:
+    with pytest.raises(ValueError, match="longer than the header"):
+        DurableMaterial(kind=DurableKind.dpapi_envelope, envelope=DPAPI_HEADER)
+
+
+def test_dpapi_envelope_kind_rejects_salt_field() -> None:
+    with pytest.raises(ValueError, match="must not carry a PBKDF salt"):
+        DurableMaterial(kind=DurableKind.dpapi_envelope, envelope=ENVELOPE_A, salt=SALT_A)
+
+
+def test_dpapi_envelope_journal_round_trip_preserves_bytes() -> None:
+    entry = RotationJournalEntry.start(
+        old_durable=_dpapi_material(ENVELOPE_A),
+        new_durable=_dpapi_material(ENVELOPE_B),
+        journal_id=JOURNAL_ID,
+    )
+    restored = RotationJournalEntry.from_dict(entry.to_dict())
+    assert restored == entry
+    assert restored.old_durable.envelope == ENVELOPE_A
+    assert restored.new_durable.envelope == ENVELOPE_B
+    assert restored.to_json() == entry.to_json()  # byte-stable serialization
+
+
+# ── PBKDF salt entries ──────────────────────────────────────────────────────
+
+
+def test_pbkdf_salt_entry_dict_round_trip_deterministic() -> None:
+    material = _pbkdf_material(SALT_A)
+    assert material.salt == SALT_A
+    assert material.envelope is None
+    assert material.envelope_version is None
+
+    payload = material.to_dict()
+    assert payload == {"kind": "pbkdf_salt", "hex": SALT_A.hex(), "envelope_version": None}
+    restored = DurableMaterial.from_dict(payload)
+    assert restored == material
+    assert restored.salt == SALT_A
+
+
+def test_pbkdf_salt_entry_hex_round_trip_deterministic() -> None:
+    material = _pbkdf_material(SALT_B)
+    assert material.to_hex() == SALT_B.hex()
+    restored = DurableMaterial.from_hex(DurableKind.pbkdf_salt, material.to_hex())
+    assert restored.salt == SALT_B
+
+
+def test_pbkdf_salt_kind_rejects_envelope_bytes() -> None:
+    # Reverse mixing direction: a PBKDF kind over DPAPI envelope bytes fails.
+    with pytest.raises(ValueError, match="must be 16 bytes"):
+        DurableMaterial(kind=DurableKind.pbkdf_salt, salt=ENVELOPE_A)
+
+
+def test_pbkdf_salt_kind_rejects_wrong_size() -> None:
+    with pytest.raises(ValueError, match="must be 16 bytes"):
+        DurableMaterial(kind=DurableKind.pbkdf_salt, salt=SALT_A[:12])
+
+
+def test_pbkdf_salt_kind_rejects_envelope_field() -> None:
+    with pytest.raises(ValueError, match="must not carry a DPAPI envelope"):
+        DurableMaterial(kind=DurableKind.pbkdf_salt, salt=SALT_A, envelope=ENVELOPE_A)
+
+
+def test_pbkdf_salt_kind_rejects_envelope_metadata() -> None:
+    with pytest.raises(ValueError, match="must not carry DPAPI envelope metadata"):
+        DurableMaterial(kind=DurableKind.pbkdf_salt, salt=SALT_A, envelope_version="dpapi-v1")
+
+
+def test_pbkdf_salt_journal_round_trip_preserves_salt() -> None:
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(SALT_A),
+        new_durable=_pbkdf_material(SALT_B),
+        journal_id=JOURNAL_ID,
+    )
+    restored = RotationJournalEntry.from_dict(entry.to_dict())
+    assert restored == entry
+    assert restored.old_durable.salt == SALT_A
+    assert restored.new_durable.salt == SALT_B
+
+
+# ── Encrypted old-key recovery material ─────────────────────────────────────
+
+
+def test_recovery_encrypt_decrypt_round_trip_fixed_keys() -> None:
+    recovery = encrypt_old_key_recovery(OLD_KEY, NEW_KEY, JOURNAL_ID)
+    assert decrypt_old_key_recovery(recovery, NEW_KEY, JOURNAL_ID) == OLD_KEY
+
+
+def test_recovery_never_stores_plaintext_key() -> None:
+    recovery = encrypt_old_key_recovery(OLD_KEY, NEW_KEY, JOURNAL_ID)
+    assert recovery.ciphertext != OLD_KEY
+    assert OLD_KEY not in recovery.ciphertext
+    payload = recovery.to_dict()
+    assert payload["ciphertext"] != OLD_KEY.hex()
+    assert "passphrase" not in payload
+    assert "key" not in payload
+
+
+def test_recovery_deterministic_with_injected_nonce(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Inject a fixed nonce so the AES-GCM output is byte-deterministic:
+    # same keys + same journal id + same nonce -> identical ciphertext.
+    monkeypatch.setattr("os.urandom", lambda n: FIXED_NONCE[:n])
+    first = encrypt_old_key_recovery(OLD_KEY, NEW_KEY, JOURNAL_ID)
+    second = encrypt_old_key_recovery(OLD_KEY, NEW_KEY, JOURNAL_ID)
+    assert first.nonce == FIXED_NONCE
+    assert first.ciphertext == second.ciphertext
+    # And the deterministic envelope still decrypts to the old key.
+    assert decrypt_old_key_recovery(first, NEW_KEY, JOURNAL_ID) == OLD_KEY
+
+
+def test_recovery_wrong_key_fails_fixed() -> None:
+    recovery = encrypt_old_key_recovery(OLD_KEY, NEW_KEY, JOURNAL_ID)
+    with pytest.raises(InvalidTag):
+        decrypt_old_key_recovery(recovery, OLD_KEY, JOURNAL_ID)
+
+
+def test_recovery_wrong_journal_id_fails_fixed() -> None:
+    recovery = encrypt_old_key_recovery(OLD_KEY, NEW_KEY, JOURNAL_ID)
+    with pytest.raises(InvalidTag):
+        decrypt_old_key_recovery(recovery, NEW_KEY, "det-journal-9999")
+
+
+def test_recovery_tampered_ciphertext_fails_fixed() -> None:
+    recovery = encrypt_old_key_recovery(OLD_KEY, NEW_KEY, JOURNAL_ID)
+    tampered = recovery.model_copy(
+        update={"ciphertext": recovery.ciphertext[:-1] + bytes([recovery.ciphertext[-1] ^ 0x01])}
+    )
+    with pytest.raises(InvalidTag):
+        decrypt_old_key_recovery(tampered, NEW_KEY, JOURNAL_ID)
+
+
+def test_recovery_round_trip_through_journal_state() -> None:
+    entry = _started_entry()
+    recovery = encrypt_old_key_recovery(OLD_KEY, NEW_KEY, entry.journal_id)
+    committed = entry.mark_db_committed(
+        old_segment_id=OLD_SEGMENT_ID,
+        old_key_recovery=recovery,
+        committed_at=__import__("datetime").datetime.fromisoformat(COMMITTED_AT),
+    )
+    assert committed.phase() == JournalPhase.db_committed_pending
+    assert committed.old_key_recovery is not None
+    assert decrypt_old_key_recovery(committed.old_key_recovery, NEW_KEY, committed.journal_id) == OLD_KEY
+    restored = RotationJournalEntry.from_dict(committed.to_dict())
+    assert restored.old_key_recovery is not None
+    assert decrypt_old_key_recovery(restored.old_key_recovery, NEW_KEY, restored.journal_id) == OLD_KEY
+
+
+# ── Legacy v1 read ──────────────────────────────────────────────────────────
+
+
+def test_v1_fixture_reads_without_data_loss_deterministic() -> None:
+    raw = V1_FIXTURE.read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    entry = RotationJournalEntry.from_json(raw)
+
+    assert entry.version == JOURNAL_VERSION_V2  # upgraded in memory
+    assert entry.status == JournalStatus.db_committed
+    assert entry.audit_transition_state == AuditTransitionState.pending
+    assert entry.old_segment_id == payload["old_segment_id"]
+    assert entry.to_dict()["old_salt"] == payload["old_salt"]
+    assert entry.to_dict()["new_salt"] == payload["new_salt"]
+    assert entry.created_at.isoformat() == payload["created_at"]
+    assert entry.committed_at is not None
+    assert entry.committed_at.isoformat() == payload["committed_at"]
+    assert entry.old_durable.kind == DurableKind.pbkdf_salt
+    assert entry.old_durable.salt == bytes.fromhex(payload["old_salt"])
+    assert entry.new_durable.kind == DurableKind.pbkdf_salt
+
+
+def _v1_payload(*, old_hex: str, new_hex: str, status: str = "started") -> dict[str, str]:
+    payload: dict[str, str] = {
+        "version": JOURNAL_VERSION_V1,
+        "status": status,
+        "old_salt": old_hex,
+        "new_salt": new_hex,
+        "created_at": CREATED_AT,
+    }
+    if status == "db_committed":
+        payload["committed_at"] = COMMITTED_AT
+        payload["audit_transition_state"] = "pending"
+        payload["old_segment_id"] = OLD_SEGMENT_ID
+    return payload
+
+
+def test_v1_pbkdf_backward_read_fixed() -> None:
+    payload = _v1_payload(old_hex=SALT_A.hex(), new_hex=SALT_B.hex())
+    entry = RotationJournalEntry.from_dict(payload)
+    assert entry.version == JOURNAL_VERSION_V2
+    assert entry.status == JournalStatus.started
+    assert entry.old_durable.kind == DurableKind.pbkdf_salt
+    assert entry.old_durable.salt == SALT_A
+    assert entry.new_durable.salt == SALT_B
+    assert entry.to_dict()["old_salt"] == SALT_A.hex()  # hex preserved exactly
+
+
+def test_v1_dpapi_envelope_backward_read_infers_kind_fixed() -> None:
+    payload = _v1_payload(old_hex=ENVELOPE_A.hex(), new_hex=SALT_A.hex())
+    entry = RotationJournalEntry.from_dict(payload)
+    assert entry.old_durable.kind == DurableKind.dpapi_envelope
+    assert entry.old_durable.envelope == ENVELOPE_A
+    assert entry.new_durable.kind == DurableKind.pbkdf_salt
+    assert entry.new_durable.salt == SALT_A
+
+
+def test_v1_db_committed_backward_read_fixed() -> None:
+    payload = _v1_payload(old_hex=SALT_A.hex(), new_hex=SALT_B.hex(), status="db_committed")
+    entry = RotationJournalEntry.from_dict(payload)
+    assert entry.status == JournalStatus.db_committed
+    assert entry.audit_transition_state == AuditTransitionState.pending
+    assert entry.old_segment_id == OLD_SEGMENT_ID
+    assert entry.committed_at is not None
+    assert entry.committed_at.isoformat() == COMMITTED_AT
+
+
+def test_v1_ambiguous_bytes_fail_closed_fixed() -> None:
+    # 12 bytes that are neither a 16-byte salt nor a valid HVDP envelope.
+    ambiguous = bytes(range(12))
+    payload = _v1_payload(old_hex=ambiguous.hex(), new_hex=ambiguous.hex())
+    with pytest.raises(RotationJournalError):
+        RotationJournalEntry.from_dict(payload)
+
+
+# ── Contradiction retention ─────────────────────────────────────────────────
+
+
+def test_contradiction_marker_attached_for_ambiguous_v1_fixed() -> None:
+    ambiguous = bytes(range(12))
+    payload = _v1_payload(old_hex=ambiguous.hex(), new_hex=ambiguous.hex())
+    with pytest.raises(RotationJournalError) as excinfo:
+        RotationJournalEntry.from_dict(payload)
+    marker = excinfo.value.marker
+    assert marker is not None
+    assert marker.kind == ContradictionKind.ambiguous_durable
+    assert marker.declared_version == JOURNAL_VERSION_V1
+    assert marker.field == "old_salt"
+
+
+def test_retain_contradiction_marker_keeps_journal_byte_identical(tmp_path: Path) -> None:
+    journal_path = tmp_path / "rotation-journal.json"
+    original = json.dumps(
+        _v1_payload(old_hex=bytes(range(12)).hex(), new_hex=bytes(range(12)).hex()),
+        sort_keys=True,
+    )
+    journal_path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(RotationJournalError) as excinfo:
+        RotationJournalEntry.from_json(original)
+    assert excinfo.value.marker is not None
+
+    marker_path = retain_contradiction_marker(journal_path, excinfo.value.marker)
+
+    # The original journal is never truncated or rewritten.
+    assert journal_path.read_text(encoding="utf-8") == original
+    assert marker_path.name == "rotation-journal.json.contradiction.json"
+    marker_payload = json.loads(marker_path.read_text(encoding="utf-8"))
+    assert marker_payload["journal_file"] == journal_path.name
+    assert marker_payload["marker"]["kind"] == ContradictionKind.ambiguous_durable.value
+    assert marker_payload["marker"]["declared_version"] == JOURNAL_VERSION_V1
+    assert "detected_at" in marker_payload["marker"]
+
+
+def test_retain_marker_idempotent_sidecar_only(tmp_path: Path) -> None:
+    journal_path = tmp_path / "rotation-journal.json"
+    original = json.dumps(
+        _v1_payload(old_hex=bytes(range(12)).hex(), new_hex=bytes(range(12)).hex()),
+        sort_keys=True,
+    )
+    journal_path.write_text(original, encoding="utf-8")
+
+    marker = __import__("hermes_vault.rotation_journal", fromlist=["ContradictionMarker"]).ContradictionMarker(
+        kind=ContradictionKind.kind_conflict,
+        message="first detection",
+        field="old_salt",
+        declared_version=JOURNAL_VERSION_V2,
+    )
+    retain_contradiction_marker(journal_path, marker)
+
+    loaded = load_contradiction_marker(journal_path.with_name("rotation-journal.json.contradiction.json"))
+    assert loaded.kind == ContradictionKind.kind_conflict
+    # The journal is untouched.
+    assert journal_path.read_text(encoding="utf-8") == original
+
+
+# ── Interrupted-audit reconciliation (fixed keys, real sqlite) ──────────────
+
+
+def _make_audit_logger(tmp_path: Path, master_key: bytes = OLD_KEY) -> AuditLogger:
+    return AuditLogger(tmp_path / "vault.db", master_key=master_key)
+
+
+def _record(logger: AuditLogger, reason: str = "allowed") -> None:
+    logger.record(
+        AccessLogRecord(
+            agent_id="det-agent",
+            service="openai",
+            action="get_env",
+            decision=Decision.allow,
+            reason=reason,
+            metadata={"ticket": "fixed"},
+        )
+    )
+
+
+def _pending_journal(
+    old_segment_id: str,
+    old_key: bytes = OLD_KEY,
+    new_key: bytes = NEW_KEY,
+    journal_id: str = JOURNAL_ID,
+) -> RotationJournalEntry:
+    """Typed v2 journal in the exact state a rotation leaves at interruption."""
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+        journal_id=journal_id,
+        created_at=__import__("datetime").datetime.fromisoformat(CREATED_AT),
+    )
+    recovery = encrypt_old_key_recovery(old_key, new_key, entry.journal_id)
+    return entry.mark_db_committed(
+        old_segment_id=old_segment_id,
+        old_key_recovery=recovery,
+        committed_at=__import__("datetime").datetime.fromisoformat(COMMITTED_AT),
+    )
+
+
+def _segment_count(tmp_path: Path) -> int:
+    with sqlite3.connect(tmp_path / "vault.db") as conn:
+        return conn.execute("SELECT COUNT(*) FROM audit_integrity_segments").fetchone()[0]
+
+
+def test_reconcile_completes_interrupted_rotation_fixed_keys(tmp_path: Path) -> None:
+    logger = _make_audit_logger(tmp_path)
+    _record(logger)
+    _record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    assert old_segment_id is not None
+    journal = _pending_journal(old_segment_id)  # type: ignore[arg-type]
+
+    service = AuditIntegrityService(tmp_path / "vault.db", NEW_KEY)
+    before = service.verify()
+    assert before.status.value == "failed"
+    assert before.reason_code == "active_key_mismatch"
+
+    result = service.recover_pending_rotation(journal, old_master_key=OLD_KEY)
+
+    assert result.status.value == "healthy"
+    assert result.active_segment_number == 2
+    assert result.verified_count == 2
+    assert _segment_count(tmp_path) == 2
+
+
+def test_reconcile_replay_converges_same_state(tmp_path: Path) -> None:
+    """REPLAY REGRESSION: replaying the same journal must converge."""
+    logger = _make_audit_logger(tmp_path)
+    _record(logger)
+    _record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    journal = _pending_journal(old_segment_id)  # type: ignore[arg-type]
+
+    first = AuditIntegrityService(tmp_path / "vault.db", NEW_KEY)
+    result1 = first.recover_pending_rotation(journal, old_master_key=OLD_KEY)
+    assert result1.status.value == "healthy"
+    active_after_first = result1.active_segment_id
+
+    # Replay the identical journal: same active segment, no duplicate successor.
+    again = AuditIntegrityService(tmp_path / "vault.db", NEW_KEY)
+    result2 = again.recover_pending_rotation(journal, old_master_key=OLD_KEY)
+    assert result2.status.value == "healthy"
+    assert result2.active_segment_id == active_after_first
+    assert result2.active_segment_number == 2
+    assert _segment_count(tmp_path) == 2
+
+
+def test_reconcile_thrice_replay_keeps_same_state(tmp_path: Path) -> None:
+    logger = _make_audit_logger(tmp_path)
+    _record(logger)
+    _record(logger)
+    _record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    journal = _pending_journal(old_segment_id)  # type: ignore[arg-type]
+
+    results = [
+        AuditIntegrityService(tmp_path / "vault.db", NEW_KEY)
+        .recover_pending_rotation(journal, old_master_key=OLD_KEY)
+        .active_segment_id
+        for _ in range(3)
+    ]
+    assert results[0] == results[1] == results[2]
+    assert _segment_count(tmp_path) == 2
+
+
+def test_reconcile_resumes_interrupted_audit_same_state(tmp_path: Path) -> None:
+    """A lost checkpoint after segment commit resumes to the clean state."""
+    logger = _make_audit_logger(tmp_path)
+    _record(logger)
+    _record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+
+    # Clean rotation creates the successor and writes the checkpoint.
+    clean_service = AuditIntegrityService(tmp_path / "vault.db", OLD_KEY)
+    clean_service.rotate_segment(NEW_KEY)
+    clean_active = clean_service.verify().active_segment_id
+    assert _segment_count(tmp_path) == 2
+
+    # Simulate interruption: segment commit done, checkpoint write lost.
+    checkpoint = tmp_path / "audit.checkpoint.json"
+    checkpoint.unlink()
+    interrupted = AuditIntegrityService(tmp_path / "vault.db", NEW_KEY)
+    before = interrupted.verify()
+    assert before.status.value == "incomplete"
+
+    journal = _pending_journal(old_segment_id)  # type: ignore[arg-type]
+    result = interrupted.recover_pending_rotation(journal, old_master_key=OLD_KEY)
+
+    assert result.status.value == "healthy"
+    assert result.active_segment_id == clean_active
+    assert result.active_segment_number == 2
+    assert _segment_count(tmp_path) == 2
+
+
+def test_reconcile_contradictory_journal_fails_closed(tmp_path: Path) -> None:
+    logger = _make_audit_logger(tmp_path)
+    _record(logger)
+    journal = _pending_journal("seg-does-not-exist")
+
+    service = AuditIntegrityService(tmp_path / "vault.db", NEW_KEY)
+    before = service.verify()
+
+    with pytest.raises(AuditIntegrityError, match="contradictory"):
+        service.recover_pending_rotation(journal, old_master_key=OLD_KEY)
+
+    # Nothing was mutated: same segments, same verify result.
+    assert _segment_count(tmp_path) == 1
+    after = service.verify()
+    assert after.status is before.status
+    assert after.reason_code == before.reason_code
+
+
+def test_reconcile_wrong_old_key_fails_closed(tmp_path: Path) -> None:
+    logger = _make_audit_logger(tmp_path)
+    _record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    journal = _pending_journal(old_segment_id)  # type: ignore[arg-type]
+
+    service = AuditIntegrityService(tmp_path / "vault.db", NEW_KEY)
+    with pytest.raises(AuditIntegrityError, match="contradictory|old key"):
+        service.recover_pending_rotation(journal, old_master_key=bytes(range(64, 96)))
+
+
+def test_reconcile_started_journal_fails_closed(tmp_path: Path) -> None:
+    logger = _make_audit_logger(tmp_path)
+    _record(logger)
+    entry = _started_entry()
+
+    service = AuditIntegrityService(tmp_path / "vault.db", NEW_KEY)
+    with pytest.raises(AuditIntegrityError, match="started"):
+        service.recover_pending_rotation(entry, old_master_key=OLD_KEY)
+
+
+def test_reconcile_checkpoint_committed_journal_is_noop(tmp_path: Path) -> None:
+    logger = _make_audit_logger(tmp_path)
+    _record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+
+    clean = AuditIntegrityService(tmp_path / "vault.db", OLD_KEY)
+    clean.rotate_segment(NEW_KEY)
+    segments_before = _segment_count(tmp_path)
+
+    entry = _pending_journal(old_segment_id).mark_audit_checkpoint_committed()  # type: ignore[arg-type]
+    assert entry.phase() == JournalPhase.checkpoint_committed
+
+    service = AuditIntegrityService(tmp_path / "vault.db", NEW_KEY)
+    result = service.recover_pending_rotation(entry, old_master_key=OLD_KEY)
+    assert result.status.value == "healthy"
+    assert _segment_count(tmp_path) == segments_before

--- a/tests/test_rotation_journal_reconcile.py
+++ b/tests/test_rotation_journal_reconcile.py
@@ -1,0 +1,360 @@
+"""Tests for idempotent audit transition reconciliation (Slice C, #66).
+
+Covers the ``AuditIntegrityService.recover_pending_rotation`` seam from
+INTEGRITY_RECOVERY_PLAN.md lines 341-345: given the typed v2 rotation
+journal (which records the *old* audit segment id and phase
+``db_committed_pending``), reconcile the audit chain under the new master
+key:
+
+* repeated replay of the same journal converges to the same state
+  (idempotent transition application);
+* an interrupted audit (segment rotation committed but checkpoint rewrite
+  lost, or rotation never committed) resumes to the same state as a clean
+  rotation;
+* contradictions fail closed and the destructive
+  ``recover_checkpoint`` / ``_rebuild_integrity_for_key_mismatch``
+  semantics are never expanded or invoked.
+
+These tests exercise the real ``AuditIntegrityService`` against a real
+sqlite audit DB (same fixture pattern as ``test_audit_integrity_core.py``).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.audit_integrity.models import AuditIntegrityStatus
+from hermes_vault.audit_integrity.service import AuditIntegrityError, AuditIntegrityService
+from hermes_vault.models import AccessLogRecord, Decision
+from hermes_vault.rotation_journal import (
+    DurableKind,
+    DurableMaterial,
+    JournalPhase,
+    RotationJournalEntry,
+    encrypt_old_key_recovery,
+)
+from hermes_vault.vault import Vault
+
+
+def make_logger(tmp_path: Path, passphrase: str = "test-passphrase") -> tuple[AuditLogger, Vault]:
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", passphrase)
+    return AuditLogger(vault.db_path, master_key=vault.key), vault
+
+
+def record(logger: AuditLogger, reason: str = "allowed") -> None:
+    logger.record(
+        AccessLogRecord(
+            agent_id="test-agent",
+            service="openai",
+            action="get_env",
+            decision=Decision.allow,
+            reason=reason,
+            metadata={"ticket": "fake"},
+        )
+    )
+
+
+def _pbkdf_material() -> DurableMaterial:
+    return DurableMaterial(kind=DurableKind.pbkdf_salt, salt=os.urandom(16))
+
+
+def _pending_journal(
+    old_segment_id: str | None,
+    old_key: bytes,
+    new_key: bytes,
+    journal_id: str = "reconcile-journal-1",
+) -> RotationJournalEntry:
+    """Typed v2 journal in the exact state a rotation leaves at interruption."""
+    assert old_segment_id is not None  # verify() always yields an active segment
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+        journal_id=journal_id,
+    )
+    recovery = encrypt_old_key_recovery(old_key, new_key, entry.journal_id)
+    return entry.mark_db_committed(old_segment_id=old_segment_id, old_key_recovery=recovery)
+
+
+def _segment_rows(tmp_path: Path) -> list[sqlite3.Row]:
+    with sqlite3.connect(tmp_path / "vault.db") as conn:
+        conn.row_factory = sqlite3.Row
+        return conn.execute(
+            "SELECT * FROM audit_integrity_segments ORDER BY segment_number"
+        ).fetchall()
+
+
+# ── L2/L4: completes a rotation that never reached the audit chain ────────
+
+
+def test_reconcile_completes_pending_rotation(tmp_path: Path) -> None:
+    logger, vault = make_logger(tmp_path)
+    record(logger)
+    record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    assert old_segment_id is not None
+
+    new_key = os.urandom(32)
+    journal = _pending_journal(old_segment_id, vault.key, new_key)
+
+    # Reopen with the new key: the chain is still under the old key.
+    service = AuditIntegrityService(vault.db_path, new_key)
+    before = service.verify()
+    assert before.status is AuditIntegrityStatus.failed
+    assert before.reason_code == "active_key_mismatch"
+
+    result = service.recover_pending_rotation(journal, old_master_key=vault.key)
+
+    assert result.status is AuditIntegrityStatus.healthy
+    assert result.active_segment_number == 2
+    assert result.verified_count == 2
+    # The successor must be linked to the journaled old segment.
+    segments = _segment_rows(tmp_path)
+    assert len(segments) == 2
+    assert segments[0]["segment_id"] == old_segment_id
+    assert segments[0]["sequence_end"] is not None
+    assert segments[1]["predecessor_segment_id"] == old_segment_id
+    # predecessor_tip_digest must equal the old segment's last record digest.
+    with sqlite3.connect(vault.db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        old_tip = conn.execute(
+            "SELECT entry_digest FROM audit_integrity_records WHERE segment_id = ? ORDER BY sequence DESC LIMIT 1",
+            (old_segment_id,),
+        ).fetchone()
+    assert segments[1]["predecessor_tip_digest"] == old_tip["entry_digest"]
+
+
+def test_reconcile_replay_converges(tmp_path: Path) -> None:
+    logger, vault = make_logger(tmp_path)
+    record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    new_key = os.urandom(32)
+    journal = _pending_journal(old_segment_id, vault.key, new_key)
+
+    first = AuditIntegrityService(vault.db_path, new_key)
+    result1 = first.recover_pending_rotation(journal, old_master_key=vault.key)
+    assert result1.status is AuditIntegrityStatus.healthy
+    active_after_first = result1.active_segment_id
+
+    # Replaying the same journal must converge — no duplicate segment, same
+    # active segment, still healthy.
+    again = AuditIntegrityService(vault.db_path, new_key)
+    result2 = again.recover_pending_rotation(journal, old_master_key=vault.key)
+    assert result2.status is AuditIntegrityStatus.healthy
+    assert result2.active_segment_id == active_after_first
+    assert result2.active_segment_number == 2
+    assert result2.verified_count == 1
+    assert len(_segment_rows(tmp_path)) == 2
+
+
+def test_reconcile_thrice_replay_keeps_same_state(tmp_path: Path) -> None:
+    logger, vault = make_logger(tmp_path)
+    record(logger)
+    record(logger)
+    record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    new_key = os.urandom(32)
+    journal = _pending_journal(old_segment_id, vault.key, new_key)
+
+    results = [
+        AuditIntegrityService(vault.db_path, new_key)
+        .recover_pending_rotation(journal, old_master_key=vault.key)
+        .active_segment_id
+        for _ in range(3)
+    ]
+    assert results[0] == results[1] == results[2]
+    assert len(_segment_rows(tmp_path)) == 2
+
+
+# ── L2/L4: interrupted audit resume (rotation committed, checkpoint lost) ──
+
+
+def test_reconcile_resumes_interrupted_audit_same_state(tmp_path: Path) -> None:
+    """A lost checkpoint after the segment commit resumes to the clean state."""
+    logger, vault = make_logger(tmp_path)
+    record(logger)
+    record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+
+    # Clean rotation creates the successor and writes the checkpoint.
+    new_key = os.urandom(32)
+    clean_service = AuditIntegrityService(vault.db_path, vault.key)
+    clean_service.rotate_segment(new_key)
+    clean_active = clean_service.verify().active_segment_id
+    assert len(_segment_rows(tmp_path)) == 2
+
+    # Simulate an interruption: the segment commit happened but the
+    # checkpoint write was lost.  Rewind by removing the checkpoint.
+    checkpoint = vault.db_path.with_name("audit.checkpoint.json")
+    checkpoint.unlink()
+    interrupted = AuditIntegrityService(vault.db_path, new_key)
+    before = interrupted.verify()
+    assert before.status is AuditIntegrityStatus.incomplete  # checkpoint_missing
+
+    journal = _pending_journal(old_segment_id, vault.key, new_key)
+    result = interrupted.recover_pending_rotation(journal, old_master_key=vault.key)
+
+    assert result.status is AuditIntegrityStatus.healthy
+    # Same state as the clean rotation: same active segment, no third segment.
+    assert result.active_segment_id == clean_active
+    assert result.active_segment_number == 2
+    assert result.verified_count == 2
+    assert len(_segment_rows(tmp_path)) == 2
+
+
+def test_reconcile_rewrites_only_checkpoint_when_rotation_committed(tmp_path: Path) -> None:
+    """If the successor already exists, reconciliation must not create another."""
+    logger, vault = make_logger(tmp_path)
+    record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    new_key = os.urandom(32)
+
+    clean = AuditIntegrityService(vault.db_path, vault.key)
+    clean.rotate_segment(new_key)
+    segments_after_rotation = _segment_rows(tmp_path)
+    assert len(segments_after_rotation) == 2
+
+    checkpoint = vault.db_path.with_name("audit.checkpoint.json")
+    checkpoint.unlink()
+    journal = _pending_journal(old_segment_id, vault.key, new_key)
+    service = AuditIntegrityService(vault.db_path, new_key)
+    result = service.recover_pending_rotation(journal, old_master_key=vault.key)
+
+    assert result.status is AuditIntegrityStatus.healthy
+    segments = _segment_rows(tmp_path)
+    assert len(segments) == 2  # no duplicate successor
+    assert [s["segment_id"] for s in segments] == [
+        s["segment_id"] for s in segments_after_rotation
+    ]
+
+
+# ── L2/L4: fail-closed contradictions ─────────────────────────────────────
+
+
+def test_reconcile_contradictory_journal_fails_closed(tmp_path: Path) -> None:
+    logger, vault = make_logger(tmp_path)
+    record(logger)
+    new_key = os.urandom(32)
+
+    # Journal claims an old segment id that is neither active nor a predecessor.
+    journal = _pending_journal("seg-does-not-exist", vault.key, new_key)
+    service = AuditIntegrityService(vault.db_path, new_key)
+    before = service.verify()
+
+    with pytest.raises(AuditIntegrityError, match="contradictory"):
+        service.recover_pending_rotation(journal, old_master_key=vault.key)
+
+    # Nothing was mutated: same segments, same verify result.
+    assert len(_segment_rows(tmp_path)) == 1
+    after = service.verify()
+    assert after.status is before.status
+    assert after.reason_code == before.reason_code
+
+
+def test_reconcile_wrong_old_key_fails_closed(tmp_path: Path) -> None:
+    logger, vault = make_logger(tmp_path)
+    record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    new_key = os.urandom(32)
+    journal = _pending_journal(old_segment_id, vault.key, new_key)
+
+    service = AuditIntegrityService(vault.db_path, new_key)
+    with pytest.raises(AuditIntegrityError, match="contradictory|old key"):
+        # The journaled old key does not match the segment's recorded key.
+        service.recover_pending_rotation(
+            journal, old_master_key=os.urandom(32)
+        )
+
+
+def test_reconcile_started_journal_fails_closed(tmp_path: Path) -> None:
+    logger, vault = make_logger(tmp_path)
+    record(logger)
+    new_key = os.urandom(32)
+
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+        journal_id="reconcile-started",
+    )
+    service = AuditIntegrityService(vault.db_path, new_key)
+    with pytest.raises(AuditIntegrityError, match="started"):
+        service.recover_pending_rotation(entry, old_master_key=vault.key)
+
+
+def test_reconcile_checkpoint_committed_journal_is_noop(tmp_path: Path) -> None:
+    logger, vault = make_logger(tmp_path)
+    record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    new_key = os.urandom(32)
+
+    # Fully completed rotation.
+    clean = AuditIntegrityService(vault.db_path, vault.key)
+    clean.rotate_segment(new_key)
+    segments_before = _segment_rows(tmp_path)
+
+    # A checkpoint_committed journal replay is a no-op.
+    entry = _pending_journal(old_segment_id, vault.key, new_key)
+    done = entry.mark_audit_checkpoint_committed()
+    assert done.phase() == JournalPhase.checkpoint_committed
+
+    service = AuditIntegrityService(vault.db_path, new_key)
+    result = service.recover_pending_rotation(done, old_master_key=vault.key)
+    assert result.status is AuditIntegrityStatus.healthy
+    assert len(_segment_rows(tmp_path)) == len(segments_before)
+
+
+# ── L3/L4: no destructive operations are added or invoked ─────────────────
+
+
+def test_reconcile_never_invokes_destructive_rebuild(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    logger, vault = make_logger(tmp_path)
+    record(logger)
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    new_key = os.urandom(32)
+    journal = _pending_journal(old_segment_id, vault.key, new_key)
+
+    service = AuditIntegrityService(vault.db_path, new_key)
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("destructive rebuild must not be invoked")
+
+    monkeypatch.setattr(service, "_rebuild_integrity_for_key_mismatch", _boom)
+    monkeypatch.setattr(service, "recover_checkpoint", _boom)
+
+    result = service.recover_pending_rotation(journal, old_master_key=vault.key)
+    assert result.status is AuditIntegrityStatus.healthy
+    assert len(_segment_rows(tmp_path)) == 2
+
+
+def test_reconcile_preserves_all_records_and_tables(tmp_path: Path) -> None:
+    logger, vault = make_logger(tmp_path)
+    for i in range(5):
+        record(logger, reason=f"r{i}")
+    old_segment_id = logger.integrity.verify().active_segment_id  # type: ignore[union-attr]
+    new_key = os.urandom(32)
+    journal = _pending_journal(old_segment_id, vault.key, new_key)
+
+    service = AuditIntegrityService(vault.db_path, new_key)
+    result = service.recover_pending_rotation(journal, old_master_key=vault.key)
+    assert result.status is AuditIntegrityStatus.healthy
+    assert result.verified_count == 5
+    assert result.legacy_count == 0
+
+    with sqlite3.connect(vault.db_path) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+    for required in (
+        "access_logs",
+        "audit_integrity_state",
+        "audit_integrity_segments",
+        "audit_integrity_records",
+    ):
+        assert required in tables

--- a/tests/test_rotation_journal_recovery.py
+++ b/tests/test_rotation_journal_recovery.py
@@ -1,0 +1,479 @@
+"""Unit tests for the v2 old-key recovery material and state transitions.
+
+Covers the S1 shared seam from INTEGRITY_RECOVERY_PLAN.md, Slice C
+(issues #58 / #66), as scoped to this card: the typed encrypted old-key
+recovery material (:class:`OldKeyRecovery` plus the
+:func:`encrypt_old_key_recovery` / :func:`decrypt_old_key_recovery`
+helpers) and the explicit v2 state transition helpers
+(:class:`RotationJournalEntry` ``start`` / ``mark_db_committed`` /
+``mark_audit_checkpoint_committed`` / ``phase``, and the derived
+:class:`JournalPhase`).
+
+The typed durable entry types (:class:`DurableKind` /
+:class:`DurableMaterial`) come from the prerequisite card; journal-level
+serialize/deserialize lives on the sibling card.  The destructive
+``recover_checkpoint`` semantics live in
+:mod:`hermes_vault.audit_integrity.service` and are intentionally not
+touched — no test here exercises or depends on them.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from hermes_vault.crypto import AAD_DOMAIN, NONCE_SIZE
+from hermes_vault.dpapi import DPAPI_ENVELOPE_VERSION, DPAPI_HEADER
+from hermes_vault.models import utc_now
+from hermes_vault.rotation_journal import (
+    JOURNAL_VERSION_V1,
+    JOURNAL_VERSION_V2,
+    RECOVERY_AAD_KIND,
+    RECOVERY_AAD_VERSION,
+    RECOVERY_ENVELOPE_VERSION,
+    AuditTransitionState,
+    DurableKind,
+    DurableMaterial,
+    JournalPhase,
+    JournalStatus,
+    OldKeyRecovery,
+    RotationJournalEntry,
+    RotationJournalError,
+    build_recovery_aad,
+    decrypt_old_key_recovery,
+    encrypt_old_key_recovery,
+)
+
+
+def _pbkdf_material() -> DurableMaterial:
+    return DurableMaterial(kind=DurableKind.pbkdf_salt, salt=os.urandom(16))
+
+
+def _dpapi_material() -> DurableMaterial:
+    return DurableMaterial(
+        kind=DurableKind.dpapi_envelope,
+        envelope=DPAPI_HEADER + os.urandom(24),
+    )
+
+
+def _old_key() -> bytes:
+    return os.urandom(32)
+
+
+def _new_key() -> bytes:
+    return os.urandom(32)
+
+
+# ── OldKeyRecovery: typed encrypted recovery material ────────────────
+
+
+def test_old_key_recovery_requires_nonce() -> None:
+    with pytest.raises(ValueError, match="nonce"):
+        OldKeyRecovery(nonce=b"", ciphertext=b"x")
+
+
+def test_old_key_recovery_requires_12_byte_nonce() -> None:
+    with pytest.raises(ValueError, match="must be 12 bytes"):
+        OldKeyRecovery(nonce=os.urandom(8), ciphertext=b"x")
+
+
+def test_old_key_recovery_rejects_empty_ciphertext() -> None:
+    with pytest.raises(ValueError, match="ciphertext must not be empty"):
+        OldKeyRecovery(nonce=os.urandom(NONCE_SIZE), ciphertext=b"")
+
+
+def test_old_key_recovery_defaults_envelope_version() -> None:
+    recovery = OldKeyRecovery(nonce=os.urandom(NONCE_SIZE), ciphertext=os.urandom(48))
+    assert recovery.version == RECOVERY_ENVELOPE_VERSION
+
+
+def test_old_key_recovery_extra_fields_forbidden() -> None:
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        OldKeyRecovery.model_validate(
+            {
+                "nonce": os.urandom(NONCE_SIZE),
+                "ciphertext": os.urandom(48),
+                "unexpected": "nope",
+            }
+        )
+
+
+def test_old_key_recovery_dict_round_trip() -> None:
+    recovery = OldKeyRecovery(nonce=os.urandom(NONCE_SIZE), ciphertext=os.urandom(48))
+    payload = recovery.to_dict()
+    assert set(payload) == {"version", "nonce", "ciphertext"}
+    restored = OldKeyRecovery.from_dict(payload)
+    assert restored.version == recovery.version
+    assert restored.nonce == recovery.nonce
+    assert restored.ciphertext == recovery.ciphertext
+
+
+def test_old_key_recovery_from_dict_rejects_missing_ciphertext() -> None:
+    with pytest.raises(RotationJournalError, match="invalid old_key_recovery payload"):
+        OldKeyRecovery.from_dict({"nonce": os.urandom(NONCE_SIZE).hex()})
+
+
+def test_old_key_recovery_from_dict_rejects_bad_hex() -> None:
+    with pytest.raises(RotationJournalError, match="invalid old_key_recovery payload"):
+        OldKeyRecovery.from_dict({"nonce": "zz", "ciphertext": "aa"})
+
+
+# ── encrypt/decrypt helpers ──────────────────────────────────────────
+
+
+def test_recovery_round_trip_returns_old_key() -> None:
+    old_key = _old_key()
+    new_key = _new_key()
+    journal_id = "journal-123"
+    recovery = encrypt_old_key_recovery(old_key, new_key, journal_id)
+    assert decrypt_old_key_recovery(recovery, new_key, journal_id) == old_key
+
+
+def test_recovery_never_stores_plaintext_or_passphrase() -> None:
+    old_key = _old_key()
+    recovery = encrypt_old_key_recovery(old_key, _new_key(), "journal-123")
+    # The ciphertext must not equal or embed the plaintext key bytes.
+    assert recovery.ciphertext != old_key
+    assert old_key not in recovery.ciphertext
+    payload = recovery.to_dict()
+    assert payload["ciphertext"] != old_key.hex()
+    # No human-readable key material in the serialized envelope.
+    assert "passphrase" not in payload
+
+
+def test_recovery_wrong_new_key_fails() -> None:
+    old_key = _old_key()
+    journal_id = "journal-123"
+    recovery = encrypt_old_key_recovery(old_key, _new_key(), journal_id)
+    with pytest.raises(InvalidTag):
+        decrypt_old_key_recovery(recovery, _new_key(), journal_id)
+
+
+def test_recovery_wrong_journal_id_fails() -> None:
+    old_key = _old_key()
+    new_key = _new_key()
+    recovery = encrypt_old_key_recovery(old_key, new_key, "journal-123")
+    with pytest.raises(InvalidTag):
+        decrypt_old_key_recovery(recovery, new_key, "journal-456")
+
+
+def test_recovery_tampered_ciphertext_fails() -> None:
+    old_key = _old_key()
+    new_key = _new_key()
+    journal_id = "journal-123"
+    recovery = encrypt_old_key_recovery(old_key, new_key, journal_id)
+    tampered = OldKeyRecovery(
+        nonce=recovery.nonce,
+        ciphertext=recovery.ciphertext[:-1] + bytes([recovery.ciphertext[-1] ^ 0x01]),
+    )
+    with pytest.raises(InvalidTag):
+        decrypt_old_key_recovery(tampered, new_key, journal_id)
+
+
+def test_recovery_aad_binds_journal_id_deterministically() -> None:
+    aad_1 = build_recovery_aad("journal-123")
+    aad_2 = build_recovery_aad("journal-123")
+    aad_other = build_recovery_aad("journal-456")
+    assert aad_1 == aad_2
+    assert aad_1 != aad_other
+    marker = f"{AAD_DOMAIN}:{RECOVERY_AAD_KIND}:{RECOVERY_AAD_VERSION}"
+    assert aad_1.startswith(marker.encode("utf-8"))
+
+
+def test_recovery_aad_distinct_from_credential_aad() -> None:
+    # The recovery marker kind must differ from the credential-aad marker so
+    # ciphertexts can never be replayed across the two domains.
+    aad = build_recovery_aad("journal-123").decode("utf-8")
+    assert RECOVERY_AAD_KIND == "rotation-journal-old-key"
+    assert RECOVERY_AAD_KIND != "credential-aad"
+    assert "credential-aad" not in aad
+
+
+# ── state machine enums / phase derivation ───────────────────────────
+
+
+def test_phase_derivation() -> None:
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+    )
+    assert entry.phase() == JournalPhase.started
+    committed = entry.mark_db_committed(
+        old_segment_id="seg-1",
+        old_key_recovery=encrypt_old_key_recovery(_old_key(), _new_key(), entry.journal_id),
+    )
+    assert committed.phase() == JournalPhase.db_committed_pending
+    final = committed.mark_audit_checkpoint_committed()
+    assert final.phase() == JournalPhase.checkpoint_committed
+
+
+def test_journal_status_values() -> None:
+    assert JournalStatus.started.value == "started"
+    assert JournalStatus.db_committed.value == "db_committed"
+
+
+def test_audit_transition_state_values() -> None:
+    assert AuditTransitionState.pending.value == "pending"
+    assert AuditTransitionState.checkpoint_committed.value == "checkpoint_committed"
+
+
+def test_journal_phase_values() -> None:
+    assert JournalPhase.started.value == "started"
+    assert JournalPhase.db_committed_pending.value == "db_committed_pending"
+    assert JournalPhase.checkpoint_committed.value == "checkpoint_committed"
+
+
+# ── RotationJournalEntry: start / legal state validation ─────────────
+
+
+def test_start_creates_started_entry_with_typed_materials() -> None:
+    old_durable = _dpapi_material()
+    new_durable = _pbkdf_material()
+    entry = RotationJournalEntry.start(old_durable=old_durable, new_durable=new_durable)
+    assert entry.version == JOURNAL_VERSION_V2
+    assert entry.status == JournalStatus.started
+    assert entry.audit_transition_state is None
+    assert entry.old_segment_id is None
+    assert entry.committed_at is None
+    assert entry.old_durable.kind == DurableKind.dpapi_envelope
+    assert entry.old_durable.to_hex() == old_durable.to_hex()
+    assert entry.new_durable.kind == DurableKind.pbkdf_salt
+    assert entry.old_key_recovery is None
+
+
+def test_started_entry_rejects_audit_transition_state() -> None:
+    with pytest.raises(ValueError, match="must not carry an audit transition state"):
+        RotationJournalEntry(
+            status=JournalStatus.started,
+            audit_transition_state=AuditTransitionState.pending,
+            old_durable=_pbkdf_material(),
+            new_durable=_pbkdf_material(),
+        )
+
+
+def test_started_entry_rejects_old_segment_id() -> None:
+    with pytest.raises(ValueError, match="must not carry an old segment id"):
+        RotationJournalEntry(
+            status=JournalStatus.started,
+            old_segment_id="seg-1",
+            old_durable=_pbkdf_material(),
+            new_durable=_pbkdf_material(),
+        )
+
+
+def test_started_entry_rejects_committed_at() -> None:
+    with pytest.raises(ValueError, match="must not carry a committed_at timestamp"):
+        RotationJournalEntry(
+            status=JournalStatus.started,
+            committed_at=utc_now(),
+            old_durable=_pbkdf_material(),
+            new_durable=_pbkdf_material(),
+        )
+
+
+def test_entry_rejects_unknown_version() -> None:
+    with pytest.raises(ValueError, match="unsupported journal version"):
+        RotationJournalEntry(
+            version="rotation-journal-v3",
+            old_durable=_pbkdf_material(),
+            new_durable=_pbkdf_material(),
+        )
+
+
+def test_v1_version_label_is_distinct() -> None:
+    assert JOURNAL_VERSION_V1 == "rotation-journal-v1"
+    assert JOURNAL_VERSION_V1 != JOURNAL_VERSION_V2
+
+
+# ── mark_db_committed transition ─────────────────────────────────────
+
+
+def test_mark_db_committed_requires_recovery_material() -> None:
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+    )
+    with pytest.raises(RotationJournalError, match="old_key_recovery is required"):
+        entry.mark_db_committed(old_segment_id="seg-1")
+
+
+def test_mark_db_committed_accepts_recovery_from_started_entry() -> None:
+    recovery = encrypt_old_key_recovery(_old_key(), _new_key(), "journal-x")
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+        old_key_recovery=recovery,
+    )
+    committed = entry.mark_db_committed(old_segment_id="seg-1")
+    assert committed.status == JournalStatus.db_committed
+    assert committed.audit_transition_state == AuditTransitionState.pending
+    assert committed.old_segment_id == "seg-1"
+    assert committed.committed_at is not None
+    assert committed.old_key_recovery == recovery
+    # journal id and durable materials are preserved.
+    assert committed.journal_id == entry.journal_id
+    assert committed.old_durable == entry.old_durable
+    assert committed.new_durable == entry.new_durable
+
+
+def test_mark_db_committed_accepts_recovery_passed_inline() -> None:
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+    )
+    recovery = encrypt_old_key_recovery(_old_key(), _new_key(), entry.journal_id)
+    committed = entry.mark_db_committed(old_segment_id="seg-1", old_key_recovery=recovery)
+    assert committed.old_key_recovery == recovery
+
+
+def test_mark_db_committed_from_non_started_raises() -> None:
+    recovery = encrypt_old_key_recovery(_old_key(), _new_key(), "journal-x")
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+        old_key_recovery=recovery,
+    ).mark_db_committed(old_segment_id="seg-1")
+    with pytest.raises(RotationJournalError, match="cannot mark db_committed"):
+        entry.mark_db_committed(old_segment_id="seg-2", old_key_recovery=recovery)
+
+
+def test_db_committed_entry_requires_old_segment_id() -> None:
+    recovery = encrypt_old_key_recovery(_old_key(), _new_key(), "journal-x")
+    with pytest.raises(ValueError, match="requires an old segment id"):
+        RotationJournalEntry(
+            status=JournalStatus.db_committed,
+            audit_transition_state=AuditTransitionState.pending,
+            old_key_recovery=recovery,
+            old_durable=_pbkdf_material(),
+            new_durable=_pbkdf_material(),
+            committed_at=utc_now(),
+        )
+
+
+def test_db_committed_pending_requires_recovery_material() -> None:
+    with pytest.raises(ValueError, match="requires old_key_recovery"):
+        RotationJournalEntry(
+            status=JournalStatus.db_committed,
+            audit_transition_state=AuditTransitionState.pending,
+            old_segment_id="seg-1",
+            old_durable=_pbkdf_material(),
+            new_durable=_pbkdf_material(),
+            committed_at=utc_now(),
+        )
+
+
+def test_db_committed_requires_committed_at() -> None:
+    recovery = encrypt_old_key_recovery(_old_key(), _new_key(), "journal-x")
+    with pytest.raises(ValueError, match="requires a committed_at timestamp"):
+        RotationJournalEntry(
+            status=JournalStatus.db_committed,
+            audit_transition_state=AuditTransitionState.pending,
+            old_segment_id="seg-1",
+            old_key_recovery=recovery,
+            old_durable=_pbkdf_material(),
+            new_durable=_pbkdf_material(),
+        )
+
+
+# ── mark_audit_checkpoint_committed transition ───────────────────────
+
+
+def test_mark_audit_checkpoint_committed_from_pending() -> None:
+    recovery = encrypt_old_key_recovery(_old_key(), _new_key(), "journal-x")
+    entry = RotationJournalEntry.start(
+        old_durable=_dpapi_material(),
+        new_durable=_dpapi_material(),
+        old_key_recovery=recovery,
+    ).mark_db_committed(old_segment_id="seg-1")
+    final = entry.mark_audit_checkpoint_committed()
+    assert final.status == JournalStatus.db_committed
+    assert final.audit_transition_state == AuditTransitionState.checkpoint_committed
+    assert final.phase() == JournalPhase.checkpoint_committed
+    # Recovery material is retained through the final state.
+    assert final.old_key_recovery == recovery
+    assert final.old_segment_id == "seg-1"
+    assert final.committed_at is not None
+
+
+def test_mark_audit_checkpoint_committed_from_started_raises() -> None:
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+    )
+    with pytest.raises(RotationJournalError, match="cannot mark audit checkpoint committed"):
+        entry.mark_audit_checkpoint_committed()
+
+
+def test_mark_audit_checkpoint_committed_twice_raises() -> None:
+    recovery = encrypt_old_key_recovery(_old_key(), _new_key(), "journal-x")
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+        old_key_recovery=recovery,
+    ).mark_db_committed(old_segment_id="seg-1")
+    final = entry.mark_audit_checkpoint_committed()
+    with pytest.raises(RotationJournalError, match="cannot mark audit checkpoint committed"):
+        final.mark_audit_checkpoint_committed()
+
+
+# ── coexistence with typed durable materials ─────────────────────────
+
+
+def test_recovery_coexists_with_pbkdf_and_dpapi_materials() -> None:
+    # A full v2 journal transition preserves every typed field: old and new
+    # durable materials (both envelope kinds), journal id, and recovery.
+    old_key = _old_key()
+    new_key = _new_key()
+    old_durable = _dpapi_material()
+    new_durable = _pbkdf_material()
+    entry = RotationJournalEntry.start(
+        old_durable=old_durable,
+        new_durable=new_durable,
+        journal_id="journal-42",
+    )
+    recovery = encrypt_old_key_recovery(old_key, new_key, entry.journal_id)
+    committed = entry.mark_db_committed(old_segment_id="seg-7", old_key_recovery=recovery)
+    final = committed.mark_audit_checkpoint_committed()
+
+    assert final.journal_id == "journal-42"
+    assert final.old_durable.kind == DurableKind.dpapi_envelope
+    assert final.old_durable.envelope_version == DPAPI_ENVELOPE_VERSION
+    assert final.new_durable.kind == DurableKind.pbkdf_salt
+    assert final.new_durable.salt is not None
+    assert final.old_key_recovery is not None
+    assert decrypt_old_key_recovery(final.old_key_recovery, new_key, final.journal_id) == old_key
+
+
+def test_recovery_round_trip_via_journal_field_preserves_key() -> None:
+    old_key = _old_key()
+    new_key = _new_key()
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+    )
+    committed = entry.mark_db_committed(
+        old_segment_id="seg-1",
+        old_key_recovery=encrypt_old_key_recovery(old_key, new_key, entry.journal_id),
+    )
+    # The recovery material stored on the journal state decrypts to the
+    # original old key with the new key and the same journal id.
+    assert committed.old_key_recovery is not None
+    assert decrypt_old_key_recovery(
+        committed.old_key_recovery, new_key, committed.journal_id
+    ) == old_key
+
+
+def test_durable_material_helpers_still_round_trip() -> None:
+    # Regression guard: the parent card's DurableMaterial hex/dict round
+    # trips must keep working with the new module contents present.
+    salt = os.urandom(16)
+    material = DurableMaterial(kind=DurableKind.pbkdf_salt, salt=salt)
+    assert DurableMaterial.from_dict(material.to_dict()).salt == salt
+
+    envelope = DPAPI_HEADER + os.urandom(24)
+    dpapi_material = DurableMaterial(kind=DurableKind.dpapi_envelope, envelope=envelope)
+    restored = DurableMaterial.from_dict(dpapi_material.to_dict())
+    assert restored.kind == DurableKind.dpapi_envelope
+    assert restored.envelope == envelope

--- a/tests/test_rotation_journal_serde.py
+++ b/tests/test_rotation_journal_serde.py
@@ -1,0 +1,373 @@
+"""Focused unit tests for journal-level serialize/deserialize and validation.
+
+Covers the S1 shared seam from INTEGRITY_RECOVERY_PLAN.md, Slice C
+(issues #58 / #66), as scoped to this card: the journal-level
+serialize/deserialize for the typed v2 rotation journal record
+(:class:`RotationJournalEntry`) and its validation.
+
+Acceptance covered here:
+
+* Serialization round-trips every field exactly — the dict produced by
+  ``to_dict`` parses back (``from_dict``) to an identical entry, and the
+  serialized shape keeps the v1-compatible ``old_salt`` / ``new_salt`` hex
+  fields so pre-v2 readers keep working on the common fields.
+* Validation rejects entries that mix envelope kinds: a DPAPI envelope kind
+  carrying PBKDF-only salt bytes, or a PBKDF entry missing its required
+  16-byte salt, are both rejected with :class:`RotationJournalError`.
+* v1 backward read: ``rotation-journal-v1`` payloads are accepted and their
+  durable kind is inferred from the bytes (``HVDP`` magic + length gate);
+  ambiguous bytes fail closed.
+
+The destructive ``recover_checkpoint`` /
+``_rebuild_integrity_for_key_mismatch`` semantics in
+:mod:`hermes_vault.audit_integrity.service` are intentionally not touched by
+this workstream and no test here depends on them.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from hermes_vault.dpapi import DPAPI_ENVELOPE_VERSION, DPAPI_HEADER
+from hermes_vault.rotation_journal import (
+    JOURNAL_VERSION_V1,
+    JOURNAL_VERSION_V2,
+    AuditTransitionState,
+    DurableKind,
+    DurableMaterial,
+    JournalStatus,
+    RotationJournalEntry,
+    RotationJournalError,
+    encrypt_old_key_recovery,
+)
+
+
+def _pbkdf_material() -> DurableMaterial:
+    return DurableMaterial(kind=DurableKind.pbkdf_salt, salt=os.urandom(16))
+
+
+def _dpapi_material() -> DurableMaterial:
+    return DurableMaterial(
+        kind=DurableKind.dpapi_envelope,
+        envelope=DPAPI_HEADER + os.urandom(24),
+    )
+
+
+def _started_entry() -> RotationJournalEntry:
+    return RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_pbkdf_material(),
+    )
+
+
+def _db_committed_entry() -> RotationJournalEntry:
+    old = _pbkdf_material()
+    new = _dpapi_material()
+    started = RotationJournalEntry.start(old_durable=old, new_durable=new)
+    recovery = encrypt_old_key_recovery(os.urandom(32), os.urandom(32), started.journal_id)
+    return started.mark_db_committed(
+        old_segment_id="seg-1",
+        old_key_recovery=recovery,
+    )
+
+
+def _checkpoint_committed_entry() -> RotationJournalEntry:
+    return _db_committed_entry().mark_audit_checkpoint_committed()
+
+
+def _v1_payload(*, old_hex: str, new_hex: str, status: str = "started") -> dict[str, str]:
+    payload: dict[str, str] = {
+        "version": JOURNAL_VERSION_V1,
+        "status": status,
+        "old_salt": old_hex,
+        "new_salt": new_hex,
+        "created_at": "2026-08-05T12:00:00+00:00",
+    }
+    if status == "db_committed":
+        payload["committed_at"] = "2026-08-05T12:01:00+00:00"
+        payload["audit_transition_state"] = "pending"
+        payload["old_segment_id"] = "seg-1"
+    return payload
+
+
+# ── round trips: all fields preserved exactly ─────────────────────────
+
+
+def test_started_pbkdf_journal_round_trip_preserves_all_fields() -> None:
+    entry = _started_entry()
+    payload = entry.to_dict()
+    restored = RotationJournalEntry.from_dict(payload)
+    assert restored == entry
+    assert restored.journal_id == entry.journal_id
+    assert restored.created_at == entry.created_at
+    assert restored.status == JournalStatus.started
+    assert restored.old_durable == entry.old_durable
+    assert restored.new_durable == entry.new_durable
+    assert restored.old_key_recovery is None
+    assert restored.audit_transition_state is None
+    assert restored.old_segment_id is None
+    assert restored.committed_at is None
+
+
+def test_db_committed_dpapi_journal_round_trip_preserves_all_fields() -> None:
+    entry = _db_committed_entry()
+    payload = entry.to_dict()
+    restored = RotationJournalEntry.from_dict(payload)
+    assert restored == entry
+    assert restored.journal_id == entry.journal_id
+    assert restored.created_at == entry.created_at
+    assert restored.committed_at == entry.committed_at
+    assert restored.status == JournalStatus.db_committed
+    assert restored.audit_transition_state == AuditTransitionState.pending
+    assert restored.old_segment_id == "seg-1"
+    assert restored.old_key_recovery is not None
+    assert entry.old_key_recovery is not None
+    assert restored.old_key_recovery == entry.old_key_recovery
+    assert restored.old_key_recovery.nonce == entry.old_key_recovery.nonce
+    assert restored.old_key_recovery.ciphertext == entry.old_key_recovery.ciphertext
+
+
+def test_mixed_kind_journal_round_trip_preserves_kinds_and_metadata() -> None:
+    entry = RotationJournalEntry.start(
+        old_durable=_pbkdf_material(),
+        new_durable=_dpapi_material(),
+    )
+    payload = entry.to_dict()
+    assert payload["old_durable_type"] == DurableKind.pbkdf_salt.value
+    assert payload["new_durable_type"] == DurableKind.dpapi_envelope.value
+    restored = RotationJournalEntry.from_dict(payload)
+    assert restored == entry
+    assert restored.old_durable.kind == DurableKind.pbkdf_salt
+    assert restored.new_durable.kind == DurableKind.dpapi_envelope
+    assert restored.new_durable.envelope_version == DPAPI_ENVELOPE_VERSION
+    assert restored.new_durable.envelope == entry.new_durable.envelope
+
+
+def test_serialized_dict_keeps_v1_compatible_hex_fields() -> None:
+    entry = _started_entry()
+    payload = entry.to_dict()
+    assert payload["old_salt"] == entry.old_durable.to_hex()
+    assert payload["new_salt"] == entry.new_durable.to_hex()
+    # v1 readers read old_salt/new_salt directly as hex — unchanged shape.
+    assert bytes.fromhex(payload["old_salt"]) == entry.old_durable.salt
+    assert bytes.fromhex(payload["new_salt"]) == entry.new_durable.salt
+
+
+def test_to_json_from_json_round_trip() -> None:
+    entry = _db_committed_entry()
+    restored = RotationJournalEntry.from_json(entry.to_json())
+    assert restored == entry
+
+
+def test_checkpoint_committed_round_trip_preserves_all_fields() -> None:
+    # The terminal state carries the fullest field set (status, audit
+    # transition state, segment id, committed_at, and the retained recovery
+    # material); the round trip must preserve every one of them.
+    entry = _checkpoint_committed_entry()
+    assert entry.audit_transition_state == AuditTransitionState.checkpoint_committed
+    assert entry.old_key_recovery is not None
+    payload = entry.to_dict()
+    restored = RotationJournalEntry.from_dict(payload)
+    assert restored == entry
+    assert restored.status == JournalStatus.db_committed
+    assert restored.audit_transition_state == AuditTransitionState.checkpoint_committed
+    assert restored.old_segment_id == entry.old_segment_id
+    assert restored.committed_at == entry.committed_at
+    assert restored.old_key_recovery == entry.old_key_recovery
+    assert restored.old_durable == entry.old_durable
+    assert restored.new_durable == entry.new_durable
+    assert restored.journal_id == entry.journal_id
+    assert RotationJournalEntry.from_json(entry.to_json()) == entry
+
+
+def test_serialization_is_deterministic() -> None:
+    entry = _db_committed_entry()
+    assert entry.to_dict() == entry.to_dict()
+    assert entry.to_json() == entry.to_json()
+
+
+# ── validation: reject envelope-kind mixing ───────────────────────────
+
+
+def test_from_dict_rejects_dpapi_kind_with_pbkdf_only_salt_bytes() -> None:
+    # A DPAPI envelope kind declared over a plain 16-byte salt must fail:
+    # the bytes are not an envelope, so the kind is mixed/unrepresentable.
+    salt_hex = os.urandom(16).hex()
+    payload = {
+        "version": JOURNAL_VERSION_V2,
+        "status": "started",
+        "old_salt": salt_hex,
+        "new_salt": salt_hex,
+        "old_durable_type": DurableKind.dpapi_envelope.value,
+        "new_durable_type": DurableKind.dpapi_envelope.value,
+    }
+    with pytest.raises(RotationJournalError, match="must start with the DPAPI header"):
+        RotationJournalEntry.from_dict(payload)
+
+
+def test_from_dict_rejects_pbkdf_missing_required_salt() -> None:
+    payload = {
+        "version": JOURNAL_VERSION_V2,
+        "status": "started",
+        "old_salt": "",
+        "new_salt": os.urandom(16).hex(),
+        "old_durable_type": DurableKind.pbkdf_salt.value,
+        "new_durable_type": DurableKind.pbkdf_salt.value,
+    }
+    with pytest.raises(RotationJournalError, match="must be 16 bytes"):
+        RotationJournalEntry.from_dict(payload)
+
+
+def test_from_dict_rejects_pbkdf_kind_with_dpapi_envelope_bytes() -> None:
+    # Reverse mixing direction: a pbkdf_salt kind declared over actual DPAPI
+    # envelope bytes must fail closed at the journal level too — the bytes
+    # are not a 16-byte salt, so the entry is mixed/unrepresentable.
+    envelope_hex = (DPAPI_HEADER + os.urandom(24)).hex()
+    payload = {
+        "version": JOURNAL_VERSION_V2,
+        "status": "started",
+        "old_salt": envelope_hex,
+        "new_salt": os.urandom(16).hex(),
+        "old_durable_type": DurableKind.pbkdf_salt.value,
+        "new_durable_type": DurableKind.pbkdf_salt.value,
+    }
+    with pytest.raises(RotationJournalError, match="must be 16 bytes"):
+        RotationJournalEntry.from_dict(payload)
+
+
+def test_pbkdf_material_rejects_dpapi_envelope_metadata() -> None:
+    # A PBKDF salt entry carrying DPAPI-only envelope_version metadata is
+    # kind mixing and must be rejected by the model itself.
+    with pytest.raises(ValueError, match="must not carry DPAPI envelope metadata"):
+        DurableMaterial(
+            kind=DurableKind.pbkdf_salt,
+            salt=os.urandom(16),
+            envelope_version="dpapi-v1",
+        )
+
+
+def test_from_dict_rejects_pbkdf_kind_with_dpapi_envelope_metadata() -> None:
+    # Journal-level: a PBKDF durable declaring DPAPI envelope metadata must
+    # be rejected, not silently normalized (the metadata is dpapi-only).
+    salt_hex = os.urandom(16).hex()
+    payload = {
+        "version": JOURNAL_VERSION_V2,
+        "status": "started",
+        "old_salt": salt_hex,
+        "new_salt": salt_hex,
+        "old_durable_type": DurableKind.pbkdf_salt.value,
+        "new_durable_type": DurableKind.pbkdf_salt.value,
+        "old_envelope_version": "dpapi-v1",
+    }
+    with pytest.raises(RotationJournalError, match="must not carry DPAPI envelope metadata"):
+        RotationJournalEntry.from_dict(payload)
+
+
+def test_from_dict_rejects_v2_without_typed_fields() -> None:
+    payload = {
+        "version": JOURNAL_VERSION_V2,
+        "status": "started",
+        "old_salt": os.urandom(16).hex(),
+        "new_salt": os.urandom(16).hex(),
+    }
+    with pytest.raises(RotationJournalError):
+        RotationJournalEntry.from_dict(payload)
+
+
+def test_from_dict_rejects_unknown_version() -> None:
+    payload = {
+        "version": "rotation-journal-v3",
+        "status": "started",
+        "old_salt": os.urandom(16).hex(),
+        "new_salt": os.urandom(16).hex(),
+        "old_durable_type": DurableKind.pbkdf_salt.value,
+        "new_durable_type": DurableKind.pbkdf_salt.value,
+    }
+    with pytest.raises(RotationJournalError, match="unsupported journal version"):
+        RotationJournalEntry.from_dict(payload)
+
+
+def test_from_dict_rejects_invalid_hex() -> None:
+    payload = {
+        "version": JOURNAL_VERSION_V2,
+        "status": "started",
+        "old_salt": "not-hex!!",
+        "new_salt": os.urandom(16).hex(),
+        "old_durable_type": DurableKind.pbkdf_salt.value,
+        "new_durable_type": DurableKind.pbkdf_salt.value,
+    }
+    with pytest.raises(RotationJournalError):
+        RotationJournalEntry.from_dict(payload)
+
+
+def test_from_dict_rejects_extra_fields() -> None:
+    payload = _started_entry().to_dict()
+    payload["unexpected"] = "nope"
+    with pytest.raises(RotationJournalError):
+        RotationJournalEntry.from_dict(payload)
+
+
+def test_from_dict_rejects_state_machine_contradiction() -> None:
+    # db_committed without an old_segment_id is contradictory.
+    payload = _db_committed_entry().to_dict()
+    payload.pop("old_segment_id")
+    with pytest.raises(RotationJournalError, match="requires an old segment id"):
+        RotationJournalEntry.from_dict(payload)
+
+
+# ── v1 backward read: infer kind from bytes, fail closed ──────────────
+
+
+def test_v1_pbkdf_journal_backward_read_infers_kind() -> None:
+    salt = os.urandom(16)
+    payload = _v1_payload(old_hex=salt.hex(), new_hex=salt.hex())
+    entry = RotationJournalEntry.from_dict(payload)
+    assert entry.version == JOURNAL_VERSION_V2  # upgraded in memory
+    assert entry.status == JournalStatus.started
+    assert entry.old_durable.kind == DurableKind.pbkdf_salt
+    assert entry.new_durable.kind == DurableKind.pbkdf_salt
+    assert entry.old_durable.salt == salt
+    assert entry.new_durable.salt == salt
+
+
+def test_v1_dpapi_journal_backward_read_infers_kind() -> None:
+    envelope = DPAPI_HEADER + os.urandom(24)
+    salt = os.urandom(16)
+    payload = _v1_payload(old_hex=envelope.hex(), new_hex=salt.hex())
+    entry = RotationJournalEntry.from_dict(payload)
+    assert entry.old_durable.kind == DurableKind.dpapi_envelope
+    assert entry.old_durable.envelope == envelope
+    assert entry.new_durable.kind == DurableKind.pbkdf_salt
+    assert entry.new_durable.salt == salt
+
+
+def test_v1_db_committed_backward_read_preserves_state() -> None:
+    salt = os.urandom(16)
+    payload = _v1_payload(
+        old_hex=salt.hex(),
+        new_hex=salt.hex(),
+        status="db_committed",
+    )
+    entry = RotationJournalEntry.from_dict(payload)
+    assert entry.status == JournalStatus.db_committed
+    assert entry.audit_transition_state == AuditTransitionState.pending
+    assert entry.old_segment_id == "seg-1"
+    assert entry.committed_at is not None
+
+
+def test_v1_ambiguous_bytes_fail_closed() -> None:
+    # 12 random bytes that are neither a 16-byte salt nor an HVDP envelope.
+    ambiguous = os.urandom(12)
+    payload = _v1_payload(old_hex=ambiguous.hex(), new_hex=ambiguous.hex())
+    with pytest.raises(RotationJournalError, match="must be 16 bytes"):
+        RotationJournalEntry.from_dict(payload)
+
+
+def test_v1_backward_read_keeps_hex_identical() -> None:
+    salt = os.urandom(16)
+    payload = _v1_payload(old_hex=salt.hex(), new_hex=salt.hex())
+    entry = RotationJournalEntry.from_dict(payload)
+    assert entry.to_dict()["old_salt"] == salt.hex()
+    assert entry.to_dict()["new_salt"] == salt.hex()

--- a/tests/test_rotation_journal_types.py
+++ b/tests/test_rotation_journal_types.py
@@ -1,0 +1,217 @@
+"""Unit tests for the typed rotation-journal-v2 entry types.
+
+Covers the S1 shared seam from INTEGRITY_RECOVERY_PLAN.md, Slice C
+(issues #58 / #66), as scoped to this card: the explicit typed v2 journal
+entry types — :class:`DurableKind` / :class:`DurableMaterial` — for the
+DPAPI envelope and PBKDF salt durable modes, discriminated by envelope
+kind, with the required salt field for PBKDF entries and DPAPI envelope
+metadata fields. Round-trip preservation through hex and dict forms is
+covered here because the acceptance criterion for the types is that they
+expose the fields needed for a round trip.
+
+The encrypted old-key recovery material, the typed journal record, and the
+journal-level serialize/deserialize and state-transition helpers are added
+by downstream slices and have their own tests. The destructive
+``recover_checkpoint`` semantics live in
+:mod:`hermes_vault.audit_integrity.service` and are intentionally not
+touched — no test here exercises or depends on them.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from hermes_vault.dpapi import DPAPI_ENVELOPE_VERSION, DPAPI_HEADER
+from hermes_vault.rotation_journal import (
+    JOURNAL_VERSION_V1,
+    JOURNAL_VERSION_V2,
+    DurableKind,
+    DurableMaterial,
+    RotationJournalError,
+    looks_like_dpapi_envelope,
+)
+
+
+# ── DurableKind discriminator ───────────────────────────────────────
+
+
+def test_durable_kind_values() -> None:
+    assert DurableKind.pbkdf_salt.value == "pbkdf_salt"
+    assert DurableKind.dpapi_envelope.value == "dpapi_envelope"
+
+
+def test_journal_version_labels() -> None:
+    assert JOURNAL_VERSION_V1 == "rotation-journal-v1"
+    assert JOURNAL_VERSION_V2 == "rotation-journal-v2"
+
+
+# ── DurableMaterial: per-kind validation ────────────────────────────
+
+
+def test_pbkdf_salt_material_requires_salt() -> None:
+    with pytest.raises(ValueError, match="requires a salt"):
+        DurableMaterial(kind=DurableKind.pbkdf_salt)
+
+
+def test_pbkdf_salt_material_rejects_envelope() -> None:
+    with pytest.raises(ValueError, match="must not carry a DPAPI envelope"):
+        DurableMaterial(
+            kind=DurableKind.pbkdf_salt,
+            salt=os.urandom(16),
+            envelope=DPAPI_HEADER + os.urandom(24),
+        )
+
+
+def test_pbkdf_salt_material_rejects_wrong_salt_size() -> None:
+    with pytest.raises(ValueError, match="must be 16 bytes"):
+        DurableMaterial(kind=DurableKind.pbkdf_salt, salt=os.urandom(12))
+
+
+def test_dpapi_envelope_material_requires_envelope() -> None:
+    with pytest.raises(ValueError, match="requires an envelope"):
+        DurableMaterial(kind=DurableKind.dpapi_envelope)
+
+
+def test_dpapi_envelope_material_rejects_salt() -> None:
+    with pytest.raises(ValueError, match="must not carry a PBKDF salt"):
+        DurableMaterial(
+            kind=DurableKind.dpapi_envelope,
+            envelope=DPAPI_HEADER + os.urandom(24),
+            salt=os.urandom(16),
+        )
+
+
+def test_dpapi_envelope_material_rejects_bad_header() -> None:
+    with pytest.raises(ValueError, match="must start with the DPAPI header"):
+        DurableMaterial(kind=DurableKind.dpapi_envelope, envelope=b"XXXX" + os.urandom(24))
+
+
+def test_dpapi_envelope_material_rejects_header_only() -> None:
+    with pytest.raises(ValueError, match="longer than the header"):
+        DurableMaterial(kind=DurableKind.dpapi_envelope, envelope=DPAPI_HEADER)
+
+
+def test_dpapi_envelope_material_defaults_version() -> None:
+    material = DurableMaterial(
+        kind=DurableKind.dpapi_envelope,
+        envelope=DPAPI_HEADER + os.urandom(24),
+    )
+    assert material.envelope_version == DPAPI_ENVELOPE_VERSION
+    assert material.length == len(DPAPI_HEADER) + 24
+
+
+def test_pbkdf_salt_material_exposes_salt_field() -> None:
+    salt = os.urandom(16)
+    material = DurableMaterial(kind=DurableKind.pbkdf_salt, salt=salt)
+    assert material.salt == salt
+    assert material.envelope is None
+    assert material.envelope_version is None
+    assert material.length is None
+
+
+def test_extra_fields_forbidden() -> None:
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        DurableMaterial(
+            kind=DurableKind.pbkdf_salt,
+            salt=os.urandom(16),
+            unexpected="nope",
+        )
+
+
+# ── looks_like_dpapi_envelope ───────────────────────────────────────
+
+
+def test_looks_like_dpapi_envelope() -> None:
+    assert looks_like_dpapi_envelope(DPAPI_HEADER + os.urandom(24))
+    assert not looks_like_dpapi_envelope(DPAPI_HEADER)  # header only, not an envelope
+    assert not looks_like_dpapi_envelope(os.urandom(16))  # random salt
+
+
+# ── DurableMaterial: hex round trips ────────────────────────────────
+
+
+def test_pbkdf_durable_material_hex_round_trip() -> None:
+    salt = os.urandom(16)
+    material = DurableMaterial(kind=DurableKind.pbkdf_salt, salt=salt)
+    assert material.to_hex() == salt.hex()
+    restored = DurableMaterial.from_hex(DurableKind.pbkdf_salt, material.to_hex())
+    assert restored.kind == DurableKind.pbkdf_salt
+    assert restored.salt == salt
+    assert restored.envelope is None
+
+
+def test_dpapi_durable_material_hex_round_trip() -> None:
+    envelope = DPAPI_HEADER + os.urandom(24)
+    material = DurableMaterial(kind=DurableKind.dpapi_envelope, envelope=envelope)
+    assert material.to_hex() == envelope.hex()
+    restored = DurableMaterial.from_hex(
+        DurableKind.dpapi_envelope,
+        material.to_hex(),
+        envelope_version=material.envelope_version,
+    )
+    assert restored.kind == DurableKind.dpapi_envelope
+    assert restored.envelope == envelope
+    assert restored.envelope_version == material.envelope_version
+
+
+def test_from_hex_accepts_string_kind() -> None:
+    salt = os.urandom(16)
+    restored = DurableMaterial.from_hex("pbkdf_salt", salt.hex())
+    assert restored.kind == DurableKind.pbkdf_salt
+    assert restored.salt == salt
+
+
+def test_from_hex_rejects_invalid_hex() -> None:
+    with pytest.raises(ValueError, match="not valid hex"):
+        DurableMaterial.from_hex(DurableKind.pbkdf_salt, "not-hex!!")
+
+
+# ── DurableMaterial: dict round trips (round-trip acceptance) ───────
+
+
+def test_pbkdf_dict_round_trip_preserves_all_fields() -> None:
+    salt = os.urandom(16)
+    material = DurableMaterial(kind=DurableKind.pbkdf_salt, salt=salt)
+    payload = material.to_dict()
+    assert payload == {
+        "kind": "pbkdf_salt",
+        "hex": salt.hex(),
+        "envelope_version": None,
+    }
+    restored = DurableMaterial.from_dict(payload)
+    assert restored.kind == DurableKind.pbkdf_salt
+    assert restored.salt == salt
+    assert restored.envelope is None
+    assert restored.envelope_version is None
+
+
+def test_dpapi_dict_round_trip_preserves_all_fields() -> None:
+    envelope = DPAPI_HEADER + os.urandom(24)
+    material = DurableMaterial(kind=DurableKind.dpapi_envelope, envelope=envelope)
+    payload = material.to_dict()
+    assert payload == {
+        "kind": "dpapi_envelope",
+        "hex": envelope.hex(),
+        "envelope_version": DPAPI_ENVELOPE_VERSION,
+    }
+    restored = DurableMaterial.from_dict(payload)
+    assert restored.kind == DurableKind.dpapi_envelope
+    assert restored.envelope == envelope
+    assert restored.envelope_version == DPAPI_ENVELOPE_VERSION
+
+
+def test_from_dict_rejects_missing_kind() -> None:
+    with pytest.raises(RotationJournalError, match="invalid durable material payload"):
+        DurableMaterial.from_dict({"hex": os.urandom(16).hex()})
+
+
+def test_from_dict_rejects_mixed_kind_with_salt_bytes() -> None:
+    # A DPAPI envelope kind entry carrying PBKDF-only salt bytes is rejected:
+    # the 16-byte payload is not a valid envelope, so kind mixing is
+    # unrepresentable through the typed constructor. from_dict wraps the
+    # per-kind validation failure in RotationJournalError (a ValueError).
+    salt = os.urandom(16)
+    with pytest.raises(RotationJournalError, match="must start with the DPAPI header"):
+        DurableMaterial.from_dict({"kind": "dpapi_envelope", "hex": salt.hex()})

--- a/tests/testdata/README.md
+++ b/tests/testdata/README.md
@@ -5,6 +5,7 @@
 | `backup_aesgcm_v1.json` | Real hvbackup-v1 backup produced by `Vault.export_backup()` with writes pinned to aesgcm-v1. Contains a legacy credential without `crypto_version`, an explicit `aesgcm-v1` credential with scopes/tags/notes, and one lease. |
 | `backup_aesgcm_v1.salt` | The 16-byte salt the backup's ciphertexts were encrypted under. Tests copy it to a temp vault so the derived key matches (a real restore uses the operator's own salt file). |
 | `generate_v1_fixture.py` | Reproducible generator. Re-run with `env -u PYTHONPATH .venv/bin/python tests/testdata/generate_v1_fixture.py` from the repo root. |
+| `rotation_journal_v1.json` | Legacy `rotation-journal-v1` journal (the exact shape written by `Vault.rotate_master_key` pre-v2): a `db_committed`/`pending` journal with 16-byte PBKDF salts and an `old_segment_id`. Consumed by `tests/test_rotation_journal_contradiction.py` to prove a v1 fixture reads without data loss. |
 
 Passphrase for the fixture: `test-passphrase` (constant `PASSPHRASE` in
 `tests/test_backup_roundtrip_v1_v2.py` and in the generator).

--- a/tests/testdata/rotation_journal_v1.json
+++ b/tests/testdata/rotation_journal_v1.json
@@ -1,0 +1,10 @@
+{
+  "version": "rotation-journal-v1",
+  "status": "db_committed",
+  "old_salt": "a1b2c3d4e5f60718293a4b5c6d7e8f90",
+  "new_salt": "9f8e7d6c5b4a39281706f5e4d3c2b1a0",
+  "created_at": "2026-07-30T10:15:30+00:00",
+  "committed_at": "2026-07-30T10:15:45+00:00",
+  "audit_transition_state": "pending",
+  "old_segment_id": "seg-7f3a9c2e"
+}


### PR DESCRIPTION
## Summary

Implements Slice C of INTEGRITY_RECOVERY_PLAN.md: one shared, typed **rotation-journal-v2** state machine covering issues #58 (DPAPI envelope vs PBKDF salt mis-typing bricks Windows recovery) and #66 (journal deleted before the audit transition reconciles, losing the only recovery evidence).

New module `src/hermes_vault/rotation_journal.py`:

- **`DurableKind` / `DurableMaterial`** — typed discriminator for the durable master-key representation (`pbkdf_salt` | `dpapi_envelope`). Per-kind validation makes envelope-kind mixing unrepresentable; DPAPI entries require the `HVDP` magic + length gate, PBKDF entries require a 16-byte salt.
- **`OldKeyRecovery`** — encrypted old-key recovery material (issue #66): the pre-rotation audit/master key wrapped with AES-GCM under the *new* master key, AAD bound to the journal id with a domain-separated marker (`AAD_DOMAIN:rotation-journal-old-key:v1`) so recovery ciphertext can never be replayed as credential AAD. No passphrase or plaintext key is ever stored in the journal.
- **`RotationJournalEntry`** — typed v2 record with explicit state transitions (`start` → `mark_db_committed` → `mark_audit_checkpoint_committed`), a derived `phase()`, strict field validation, and deterministic JSON (canonical separators, sorted keys).
- **v1 backward read** — legacy `rotation-journal-v1` payloads are accepted, the durable kind is inferred from bytes (`HVDP` magic + length gate), ambiguous bytes fail closed with a `RotationJournalError`.
- **Contradiction retention** — contradictions (version/kind/durable/state conflicts) raise with a `ContradictionMarker`; `retain_contradiction_marker()` writes a sidecar marker and never truncates/deletes the original journal (Slice C retention rule).

`AuditIntegrityService.recover_pending_rotation(journal, old_master_key, new_master_key=None)`:

- Completes an interrupted `db_committed`/`pending` rotation idempotently: if the active segment is still the journaled old segment it completes the segment rotation under the new key (the `rotate_segment` body, minus the healthy-verify precondition); if the successor already exists it only rewrites the checkpoint; anything else fails closed and retains the journal + durable key material.
- Replay converges: re-running the same journal reaches the same state. The destructive `recover_checkpoint` / `_rebuild_integrity_for_key_mismatch` semantics are untouched (byte-identical).

## Tests

145 new tests across 6 files (types, serde, recovery, reconcile, contradiction, deterministic):

- DPAPI/legacy typing, mixed-kind rejection, round-trips
- v1 fixture reads without data loss; contradiction markers + journal retention
- interrupted-audit recovery resumes to the same state as a clean rotation; replay converges; fail-closed on contradiction/wrong key/started journal
- deterministic DPAPI/legacy/interrupted-audit scenarios (run on every platform via the `fake_win32` pattern)

Full suite: **1113 passed**. `ruff check` clean, `mypy` clean (63 files).

## Security review

Inline security review performed at integration (see task t_d12368ac on the Hermes board): no secrets in prompts/artifacts, parameterized SQL only, `BEGIN IMMEDIATE` static literal, journal writes go through `_platform.write_text_durable` → `secure_file` (0600), recovery material encrypted with domain-separated AAD, destructive functions untouched.

Closes #58, #66.