### PR TITLE
fix: complete secure restore and rotation recovery closeout

### DIFF
--- a/src/hermes_vault/audit_integrity/service.py
+++ b/src/hermes_vault/audit_integrity/service.py
@@ -254,6 +254,29 @@ class AuditIntegrityService:
             latest_digest=str(result["digest"]),
         )
 
+    def refresh_checkpoint(self, conn: sqlite3.Connection) -> None:
+        """Persist the authenticated checkpoint covering the current database tip.
+
+        Used after a transaction that committed no new protected record (an
+        idempotent restore replay): the checkpoint must still cover the tip
+        so the chain remains verifiable.
+        """
+        sequence, tip = self._tip(conn)
+        active = self._active(conn)
+        self._write_current_checkpoint(conn, active, latest_sequence=sequence, latest_digest=tip)
+
+    def access_log_exists(self, record_id: str) -> bool:
+        """Return whether an access-log row with *record_id* already exists.
+
+        Used by restore to detect an already-committed protected event so a
+        retry never appends a duplicate (issue #62B / F6).
+        """
+        try:
+            with self._connection() as conn:
+                return conn.execute("SELECT 1 FROM access_logs WHERE id = ?", (record_id,)).fetchone() is not None
+        except sqlite3.Error:
+            return False
+
     def _verify_checkpoint(self, conn: sqlite3.Connection, active: sqlite3.Row, sequence: int, tip: str) -> tuple[AuditCheckpointStatus, str | None]:
         checkpoint = read_checkpoint(self.checkpoint_path)
         if checkpoint is None:

--- a/src/hermes_vault/broker.py
+++ b/src/hermes_vault/broker.py
@@ -611,11 +611,16 @@ class Broker:
         )
 
     def import_credentials(self, agent_id: str, backup: dict, replace: bool = True) -> BrokerDecision:
-        """Import credentials from a backup dict.  Gated on ``import_credentials`` capability."""
+        """Import credentials from a backup dict.  Gated on ``import_credentials`` capability.
+
+        The real *agent_id* is passed through to the vault so the protected
+        (tamper-evident) restore audit event records the acting agent, not
+        the operator default (issue #62A F4).
+        """
         cap_ok, cap_reason = self.policy.can_capability(agent_id, AgentCapability.import_credentials)
         if not cap_ok:
             return self._deny(agent_id, "n/a", "import_credentials", cap_reason)
-        imported = self.vault.import_backup(backup, replace=replace)
+        imported = self.vault.import_backup(backup, replace=replace, agent_id=agent_id)
         self.audit.record(
             AccessLogRecord(
                 agent_id=agent_id,

--- a/src/hermes_vault/cli.py
+++ b/src/hermes_vault/cli.py
@@ -2978,7 +2978,7 @@ def restore_vault(
             "force-revoked on restore (active lease identities are never restored).[/yellow]"
         )
     try:
-        imported = vault.import_backup(backup)
+        imported = vault.import_backup(backup, agent_id=OPERATOR_AGENT_ID)
     except (ValueError, AuditIntegrityError, sqlite3.Error) as exc:
         error_class = _restore_error_class(exc)
         console.print(f"[red]Restore blocked ({error_class}): {exc}[/red]")
@@ -3014,6 +3014,8 @@ def _restore_error_class(exc: Exception) -> str:
         return "foreign credential linkage"
     if "does not match" in lowered:
         return "broker mismatch"
+    if "invalid audit integrity evidence" in lowered:
+        return "invalid audit integrity evidence"
     if "audit integrity evidence" in lowered:
         return "missing audit integrity evidence"
     if "unsupported backup version" in lowered:

--- a/src/hermes_vault/cli.py
+++ b/src/hermes_vault/cli.py
@@ -39,7 +39,7 @@ from hermes_vault.service_ids import normalize
 from hermes_vault.skillgen import SkillGenerator
 from hermes_vault.update import UpdateError, UpdatePlan, perform_update, resolve_update_plan
 from hermes_vault.verifier import Verifier
-from hermes_vault.vault import AmbiguousTargetError, Vault
+from hermes_vault.vault import AmbiguousTargetError, RestoreCommittedCheckpointError, Vault
 
 # â”€â”€ Banner helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
@@ -2979,6 +2979,18 @@ def restore_vault(
         )
     try:
         imported = vault.import_backup(backup, agent_id=OPERATOR_AGENT_ID)
+    except RestoreCommittedCheckpointError as exc:
+        # The restore data and its protected event committed; only the
+        # checkpoint publication failed. Never report this as a blocked /
+        # rolled-back restore (issue #62B / F6). Exit non-zero so automation
+        # notices the degraded audit state, with an accurate remediation hint.
+        console.print(f"[yellow]Restore committed, but the audit checkpoint could not be published: {exc}[/yellow]")
+        console.print(
+            "[yellow]The vault data was restored. Audit integrity will report checkpoint_stale until the "
+            "checkpoint is re-published; re-run the same restore (it is idempotent) or run "
+            "'hermes-vault audit checkpoint advance --yes'.[/yellow]"
+        )
+        raise typer.Exit(code=1)
     except (ValueError, AuditIntegrityError, sqlite3.Error) as exc:
         error_class = _restore_error_class(exc)
         console.print(f"[red]Restore blocked ({error_class}): {exc}[/red]")

--- a/src/hermes_vault/vault.py
+++ b/src/hermes_vault/vault.py
@@ -43,6 +43,17 @@ from hermes_vault.models import (
     LeaseStatus,
     utc_now,
 )
+from hermes_vault.rotation_journal import (
+    DurableKind,
+    DurableMaterial,
+    JournalPhase,
+    RotationJournalEntry,
+    RotationJournalError,
+    decrypt_old_key_recovery,
+    encrypt_old_key_recovery,
+    looks_like_dpapi_envelope,
+    retain_contradiction_marker,
+)
 from hermes_vault.service_ids import normalize
 
 
@@ -98,6 +109,21 @@ def _record_aad_metadata(record: "CredentialRecord") -> dict[str, Any]:
         record.credential_type,
         record.scopes,
     )
+
+
+def _durable_from_bytes(raw: bytes, fallback_salt: bytes) -> DurableMaterial:
+    """Typed durable material from the on-disk salt bytes.
+
+    The existing salt file is either a 16-byte PBKDF derivation salt or a
+    DPAPI envelope (``HVDP`` magic + payload).  A missing/empty file falls
+    back to the new derivation salt (mirrors the legacy journal behavior of
+    recording ``old_salt = new_salt`` for a fresh vault).
+    """
+    if not raw:
+        return DurableMaterial(kind=DurableKind.pbkdf_salt, salt=fallback_salt)
+    if looks_like_dpapi_envelope(raw):
+        return DurableMaterial(kind=DurableKind.dpapi_envelope, envelope=raw)
+    return DurableMaterial(kind=DurableKind.pbkdf_salt, salt=raw)
 
 
 class Vault:
@@ -391,64 +417,182 @@ class Vault:
             ).fetchone()
         return dict(row) if row else None
 
-    def _payload_decrypts_with_salt(
-        self,
-        passphrase: str,
-        salt: bytes,
-        payload: str,
-        *,
-        version: str = CRYPTO_VERSION,
-        aad_metadata: dict[str, Any] | None = None,
-    ) -> bool:
-        try:
-            decrypt_secret_versioned(payload, derive_key(passphrase, salt), version, aad_metadata)
-            return True
-        except Exception:
-            return False
-
     def _recover_rotation_journal(self, passphrase: str) -> None:
         journal_path = self.rotation_journal_path
         if not journal_path.exists():
             return
         try:
-            journal = json.loads(journal_path.read_text(encoding="utf-8"))
-            old_salt = bytes.fromhex(journal["old_salt"])
-            new_salt = bytes.fromhex(journal["new_salt"])
+            entry = RotationJournalEntry.from_json(journal_path.read_text(encoding="utf-8"))
+        except RotationJournalError as exc:
+            # Contradiction-class failure (v1/v2 version/kind/state conflicts):
+            # retain the original journal, record the marker when available,
+            # and surface a clear recovery error (Slice C retention rule).
+            if exc.marker is not None:
+                try:
+                    retain_contradiction_marker(journal_path, exc.marker)
+                except Exception:
+                    pass
+            raise RotationRecoveryError(
+                f"Master-key rotation journal at {journal_path} is malformed or contradictory "
+                f"and was retained for operator review: {exc}"
+            ) from exc
         except Exception as exc:
             raise RotationRecoveryError(
                 f"Master-key rotation journal at {journal_path} is unreadable."
             ) from exc
 
-        first = self._first_encrypted_payload()
-        if first is None:
-            recovered_salt = new_salt if journal.get("status") == "db_committed" else old_salt
-        else:
-            version = first.get("crypto_version") or CRYPTO_VERSION
-            aad_metadata = credential_aad_metadata(
-                first.get("id", ""),
-                first.get("service", ""),
-                first.get("alias", "default"),
-                first.get("credential_type", ""),
-                json.loads(first.get("scopes") or "[]"),
-            )
-            if self._payload_decrypts_with_salt(
-                passphrase, new_salt, first["encrypted_payload"],
-                version=version, aad_metadata=aad_metadata,
-            ):
-                recovered_salt = new_salt
-            elif self._payload_decrypts_with_salt(
-                passphrase, old_salt, first["encrypted_payload"],
-                version=version, aad_metadata=aad_metadata,
-            ):
-                recovered_salt = old_salt
-            else:
-                raise RotationRecoveryError(
-                    "Interrupted master-key rotation could not be recovered with either journaled salt."
-                )
+        phase = entry.phase()
 
-        self._replace_salt_durable(recovered_salt)
+        if phase == JournalPhase.started:
+            self._recover_started_journal(entry, passphrase, journal_path)
+            return
+
+        # db_committed (pending or checkpoint_committed): the credential DB is
+        # already encrypted under the new key. Derive the new key from the
+        # journaled new durable material, unwrap the old audit/master key from
+        # the recovery envelope, reconcile the audit transition idempotently,
+        # verify a healthy audit state, and only then finalize the new durable
+        # material and delete the journal.
+        new_key = self._durable_key(entry.new_durable, passphrase)
+        if entry.old_key_recovery is None:
+            if phase == JournalPhase.db_committed_pending:
+                # Legacy v1 pending journal predates protected old-key
+                # recovery: cannot reconcile without the old audit key. Retain
+                # and surface a clear recovery error (issue #66 requirement).
+                raise RotationRecoveryError(
+                    "Legacy rotation journal is pending but lacks protected old-key "
+                    "recovery material; journal retained for operator review. Manual "
+                    "recovery is required before this vault can reopen."
+                )
+            # checkpoint_committed: the audit transition already completed, so
+            # the old key is not needed by the reconciliation seam.
+            old_key = new_key
+        else:
+            try:
+                old_key = decrypt_old_key_recovery(
+                    entry.old_key_recovery, new_key, entry.journal_id
+                )
+            except Exception as exc:
+                raise RotationRecoveryError(
+                    "Master-key rotation journal old-key recovery could not be decrypted "
+                    f"(wrong passphrase or tampered journal); journal retained: {exc}"
+                ) from exc
+
+        service = AuditIntegrityService(self.db_path, new_key)
+        try:
+            result = service.recover_pending_rotation(entry, old_master_key=old_key)
+        except AuditIntegrityError as exc:
+            raise RotationRecoveryError(
+                f"Master-key rotation journal audit reconciliation failed; journal retained: {exc}"
+            ) from exc
+        if result.status != AuditIntegrityStatus.healthy:
+            raise RotationRecoveryError(
+                "Master-key rotation journal audit verification is not healthy after recovery "
+                f"({result.sanitized_reason}); journal retained for operator review."
+            )
+
+        # All checks passed: finalize the new durable material, then delete.
+        self._write_new_durable(entry.new_durable, new_key)
         journal_path.unlink()
         self._fsync_directory(journal_path.parent)
+
+    def _recover_started_journal(
+        self,
+        entry: RotationJournalEntry,
+        passphrase: str,
+        journal_path: Path,
+    ) -> None:
+        """Recover a pre-commit ``started`` journal (safe rollback).
+
+        A started journal means the credential DB was never committed under
+        the new key, so the old durable form is still correct.  Restore it
+        and delete the journal.  If the old key does not decrypt the DB but
+        the journaled new key does, the DB was committed without the journal
+        being updated — an ambiguous state that fails closed and retains the
+        journal (issue #66: never silently delete a pending journal).
+        """
+        old_key = self._durable_key(entry.old_durable, passphrase)
+        first = self._first_encrypted_payload()
+        if first is None:
+            self._restore_durable_bytes(entry.old_durable)
+            journal_path.unlink()
+            self._fsync_directory(journal_path.parent)
+            return
+        version = first.get("crypto_version") or CRYPTO_VERSION
+        aad_metadata = credential_aad_metadata(
+            first.get("id", ""),
+            first.get("service", ""),
+            first.get("alias", "default"),
+            first.get("credential_type", ""),
+            json.loads(first.get("scopes") or "[]"),
+        )
+        if self._payload_decrypts_with_key(
+            old_key,
+            first["encrypted_payload"],
+            version=version,
+            aad_metadata=aad_metadata,
+        ):
+            self._restore_durable_bytes(entry.old_durable)
+            journal_path.unlink()
+            self._fsync_directory(journal_path.parent)
+            return
+        new_key = self._durable_key(entry.new_durable, passphrase)
+        if self._payload_decrypts_with_key(
+            new_key,
+            first["encrypted_payload"],
+            version=version,
+            aad_metadata=aad_metadata,
+        ):
+            raise RotationRecoveryError(
+                "Master-key rotation journal is 'started' but the credential DB is already "
+                "encrypted under the new key (ambiguous state); journal retained for operator review."
+            )
+        raise RotationRecoveryError(
+            "Interrupted master-key rotation could not be recovered with the provided "
+            "passphrase (neither journaled key decrypts the vault); journal retained."
+        )
+
+    def _durable_key(self, durable: DurableMaterial, passphrase: str) -> bytes:
+        """Derive/unwrap the master key for a typed durable material."""
+        if durable.kind == DurableKind.pbkdf_salt:
+            assert durable.salt is not None
+            return derive_key(passphrase, durable.salt)
+        from hermes_vault import dpapi  # deferred: keeps win32crypt off the cold path
+
+        assert durable.envelope is not None
+        return dpapi.unprotect_master_key(durable.envelope)
+
+    def _restore_durable_bytes(self, durable: DurableMaterial) -> None:
+        """Write the exact durable bytes back to the salt file (rollback)."""
+        if durable.kind == DurableKind.pbkdf_salt:
+            assert durable.salt is not None
+            self._replace_salt_durable(durable.salt)
+        else:
+            assert durable.envelope is not None
+            self._replace_salt_durable(durable.envelope)
+
+    def _write_new_durable(self, durable: DurableMaterial, new_key: bytes) -> None:
+        """Persist the new durable form (DPAPI-aware for PBKDF salts)."""
+        if durable.kind == DurableKind.pbkdf_salt:
+            assert durable.salt is not None
+            self._write_master_key_durable(durable.salt, new_key)
+        else:
+            assert durable.envelope is not None
+            self._replace_salt_durable(durable.envelope)
+
+    def _payload_decrypts_with_key(
+        self,
+        key: bytes,
+        payload: str,
+        *,
+        version: str,
+        aad_metadata: dict[str, Any] | None,
+    ) -> bool:
+        try:
+            decrypt_secret_versioned(payload, key, version, aad_metadata)
+            return True
+        except Exception:
+            return False
 
     def _secure_storage_files(self) -> None:
         _platform.secure_file(self.db_path)
@@ -1930,21 +2074,30 @@ class Vault:
 
         new_salt = os.urandom(SALT_SIZE)
         new_key = derive_key(new_passphrase, new_salt)
-        journal = {
-            "version": "rotation-journal-v1",
-            "status": "started",
-            "old_salt": new_salt.hex(),  # placeholder; replaced below
-            "new_salt": new_salt.hex(),
-            "created_at": utc_now().isoformat(),
-        }
-        # The journal records the existing durable form (16-byte salt
-        # for legacy vaults, DPAPI envelope bytes for DPAPI vaults)
-        # under "old_salt" and the new derivation salt under "new_salt".
-        # DPAPI wrapping happens at the durable write, not in the
-        # journal (per spec §2.3 / §5.3 test 20).
+
+        # Typed v2 journal (issue #66 / Slice C): persist the old/new
+        # durable material plus the encrypted old audit/master key under
+        # the new key BEFORE the credential DB commit. The journal never
+        # stores a passphrase or a plaintext key; the recovery envelope
+        # is AES-GCM-wrapped under the new key with AAD bound to the
+        # journal id.
         existing_durable = self.salt_path.read_bytes() if self.salt_path.exists() else b""
-        journal["old_salt"] = existing_durable.hex() if existing_durable else new_salt.hex()
-        self._write_rotation_journal(journal)
+        old_durable = _durable_from_bytes(existing_durable, new_salt)
+        new_durable = DurableMaterial(kind=DurableKind.pbkdf_salt, salt=new_salt)
+        journal_id = str(uuid4())
+        recovery = encrypt_old_key_recovery(old_key, new_key, journal_id)
+        entry = RotationJournalEntry.start(
+            old_durable=old_durable,
+            new_durable=new_durable,
+            old_key_recovery=recovery,
+            journal_id=journal_id,
+        )
+        self._write_rotation_journal(entry.to_dict())
+
+        # Record the exact old audit segment BEFORE the DB commit so a
+        # crash between the commit and the db_committed journal write can
+        # still be reconciled on reopen.
+        old_segment_id = audit_result.active_segment_id or ""
 
         re_encrypted = 0
         all_records = self.list_credentials()
@@ -1974,14 +2127,29 @@ class Vault:
                 conn.rollback()
                 raise
 
-        journal["status"] = "db_committed"
-        journal["committed_at"] = utc_now().isoformat()
-        journal["audit_transition_state"] = "pending"
-        journal["old_segment_id"] = audit_result.active_segment_id or ""
-        self._write_rotation_journal(journal)
+        # After the DB commit persist db_committed/pending with the exact
+        # old audit segment captured before the commit.
+        committed = entry.mark_db_committed(
+            old_segment_id=old_segment_id,
+            old_key_recovery=recovery,
+        )
+        self._write_rotation_journal(committed.to_dict())
+
         audit_integrity.rotate_segment(new_key)
-        journal["audit_transition_state"] = "checkpoint_committed"
-        self._write_rotation_journal(journal)
+
+        final = committed.mark_audit_checkpoint_committed()
+        self._write_rotation_journal(final.to_dict())
+
+        # Verify the audit chain is healthy under the new key before
+        # finalizing the durable material and deleting the journal (issue
+        # #66: deletion only after all checks pass).
+        post_result = audit_integrity.verify()
+        if post_result.status.value != "healthy":
+            raise AuditIntegrityError(
+                f"Master-key rotation completed but audit verification is not healthy "
+                f"({post_result.sanitized_reason}); rotation journal retained for recovery."
+            )
+
         # DPAPI-aware write: when HERMES_VAULT_DPAPI=1 is set, the
         # new master key is wrapped with DPAPI on write. Otherwise the
         # legacy 16-byte derivation salt is written verbatim. No

--- a/src/hermes_vault/vault.py
+++ b/src/hermes_vault/vault.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 from hermes_vault import _platform
 from hermes_vault.audit_integrity.checkpoint import AuditLockError, audit_write_lock
+from hermes_vault.audit_integrity.detached import DETACHED_HEALTHY, verify_detached_evidence
 from hermes_vault.audit_integrity.models import AuditIntegrityStatus
 from hermes_vault.audit_integrity.service import AuditIntegrityError, AuditIntegrityService
 from hermes_vault.crypto import (
@@ -1381,35 +1382,58 @@ class Vault:
             backup["audit_integrity"] = audit_service.export_evidence()  # type: ignore[assignment]
         return backup
 
-    def import_backup(self, backup: dict, replace: bool = True) -> list[CredentialRecord]:
+    def import_backup(
+        self,
+        backup: dict,
+        replace: bool = True,
+        agent_id: str = "operator",  # matches OPERATOR_AGENT_ID in mutations.py
+    ) -> list[CredentialRecord]:
         """Import credentials from a backup dict. Existing records are replaced by default.
 
         Supports hvbackup-v1 and hvbackup-v2 (credential portion only).
         Rejects metadata-only backups (entries missing encrypted_payload).
 
+        *agent_id* names the acting principal for the protected restore audit
+        event. Operator/CLI callers keep the explicit safe default
+        (``operator``); broker-driven imports pass the real agent so the
+        tamper-evident trail attributes the restore correctly (issue #62A F4).
+
         Slice E1 (issue #62): the restore is validated by a preflight routine
         before any mutation — the evidence contract is confirmed (v2 backups
-        must carry audit integrity evidence), restored leases are rejected if
-        they would mint a forged active lease identity or reference a foreign
-        credential, and every lease's broker identity must match the
-        credential it references. The import then runs as a single
-        transaction together with a protected restore audit event through the
-        shared audit seam; if any row, validation, or audit append fails, the
-        whole restore rolls back atomically.
+        must carry audit integrity evidence that detached-verifies healthy,
+        matching backup-verify / restore --dry-run semantics), restored
+        leases are rejected if they would mint a forged active lease identity
+        or reference a foreign credential, and every lease's broker identity
+        must match the credential it references. The import then runs as a
+        single transaction together with a protected restore audit event
+        through the shared audit seam; if any row, validation, or audit
+        append fails, the whole restore rolls back atomically.
         """
         version = backup.get("version")
         if version not in ("hvbackup-v1", "hvbackup-v2"):
             raise ValueError(f"Unsupported backup version: {version}")
 
         # ── E1 preflight: validate before any mutation ──
-        # 1. Evidence contract: hvbackup-v2 backups must carry the detached
-        #    audit integrity evidence (slice D prerequisite).
+        # 1. Evidence contract: hvbackup-v2 backups must carry detached
+        #    audit integrity evidence that verifies healthy (slice D
+        #    prerequisite, issue #62A F3). The integrity_available marker
+        #    alone is not evidence: the full payload is detached-verified
+        #    against the current vault key with the same healthy/complete
+        #    semantics as backup-verify / restore --dry-run, so a marker-only
+        #    or forged payload fails closed before any write.
         if version == "hvbackup-v2":
             evidence = backup.get("audit_integrity")
             if not isinstance(evidence, dict) or evidence.get("integrity_available") is not True:
                 raise ValueError(
                     "Cannot restore an hvbackup-v2 backup without audit integrity evidence. "
                     "Use a full v2 backup (with audit evidence) for restore."
+                )
+            status, reason = verify_detached_evidence(evidence, self.key)
+            if status != DETACHED_HEALTHY:
+                raise ValueError(
+                    f"Cannot restore an hvbackup-v2 backup with invalid audit integrity "
+                    f"evidence ({status}: {reason}). Run backup-verify or restore "
+                    "--dry-run for a full report."
                 )
 
         # 2. Parse and validate every credential row before writing anything.
@@ -1575,7 +1599,7 @@ class Vault:
             raise AuditIntegrityError(current.sanitized_reason)
 
         restore_event = AccessLogRecord(
-            agent_id="operator",  # matches OPERATOR_AGENT_ID in mutations.py
+            agent_id=agent_id,  # real acting agent (operator default; broker passes the agent)
             service="*",
             action="restore",
             decision=Decision.allow,

--- a/src/hermes_vault/vault.py
+++ b/src/hermes_vault/vault.py
@@ -81,18 +81,20 @@ class RestoreCommittedCheckpointError(RuntimeError):
     """
 
 
-def _restore_event_id(backup: dict, version: str) -> str:
+def _restore_event_id(backup: dict, version: str, agent_id: str = "operator") -> str:
     """Deterministic id for a restore's protected audit event (issue #62B / F6).
 
-    Derived from the backup's restore-relevant content so a retry of the
-    same restore reuses the same event id: the import transaction then skips
-    the append instead of creating duplicate protected restore events.
+    Derived from the backup's restore-relevant content *and acting agent* so a
+    retry of the same restore by the same principal reuses the same event id,
+    while a distinct actor restoring identical content gets its own protected
+    restore attribution.
     """
     content = json.dumps(
         {
             "version": version,
             "credentials": backup.get("credentials", []),
             "leases": backup.get("leases", []),
+            "agent_id": agent_id,
         },
         sort_keys=True,
         default=str,
@@ -1777,13 +1779,13 @@ class Vault:
             prepared_leases.append((lease, self.get_lease(lease_id)))
 
         # 4. Build the protected restore event. Its id is deterministic
-        #    (derived from the backup's restore-relevant content) so a retry
-        #    of the same restore reuses the event instead of appending a
-        #    duplicate protected event (issue #62B / F6).
+        #    (derived from the backup's restore-relevant content and acting
+        #    agent) so a retry of the same restore reuses the event instead
+        #    of appending a duplicate protected event (issue #62B / F6).
         audit_service = AuditIntegrityService(self.db_path, self.key)
         audit_service.ensure_initialized()
         restore_event = AccessLogRecord(
-            id=_restore_event_id(backup, version),
+            id=_restore_event_id(backup, version, agent_id),
             agent_id=agent_id,  # real acting agent (operator default; broker passes the agent)
             service="*",
             action="restore",

--- a/src/hermes_vault/vault.py
+++ b/src/hermes_vault/vault.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sqlite3
@@ -56,6 +57,36 @@ class AmbiguousTargetError(RuntimeError):
 
 class RotationRecoveryError(RuntimeError):
     """Raised when an interrupted master-key rotation cannot be recovered."""
+
+
+class RestoreCommittedCheckpointError(RuntimeError):
+    """The restore data committed, but the audit checkpoint could not be published.
+
+    Raised after the restore transaction has committed and its protected
+    restore event is durable; the failure is confined to the filesystem
+    checkpoint publication. The chain will verify as ``checkpoint_stale``
+    until the checkpoint is re-published (re-run the restore — it is
+    idempotent — or run ``hermes-vault audit checkpoint advance``).
+    """
+
+
+def _restore_event_id(backup: dict, version: str) -> str:
+    """Deterministic id for a restore's protected audit event (issue #62B / F6).
+
+    Derived from the backup's restore-relevant content so a retry of the
+    same restore reuses the same event id: the import transaction then skips
+    the append instead of creating duplicate protected restore events.
+    """
+    content = json.dumps(
+        {
+            "version": version,
+            "credentials": backup.get("credentials", []),
+            "leases": backup.get("leases", []),
+        },
+        sort_keys=True,
+        default=str,
+    )
+    return f"restore-{hashlib.sha256(content.encode('utf-8')).hexdigest()[:32]}"
 
 
 def _record_aad_metadata(record: "CredentialRecord") -> dict[str, Any]:
@@ -1408,6 +1439,17 @@ class Vault:
         single transaction together with a protected restore audit event
         through the shared audit seam; if any row, validation, or audit
         append fails, the whole restore rolls back atomically.
+
+        Issue #62B (F5/F6): the audit write lock is held across the health
+        gate and the transaction, and lease/credential linkage plus broker
+        identity are re-verified inside ``BEGIN IMMEDIATE`` against fresh
+        state, closing the preflight-to-transaction TOCTOU. The protected
+        restore event uses a deterministic id derived from the backup content
+        so a retry is idempotent; the checkpoint is published after commit,
+        and a checkpoint publication failure raises
+        :class:`RestoreCommittedCheckpointError` — the restore data is
+        durable and the chain verifies ``checkpoint_stale`` until the
+        checkpoint is re-published, never a rolled-back restore.
         """
         version = backup.get("version")
         if version not in ("hvbackup-v1", "hvbackup-v2"):
@@ -1590,15 +1632,14 @@ class Vault:
                 })
             prepared_leases.append((lease, self.get_lease(lease_id)))
 
-        # 4. Confirm the vault's audit evidence contract is usable so the
-        #    protected restore event can be sealed in the same transaction.
+        # 4. Build the protected restore event. Its id is deterministic
+        #    (derived from the backup's restore-relevant content) so a retry
+        #    of the same restore reuses the event instead of appending a
+        #    duplicate protected event (issue #62B / F6).
         audit_service = AuditIntegrityService(self.db_path, self.key)
         audit_service.ensure_initialized()
-        current = audit_service.verify()
-        if current.status != AuditIntegrityStatus.healthy:
-            raise AuditIntegrityError(current.sanitized_reason)
-
         restore_event = AccessLogRecord(
+            id=_restore_event_id(backup, version),
             agent_id=agent_id,  # real acting agent (operator default; broker passes the agent)
             service="*",
             action="restore",
@@ -1615,13 +1656,71 @@ class Vault:
         )
 
         # ── E1 single transaction: credentials + leases + protected audit ──
+        # The audit write lock is held across the health gate AND the
+        # transaction, so the preflight audit verification cannot be
+        # invalidated by a concurrent audit writer before the append
+        # (issue #62B / F5).
         imported: list[CredentialRecord] = []
         try:
             with audit_write_lock(audit_service.lock_path):
+                current = audit_service.verify()
+                if current.status != AuditIntegrityStatus.healthy:
+                    # A retry of an already-committed restore is the one case
+                    # where the chain may be checkpoint_stale: the previous
+                    # attempt committed the protected event but failed to
+                    # publish the checkpoint (F6). checkpoint_stale is only
+                    # reported after the full chain walk passes, so the chain
+                    # itself is healthy and the retry may proceed to
+                    # re-publish the checkpoint instead of duplicating it.
+                    event_already_committed = audit_service.access_log_exists(restore_event.id)
+                    if not (event_already_committed and current.reason_code == "checkpoint_stale"):
+                        raise AuditIntegrityError(current.sanitized_reason)
                 with self._connection() as conn:
                     conn.row_factory = sqlite3.Row
                     conn.execute("BEGIN IMMEDIATE")
                     try:
+                        # ── F5: re-verify linkage/identity inside the write
+                        # transaction. The preflight validated against the
+                        # pre-lock snapshot; BEGIN IMMEDIATE now holds the
+                        # SQLite write lock, so re-checking against fresh
+                        # state closes the preflight-to-transaction TOCTOU:
+                        # a concurrent writer can no longer interleave once
+                        # we hold the write lock, and a dangling lease or
+                        # stale-identity import is rejected atomically.
+                        existing_ids = {row["id"] for row in conn.execute("SELECT id FROM credentials")}
+                        inserted_ids = {rec.id for rec, existing in prepared_creds if existing is None}
+                        for rec, existing in prepared_creds:
+                            if existing is not None and rec.id not in existing_ids:
+                                raise ValueError(
+                                    f"Credential {rec.service}/{rec.alias} was removed while the restore "
+                                    "was being prepared; the restore was aborted to preserve atomicity. "
+                                    "Retry the restore."
+                                )
+                        final_cred_ids = existing_ids | inserted_ids
+                        prepared_identity = {rec.id: rec for rec, _existing in prepared_creds}
+                        for lease, _existing_lease in prepared_leases:
+                            if lease.credential_id not in final_cred_ids:
+                                raise ValueError(
+                                    f"Lease {lease.id!r} references credential {lease.credential_id!r} "
+                                    "which is not part of the backup or the vault (foreign credential linkage)."
+                                )
+                            row = conn.execute(
+                                "SELECT service, alias, credential_type FROM credentials WHERE id = ?",
+                                (lease.credential_id,),
+                            ).fetchone()
+                            if row is None:
+                                referenced = prepared_identity[lease.credential_id]
+                                referenced_identity = (referenced.service, referenced.alias, referenced.credential_type)
+                            else:
+                                referenced_identity = (row["service"], row["alias"], row["credential_type"])
+                            lease_identity = (lease.service, lease.alias, lease.credential_type)
+                            if lease_identity != referenced_identity:
+                                raise ValueError(
+                                    f"Lease {lease.id!r} broker identity "
+                                    f"({lease.service}/{lease.alias}/{lease.credential_type}) does not match "
+                                    f"credential {lease.credential_id!r} "
+                                    f"({referenced_identity[0]}/{referenced_identity[1]}/{referenced_identity[2]})."
+                                )
                         for record, existing in prepared_creds:
                             if existing:
                                 conn.execute(
@@ -1734,12 +1833,40 @@ class Vault:
                                         json.dumps(lease.metadata, sort_keys=True),
                                     ),
                                 )
-                        append_result = audit_service.append_in_transaction(conn, restore_event)
+                        # ── F6: idempotent protected event. A retry of an
+                        # already-committed restore reuses the deterministic
+                        # event id and skips the append; the credential/lease
+                        # writes above are row-idempotent, so the replay only
+                        # re-publishes the checkpoint.
+                        existing_event = conn.execute(
+                            "SELECT id FROM access_logs WHERE id = ?", (restore_event.id,)
+                        ).fetchone()
+                        if existing_event is None:
+                            append_result = audit_service.append_in_transaction(conn, restore_event)
+                        else:
+                            append_result = None
                         conn.commit()
-                        audit_service.write_checkpoint_after_append(conn, append_result)
                     except Exception:
                         conn.rollback()
                         raise
+                    # Checkpoint publication runs after commit by design: the
+                    # SQLite commit is the durability boundary for the restore
+                    # data and its protected event. A failure here must not
+                    # report a rolled-back restore (F6) — the data is durable,
+                    # and the chain verifies checkpoint_stale until the
+                    # checkpoint is re-published.
+                    try:
+                        if append_result is not None:
+                            audit_service.write_checkpoint_after_append(conn, append_result)
+                        else:
+                            audit_service.refresh_checkpoint(conn)
+                    except Exception as exc:
+                        raise RestoreCommittedCheckpointError(
+                            "Restore data committed, but the audit checkpoint could not be published "
+                            f"after commit ({exc}). Audit integrity will report checkpoint_stale until "
+                            "the checkpoint is re-published; re-run this restore (it is idempotent) or "
+                            "run 'hermes-vault audit checkpoint advance'."
+                        ) from exc
         except AuditLockError as exc:
             raise AuditIntegrityError(str(exc)) from exc
         return imported

--- a/tests/test_backup_recovery.py
+++ b/tests/test_backup_recovery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 
 from hermes_vault.backup import restore_dry_run, verify_backup_file
 from hermes_vault.vault import Vault
@@ -222,7 +223,26 @@ def test_import_backup_accepts_v2(tmp_path: Path) -> None:
     vault.add_credential("openai", "sk-fake1234567890", "api_key")
     backup = vault.export_backup(include_audit=True)
 
+    # A valid v2 restore targets a vault sharing the source master key (the
+    # realistic recovery path: the same passphrase/salt material). With a
+    # mismatched key the evidence fails closed (key_mismatch), mirroring
+    # backup-verify/restore --dry-run semantics (#62A F3).
+    import shutil
+
+    shutil.copy(tmp_path / "salt.bin", tmp_path / "restored-salt.bin")
     restore_vault = Vault(tmp_path / "restored.db", tmp_path / "restored-salt.bin", "test-passphrase")
     imported = restore_vault.import_backup(backup)
     assert len(imported) == 1
     assert imported[0].service == "openai"
+
+
+def test_import_backup_v2_rejects_key_mismatch(tmp_path: Path) -> None:
+    """A v2 backup restored into a different-key vault fails closed (F3)."""
+    vault = _make_vault(tmp_path)
+    vault.add_credential("openai", "sk-fake1234567890", "api_key")
+    backup = vault.export_backup(include_audit=True)
+
+    restore_vault = Vault(tmp_path / "restored.db", tmp_path / "restored-salt.bin", "test-passphrase")
+    with pytest.raises(ValueError, match="key_mismatch"):
+        restore_vault.import_backup(backup)
+    assert restore_vault.list_credentials() == []

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -859,6 +859,47 @@ def test_broker_import_allowed_legacy_agent(tmp_path: Path) -> None:
     assert decision.metadata["imported_count"] == 1
 
 
+def test_broker_import_protected_event_attributes_real_agent(tmp_path: Path) -> None:
+    """F4: broker-driven imports must attribute the protected restore event.
+
+    Review F4 (SECURITY_REVIEW_62_66.md): the tamper-evident restore event
+    hardcoded ``agent_id="operator"`` even for broker-driven imports. The
+    protected chain must record the real acting agent so agent-driven
+    imports are accountable in the protected trail.
+    """
+    import sqlite3
+
+    vault = Vault(tmp_path / "vault.db", tmp_path / "salt.bin", "test-passphrase")
+    vault.add_credential("openai", "sk-test", "api_key")
+    backup = vault.export_backup()
+
+    vault2 = Vault(tmp_path / "vault2.db", tmp_path / "salt2.bin", "test-passphrase")
+    policy = PolicyEngine(
+        PolicyConfig(
+            agents={
+                "pam": AgentPolicy(
+                    services=["openai"],
+                    capabilities=[AgentCapability.import_credentials],
+                    max_ttl_seconds=900,
+                )
+            }
+        )
+    )
+    broker = Broker(vault2, policy, StubVerifier(), AuditLogger(tmp_path / "vault2.db"))
+    decision = broker.import_credentials("pam", backup)
+    assert decision.allowed is True
+    assert decision.metadata["imported_count"] == 1
+
+    with sqlite3.connect(vault2.db_path) as conn:
+        rows = conn.execute(
+            "SELECT action, agent_id FROM access_logs WHERE action = 'restore'"
+        ).fetchall()
+    assert rows, "no protected restore audit event written"
+    assert all(agent_id == "pam" for _, agent_id in rows), (
+        f"protected restore event misattributes actor: {rows}"
+    )
+
+
 # ── OAuth freshness helpers (inlined for test independence) ─────────────
 
 

--- a/tests/test_key_management.py
+++ b/tests/test_key_management.py
@@ -1,12 +1,25 @@
 from __future__ import annotations
 
+import json
 import os
+import sqlite3
 from pathlib import Path
 
 import pytest
 
+from hermes_vault.audit import AuditLogger
+from hermes_vault.audit_integrity.models import AuditIntegrityStatus
+from hermes_vault.audit_integrity.service import AuditIntegrityService
 from hermes_vault.config import AppSettings
-from hermes_vault.crypto import CorruptKeyMaterialError, MissingKeyMaterialError
+from hermes_vault.crypto import CorruptKeyMaterialError, MissingKeyMaterialError, derive_key
+from hermes_vault.models import AccessLogRecord, Decision
+from hermes_vault.rotation_journal import (
+    DurableKind,
+    DurableMaterial,
+    JournalPhase,
+    RotationJournalEntry,
+    encrypt_old_key_recovery,
+)
 from hermes_vault.vault import RotationRecoveryError, Vault
 
 
@@ -151,3 +164,292 @@ def test_rotate_master_key_no_secrets_in_audit(tmp_path: Path) -> None:
     entries = audit.list_recent(limit=10, action="rotate_master_key")
     for entry in entries:
         assert "sk-test" not in str(entry)
+
+
+# ── Issue #66: live v2 rotation-journal recovery regressions ──────────────
+
+
+def _seed_vault(tmp_path: Path, passphrase: str = "old-pass") -> tuple[Vault, Path, Path]:
+    """Create a vault with one credential and one protected audit record."""
+    db = tmp_path / "vault.db"
+    salt = tmp_path / "salt.bin"
+    vault = Vault(db, salt, passphrase)
+    vault.add_credential("openai", "sk-test-1234", "api_key", alias="primary")
+    logger = AuditLogger(vault.db_path, master_key=vault.key)
+    logger.record(
+        AccessLogRecord(
+            agent_id="agent-1",
+            service="openai",
+            action="get_env",
+            decision=Decision.allow,
+            reason="seed",
+        )
+    )
+    return vault, db, salt
+
+
+def _segment_rows(db: Path) -> list[sqlite3.Row]:
+    with sqlite3.connect(db) as conn:
+        conn.row_factory = sqlite3.Row
+        return conn.execute(
+            "SELECT * FROM audit_integrity_segments ORDER BY segment_number"
+        ).fetchall()
+
+
+def test_crash_before_audit_rotation_recovers_on_reopen_with_new_passphrase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Crash immediately before audit rotation; reopen with the new passphrase.
+
+    The credential DB is already committed under the new key, but the audit
+    chain is still under the old key. Recovery must decrypt the old-key
+    recovery material, reconcile the audit transition, finalize the durable
+    material, and only then delete the journal — leaving credentials readable
+    and the audit chain healthy.
+    """
+    vault, db, salt = _seed_vault(tmp_path)
+
+    def _crash_rotate_segment(self: AuditIntegrityService, new_master_key: bytes) -> None:
+        raise RuntimeError("simulated crash before audit rotation")
+
+    with monkeypatch.context() as m:
+        m.setattr(AuditIntegrityService, "rotate_segment", _crash_rotate_segment)
+        with pytest.raises(RuntimeError, match="simulated crash before audit rotation"):
+            vault.rotate_master_key("old-pass", "new-pass")
+
+    journal = salt.with_name(f"{salt.name}.rotation.json")
+    assert journal.exists()
+    entry = RotationJournalEntry.from_json(journal.read_text(encoding="utf-8"))
+    assert entry.phase() == JournalPhase.db_committed_pending
+    assert entry.old_key_recovery is not None
+
+    # Reopen with the NEW passphrase: recovery reconciles the audit chain.
+    recovered = Vault(db, salt, "new-pass")
+    secret = recovered.get_secret("openai")
+    assert secret is not None
+    assert secret.secret == "sk-test-1234"
+    assert not recovered.rotation_journal_path.exists()
+
+    svc = AuditIntegrityService(db, recovered.key)
+    result = svc.verify()
+    assert result.status is AuditIntegrityStatus.healthy
+    assert result.active_segment_number == 2
+    assert result.verified_count == 1
+
+
+def test_crash_after_audit_commit_before_checkpoint_reconciles_on_reopen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Successor committed but checkpoint publication interrupted.
+
+    Recovery must detect that the active segment is already the journaled
+    old segment's successor, rewrite only the checkpoint, and leave the exact
+    predecessor/successor relationship intact — no duplicate segment and no
+    unrelated registry authentication.
+    """
+    vault, db, salt = _seed_vault(tmp_path)
+    old_segment_id = AuditIntegrityService(db, vault.key).verify().active_segment_id
+    assert old_segment_id is not None
+
+    def _crash_checkpoint(
+        self: AuditIntegrityService, conn: sqlite3.Connection, segment: sqlite3.Row, **kwargs: object
+    ) -> None:
+        raise RuntimeError("simulated crash before checkpoint publication")
+
+    with monkeypatch.context() as m:
+        m.setattr(AuditIntegrityService, "_write_current_checkpoint", _crash_checkpoint)
+        with pytest.raises(RuntimeError, match="simulated crash before checkpoint publication"):
+            vault.rotate_master_key("old-pass", "new-pass")
+
+    journal = salt.with_name(f"{salt.name}.rotation.json")
+    assert journal.exists()
+
+    # Reopen with the NEW passphrase: recovery rewrites the checkpoint only.
+    recovered = Vault(db, salt, "new-pass")
+    secret = recovered.get_secret("openai")
+    assert secret is not None
+    assert secret.secret == "sk-test-1234"
+    assert not recovered.rotation_journal_path.exists()
+
+    svc = AuditIntegrityService(db, recovered.key)
+    result = svc.verify()
+    assert result.status is AuditIntegrityStatus.healthy
+    assert result.active_segment_number == 2
+
+    segments = _segment_rows(db)
+    assert len(segments) == 2
+    assert segments[0]["segment_id"] == old_segment_id
+    assert segments[1]["predecessor_segment_id"] == old_segment_id
+    # The successor's predecessor tip must equal the old segment's last digest.
+    with sqlite3.connect(db) as conn:
+        conn.row_factory = sqlite3.Row
+        old_tip = conn.execute(
+            "SELECT entry_digest FROM audit_integrity_records WHERE segment_id = ? ORDER BY sequence DESC LIMIT 1",
+            (old_segment_id,),
+        ).fetchone()
+    assert segments[1]["predecessor_tip_digest"] == old_tip["entry_digest"]
+
+
+def test_pre_commit_crash_rolls_back_with_old_passphrase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Crash before the credential DB commit; reopen with the OLD passphrase.
+
+    The started journal is a safe pre-commit rollback: restore the old
+    durable material, delete the journal, and leave credentials readable
+    under the old key with a healthy (untouched) audit chain.
+    """
+    vault, db, salt = _seed_vault(tmp_path)
+    original_salt = salt.read_bytes()
+
+    def _boom(secret: str, key: bytes, version: str, aad: dict) -> str:
+        raise RuntimeError("simulated crash before DB commit")
+
+    with monkeypatch.context() as m:
+        m.setattr("hermes_vault.vault.encrypt_secret_versioned", _boom)
+        with pytest.raises(RuntimeError, match="simulated crash before DB commit"):
+            vault.rotate_master_key("old-pass", "new-pass")
+
+    journal = salt.with_name(f"{salt.name}.rotation.json")
+    assert journal.exists()
+    entry = RotationJournalEntry.from_json(journal.read_text(encoding="utf-8"))
+    assert entry.phase() == JournalPhase.started
+
+    # Reopen with the OLD passphrase: safe pre-commit rollback.
+    recovered = Vault(db, salt, "old-pass")
+    secret = recovered.get_secret("openai")
+    assert secret is not None
+    assert secret.secret == "sk-test-1234"
+    assert not recovered.rotation_journal_path.exists()
+    assert salt.read_bytes() == original_salt
+
+    svc = AuditIntegrityService(db, recovered.key)
+    result = svc.verify()
+    assert result.status is AuditIntegrityStatus.healthy
+    assert result.active_segment_number == 1
+
+
+def test_contradictory_v2_journal_retained_on_reopen(tmp_path: Path) -> None:
+    """A db_committed journal whose old segment id contradicts the audit
+    registry fails closed: journal and durable material are retained."""
+    vault, db, salt = _seed_vault(tmp_path)
+    journal = salt.with_name(f"{salt.name}.rotation.json")
+
+    new_salt = os.urandom(16)
+    new_key = derive_key("new-pass", new_salt)
+    entry = RotationJournalEntry.start(
+        old_durable=DurableMaterial(kind=DurableKind.pbkdf_salt, salt=salt.read_bytes()),
+        new_durable=DurableMaterial(kind=DurableKind.pbkdf_salt, salt=new_salt),
+        journal_id="contradict-journal",
+    )
+    recovery = encrypt_old_key_recovery(vault.key, new_key, entry.journal_id)
+    committed = entry.mark_db_committed(
+        old_segment_id="seg-does-not-exist",
+        old_key_recovery=recovery,
+    )
+    journal.write_text(committed.to_json(), encoding="utf-8")
+    original_salt = salt.read_bytes()
+
+    with pytest.raises(RotationRecoveryError, match="rotation journal"):
+        Vault(db, salt, "new-pass")
+
+    # Journal and durable key material are retained — never silently deleted.
+    assert journal.exists()
+    assert salt.read_bytes() == original_salt
+
+
+def test_legacy_v1_pending_journal_without_recovery_retained(tmp_path: Path) -> None:
+    """A legacy v1 pending journal lacks protected old-key recovery: retain it
+    and surface a clear recovery error rather than claiming success."""
+    vault, db, salt = _seed_vault(tmp_path)
+    journal = salt.with_name(f"{salt.name}.rotation.json")
+    v1 = {
+        "version": "rotation-journal-v1",
+        "status": "db_committed",
+        "old_salt": salt.read_bytes().hex(),
+        "new_salt": os.urandom(16).hex(),
+        "created_at": "2026-07-30T10:15:30+00:00",
+        "committed_at": "2026-07-30T10:15:45+00:00",
+        "audit_transition_state": "pending",
+        "old_segment_id": "seg-7f3a9c2e",
+    }
+    journal.write_text(json.dumps(v1, sort_keys=True), encoding="utf-8")
+    original_salt = salt.read_bytes()
+
+    with pytest.raises(RotationRecoveryError, match="old-key recovery|recovery"):
+        Vault(db, salt, "new-pass")
+
+    assert journal.exists()
+    assert salt.read_bytes() == original_salt
+
+
+def test_malformed_journal_retained_on_reopen(tmp_path: Path) -> None:
+    """Malformed JSON journal fails closed and is retained."""
+    vault, db, salt = _seed_vault(tmp_path)
+    journal = salt.with_name(f"{salt.name}.rotation.json")
+    journal.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(RotationRecoveryError, match="journal"):
+        Vault(db, salt, "old-pass")
+
+    assert journal.exists()
+
+
+def test_rotation_journal_contains_no_plaintext_key_or_passphrase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The v2 journal never stores a plaintext passphrase or master key."""
+    vault, db, salt = _seed_vault(tmp_path)
+
+    def _crash_rotate_segment(self: AuditIntegrityService, new_master_key: bytes) -> None:
+        raise RuntimeError("simulated crash")
+
+    with monkeypatch.context() as m:
+        m.setattr(AuditIntegrityService, "rotate_segment", _crash_rotate_segment)
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            vault.rotate_master_key("old-pass", "new-pass")
+
+    journal = salt.with_name(f"{salt.name}.rotation.json")
+    raw = journal.read_text(encoding="utf-8")
+    assert "old-pass" not in raw
+    assert "new-pass" not in raw
+    assert vault.key.hex() not in raw  # old master key never appears in plaintext
+    entry = RotationJournalEntry.from_json(raw)
+    assert entry.old_key_recovery is not None
+    assert entry.new_durable.salt is not None
+    new_key = derive_key("new-pass", entry.new_durable.salt)
+    assert new_key.hex() not in raw  # new master key never appears in plaintext
+
+
+def test_journal_deleted_only_after_healthy_audit_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Journal deletion is gated on healthy audit verification.
+
+    A recovery that cannot reach a healthy audit state keeps the journal and
+    the durable material; a healthy recovery deletes both only afterwards.
+    """
+    vault, db, salt = _seed_vault(tmp_path)
+    journal = salt.with_name(f"{salt.name}.rotation.json")
+
+    # Fault: reconcile the DB commit but make the audit transition fail.
+    def _crash_rotate_segment(self: AuditIntegrityService, new_master_key: bytes) -> None:
+        raise RuntimeError("simulated crash before audit rotation")
+
+    with monkeypatch.context() as m:
+        m.setattr(AuditIntegrityService, "rotate_segment", _crash_rotate_segment)
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            vault.rotate_master_key("old-pass", "new-pass")
+
+    # Break the recovery material so reconciliation cannot produce health:
+    # replace the journal with a contradictory old segment id.
+    entry = RotationJournalEntry.from_json(journal.read_text(encoding="utf-8"))
+    broken = entry.model_copy(update={"old_segment_id": "seg-gone"})
+    journal.write_text(broken.to_json(), encoding="utf-8")
+
+    with pytest.raises(RotationRecoveryError, match="rotation journal"):
+        Vault(db, salt, "new-pass")
+
+    # The journal survived the failed recovery — deletion is health-gated.
+    assert journal.exists()
+

--- a/tests/test_restore_atomicity.py
+++ b/tests/test_restore_atomicity.py
@@ -151,6 +151,72 @@ def test_restore_forged_active_lease_never_active(tmp_path: Path) -> None:
         assert restored.status is not LeaseStatus.active, "restored lease is still active"
 
 
+# ── 2b. Forged v2 evidence (review F3) ────────────────────────────────
+
+
+def test_restore_v2_marker_only_evidence_blocked(tmp_path: Path) -> None:
+    """A marker-only integrity payload must fail closed before any write.
+
+    Review F3 (SECURITY_REVIEW_62_66.md): the live restore path accepted a
+    v2 backup whose audit_integrity carried only ``integrity_available:
+    true`` (no state/segments/records). The live gate must detached-verify
+    the evidence and reject anything less than healthy — a forged marker is
+    not evidence.
+    """
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup = source.export_backup(include_audit=True)
+    backup["audit_integrity"] = {
+        "integrity_available": True,
+        "state": [],
+        "segments": [],
+        "records": [],
+    }
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    import shutil
+
+    shutil.copy(tmp_path / "src_salt.bin", tmp_path / "tgt_salt.bin")
+    vault = _make_vault(tmp_path, name="target.db", salt="tgt_salt.bin")
+
+    with pytest.raises(ValueError):
+        vault.import_backup(json.loads(backup_path.read_text(encoding="utf-8")))
+
+    # Nothing may be committed when the evidence contract is forged.
+    services = sorted(c.service for c in vault.list_credentials())
+    assert services == [], f"marker-only evidence restore left rows behind: {services}"
+
+
+def test_restore_v2_forged_garbage_evidence_blocked(tmp_path: Path) -> None:
+    """Structurally-present but forged evidence must fail closed (review F3).
+
+    The marker is present AND state/segments exist, but the payload cannot
+    detached-verify against the vault key. The live gate must treat this the
+    same as backup-verify: failed/incomplete evidence blocks the restore.
+    """
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup = source.export_backup(include_audit=True)
+    backup["audit_integrity"] = {
+        "integrity_available": True,
+        "state": [{"migration_state": "active", "active_segment_id": "forged-seg"}],
+        "segments": [{"segment_id": "forged-seg", "chain_version": "sha256-chain-v1"}],
+        "records": [],
+    }
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    import shutil
+
+    shutil.copy(tmp_path / "src_salt.bin", tmp_path / "tgt_salt.bin")
+    vault = _make_vault(tmp_path, name="target.db", salt="tgt_salt.bin")
+
+    with pytest.raises(ValueError):
+        vault.import_backup(json.loads(backup_path.read_text(encoding="utf-8")))
+
+    services = sorted(c.service for c in vault.list_credentials())
+    assert services == [], f"forged evidence restore left rows behind: {services}"
+
+
 # ── 3. Foreign linkage (restore path) ──────────────────────────────────
 
 

--- a/tests/test_restore_cli_gate.py
+++ b/tests/test_restore_cli_gate.py
@@ -211,6 +211,34 @@ def test_cli_restore_v2_missing_evidence_blocked(monkeypatch, tmp_path: Path) ->
     assert target.list_credentials() == []
 
 
+def test_cli_restore_v2_marker_only_evidence_blocked(monkeypatch, tmp_path: Path) -> None:
+    """F3: marker-only v2 evidence fails closed at the CLI (no write, exit 1).
+
+    Review F3: the live restore path accepted a v2 backup whose
+    audit_integrity carried only ``integrity_available: true``. The CLI must
+    reject it with a non-zero exit exactly like backup-verify does, and the
+    target vault must remain unchanged.
+    """
+    runner = CliRunner()
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup = source.export_backup(include_audit=True)
+    backup["audit_integrity"] = {
+        "integrity_available": True,
+        "state": [],
+        "segments": [],
+        "records": [],
+    }
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    target = _target_with_shared_key(tmp_path, source)
+    result = _restore(runner, backup_path, target, monkeypatch)
+
+    assert result.exit_code == 1, result.output
+    assert "audit integrity evidence" in result.output.lower(), result.output
+    assert target.list_credentials() == []
+
+
 def test_cli_restore_transaction_failure_surface(monkeypatch, tmp_path: Path) -> None:
     """Transaction failure (sqlite3.Error) is surfaced as a distinct class."""
     runner = CliRunner()
@@ -220,7 +248,7 @@ def test_cli_restore_transaction_failure_surface(monkeypatch, tmp_path: Path) ->
 
     target = _target_with_shared_key(tmp_path, source)
 
-    def boom(_backup, _replace: bool = True):
+    def boom(_backup, _replace: bool = True, agent_id: str = "operator"):
         raise sqlite3.OperationalError("database is locked")
 
     monkeypatch.setattr(target, "import_backup", boom)

--- a/tests/test_restore_toctou_checkpoint.py
+++ b/tests/test_restore_toctou_checkpoint.py
@@ -1,0 +1,269 @@
+"""Red tests for Issue #62B — restore TOCTOU and checkpoint atomicity seams (F5/F6).
+
+These tests encode the failure modes the F5/F6 repair must handle and are
+intentionally RED against the pre-repair codebase:
+
+F5 — preflight-to-transaction TOCTOU:
+- A writer that deletes a referenced credential AFTER the preflight
+  validation but BEFORE ``BEGIN IMMEDIATE`` must not produce a dangling
+  restored lease or a silently skipped credential replace. The lease
+  linkage and broker identity are re-verified inside the write
+  transaction, so the restore fails closed and commits nothing.
+
+F6 — checkpoint-after-commit atomicity:
+- When the protected restore audit event commits but the checkpoint file
+  write fails afterward, the restore must NOT be reported as blocked /
+  rolled back: the data is committed, so the failure surfaces as a
+  distinct ``RestoreCommittedCheckpointError`` and the chain verifies as
+  ``checkpoint_stale`` until the checkpoint is re-published.
+- A retry of the same restore must not append a duplicate protected
+  restore event: the event id is deterministic and the retry re-publishes
+  the checkpoint idempotently.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from hermes_vault.audit import AuditLogger
+from hermes_vault.audit_integrity.models import AuditIntegrityStatus
+from hermes_vault.audit_integrity.service import AuditIntegrityService
+from hermes_vault.cli import _hermes_group
+from hermes_vault.models import AccessLogRecord, Decision
+from hermes_vault.vault import RestoreCommittedCheckpointError, Vault
+
+PASSPHRASE = "test-passphrase"
+
+
+def _make_vault(tmp_path: Path, name: str = "vault.db", salt: str = "salt.bin") -> Vault:
+    return Vault(tmp_path / name, tmp_path / salt, PASSPHRASE)
+
+
+def _target_with_shared_key(tmp_path: Path, source: Vault) -> Vault:
+    shutil.copy(source.salt_path, tmp_path / "tgt_salt.bin")
+    return _make_vault(tmp_path, name="target.db", salt="tgt_salt.bin")
+
+
+def _write_backup(path: Path, backup: dict) -> Path:
+    path.write_text(json.dumps(backup, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _seed_healthy_chain(target: Vault) -> None:
+    """Seed one protected audit event so the restore path runs a protected chain."""
+    AuditLogger(target.db_path, master_key=target.key).record(
+        AccessLogRecord(
+            agent_id="operator",
+            service="*",
+            action="seed",
+            decision=Decision.allow,
+            reason="seed protected chain",
+        )
+    )
+
+
+def _restore_event_count(target: Vault) -> int:
+    with sqlite3.connect(target.db_path) as conn:
+        return int(conn.execute("SELECT COUNT(*) FROM access_logs WHERE action = 'restore'").fetchone()[0])
+
+
+def _fake_build(vault: Vault):
+    def _inner(prompt: bool = False):
+        return vault, object(), object(), object()
+
+    return _inner
+
+
+# ── F5: preflight-to-transaction TOCTOU ───────────────────────────────
+
+
+def test_restore_reverifies_lease_linkage_inside_transaction(tmp_path: Path, monkeypatch) -> None:
+    """A credential deleted after preflight must not yield a dangling restored lease.
+
+    The preflight validates the lease linkage against the pre-lock snapshot;
+    a concurrent writer deleting the referenced credential between the
+    preflight reads and BEGIN IMMEDIATE must be caught by the in-transaction
+    re-verification, which fails closed and commits nothing.
+    """
+    target = _make_vault(tmp_path, name="target.db", salt="tgt_salt.bin")
+    record = target.add_credential("openai", "sk-target", "api_key", alias="primary")
+    target.issue_lease(record.id, agent_id="agent-a", ttl_seconds=600)
+    _seed_healthy_chain(target)
+
+    # Backup carries the lease but no credentials: the lease references a
+    # credential that already exists in the target vault (preflight accepts it).
+    backup = target.export_backup()
+    backup["credentials"] = []
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    real_verify = AuditIntegrityService.verify
+
+    def concurrent_delete(self, *args, **kwargs):
+        # Simulate a writer that removes the referenced credential after the
+        # preflight reads but before the restore transaction.
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM credentials WHERE id = ?", (record.id,))
+            conn.commit()
+        return real_verify(self, *args, **kwargs)
+
+    monkeypatch.setattr(AuditIntegrityService, "verify", concurrent_delete)
+
+    with pytest.raises(ValueError, match="foreign credential linkage"):
+        target.import_backup(json.loads(backup_path.read_text(encoding="utf-8")))
+
+    # Nothing committed: no dangling lease row and no protected restore event.
+    assert _restore_event_count(target) == 0, "restore committed a protected event for a dangling lease"
+    assert target.list_credentials() == []
+
+
+def test_restore_reverifies_existing_credential_still_present(tmp_path: Path, monkeypatch) -> None:
+    """A credential being replaced that vanishes after preflight must block the restore.
+
+    The preflight captured an existing row to UPDATE; if a concurrent writer
+    removes it before the transaction, the in-transaction re-verification must
+    reject the restore instead of silently applying a zero-row UPDATE.
+    """
+    target = _make_vault(tmp_path, name="target.db", salt="tgt_salt.bin")
+    record = target.add_credential("openai", "sk-target", "api_key", alias="primary")
+    _seed_healthy_chain(target)
+
+    backup = target.export_backup()
+    backup_path = _write_backup(tmp_path / "backup.json", backup)
+
+    real_verify = AuditIntegrityService.verify
+
+    def concurrent_delete(self, *args, **kwargs):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM credentials WHERE id = ?", (record.id,))
+            conn.commit()
+        return real_verify(self, *args, **kwargs)
+
+    monkeypatch.setattr(AuditIntegrityService, "verify", concurrent_delete)
+
+    with pytest.raises(ValueError, match="removed while the restore was being prepared"):
+        target.import_backup(json.loads(backup_path.read_text(encoding="utf-8")))
+
+    assert _restore_event_count(target) == 0, "restore committed despite the referenced credential vanishing"
+    assert target.list_credentials() == []
+
+
+# ── F6: checkpoint-after-commit atomicity ─────────────────────────────
+
+
+def test_restore_checkpoint_failure_reports_committed_not_blocked(tmp_path: Path, monkeypatch) -> None:
+    """A checkpoint write failure after commit must not look like a rolled-back restore.
+
+    The restore data and its protected audit event are already committed when
+    the checkpoint publication runs; the failure surfaces as
+    ``RestoreCommittedCheckpointError`` (not a generic audit failure) and the
+    chain verifies ``checkpoint_stale`` until the checkpoint is re-published.
+    """
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup_path = _write_backup(tmp_path / "backup.json", source.export_backup())
+
+    target = _target_with_shared_key(tmp_path, source)
+    _seed_healthy_chain(target)
+
+    def failing_write(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("hermes_vault.audit_integrity.service.write_checkpoint", failing_write)
+
+    with pytest.raises(RestoreCommittedCheckpointError):
+        target.import_backup(json.loads(backup_path.read_text(encoding="utf-8")))
+
+    # Data committed despite the checkpoint publication failure.
+    services = sorted(c.service for c in target.list_credentials())
+    assert services == ["openai"], "restore data did not commit"
+    assert _restore_event_count(target) == 1, "protected restore event did not commit"
+
+    # Fail closed: the chain is verifiable only as checkpoint_stale (incomplete).
+    result = AuditIntegrityService(target.db_path, target.key).verify()
+    assert result.status == AuditIntegrityStatus.incomplete, f"expected incomplete, got {result.status}"
+    assert result.reason_code == "checkpoint_stale"
+
+
+def test_restore_retry_after_checkpoint_failure_is_idempotent(tmp_path: Path, monkeypatch) -> None:
+    """Retrying a restore whose checkpoint publication failed must not duplicate events.
+
+    Attempt 1 commits the restore and its protected event but fails to publish
+    the checkpoint. Attempt 2 re-runs the same backup: the deterministic event
+    id is already committed, so the retry skips the append, re-publishes the
+    checkpoint, and leaves exactly one protected restore event.
+    """
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup_path = _write_backup(tmp_path / "backup.json", source.export_backup())
+    backup = json.loads(backup_path.read_text(encoding="utf-8"))
+
+    target = _target_with_shared_key(tmp_path, source)
+    _seed_healthy_chain(target)
+
+    import hermes_vault.audit_integrity.service as audit_service_module
+
+    real_write_checkpoint = audit_service_module.write_checkpoint
+
+    def failing_write(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(audit_service_module, "write_checkpoint", failing_write)
+    with pytest.raises(RestoreCommittedCheckpointError):
+        target.import_backup(backup)
+    assert _restore_event_count(target) == 1
+
+    # Second attempt: checkpoint publication works again.
+    monkeypatch.setattr(audit_service_module, "write_checkpoint", real_write_checkpoint)
+    imported = target.import_backup(backup)
+
+    assert [c.service for c in imported] == ["openai"]
+    assert _restore_event_count(target) == 1, "retry appended a duplicate protected restore event"
+
+    # The retry re-published the checkpoint, so the chain is healthy again.
+    result = AuditIntegrityService(target.db_path, target.key).verify()
+    assert result.status == AuditIntegrityStatus.healthy, (
+        f"expected healthy, got {result.status} ({result.reason_code})"
+    )
+
+
+def test_cli_restore_checkpoint_failure_reports_committed_not_blocked(monkeypatch, tmp_path: Path) -> None:
+    """The CLI must never report a committed restore as blocked/rolled back.
+
+    A checkpoint publication failure after commit exits non-zero (fail closed
+    — the degraded audit state needs attention) but the message states the
+    restore committed and points at the checkpoint, not at a rolled-back
+    restore (issue #62B / F6).
+    """
+    runner = CliRunner()
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup_path = _write_backup(tmp_path / "backup.json", source.export_backup())
+
+    target = _target_with_shared_key(tmp_path, source)
+    _seed_healthy_chain(target)
+
+    def failing_write(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("hermes_vault.audit_integrity.service.write_checkpoint", failing_write)
+    monkeypatch.setattr("hermes_vault.cli.build_services", _fake_build(target))
+
+    result = runner.invoke(
+        _hermes_group,
+        ["restore", "--input", str(backup_path), "--yes"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "Restore committed" in result.output, result.output
+    assert "blocked" not in result.output.lower(), result.output
+    assert "checkpoint_stale" in result.output, result.output
+    # The restore data committed despite the checkpoint failure.
+    assert sorted(c.service for c in target.list_credentials()) == ["openai"]
+    assert _restore_event_count(target) == 1

--- a/tests/test_restore_toctou_checkpoint.py
+++ b/tests/test_restore_toctou_checkpoint.py
@@ -16,9 +16,9 @@ F6 — checkpoint-after-commit atomicity:
   rolled back: the data is committed, so the failure surfaces as a
   distinct ``RestoreCommittedCheckpointError`` and the chain verifies as
   ``checkpoint_stale`` until the checkpoint is re-published.
-- A retry of the same restore must not append a duplicate protected
-  restore event: the event id is deterministic and the retry re-publishes
-  the checkpoint idempotently.
+- A retry of the same restore by the same acting agent must not append a duplicate protected
+  restore event: the event id is deterministic and the retry re-publishes the
+  checkpoint idempotently.
 """
 
 from __future__ import annotations
@@ -230,6 +230,33 @@ def test_restore_retry_after_checkpoint_failure_is_idempotent(tmp_path: Path, mo
     assert result.status == AuditIntegrityStatus.healthy, (
         f"expected healthy, got {result.status} ({result.reason_code})"
     )
+
+
+def test_identical_backup_restores_keep_distinct_protected_actor_attribution(tmp_path: Path) -> None:
+    """Different actors restoring identical content get distinct protected restore events.
+
+    F6 retries remain idempotent for the same acting agent, but the event identity
+    must not collapse a real second actor into the first actor's restore record
+    (F4/F6 interaction).
+    """
+    source = _make_vault(tmp_path, name="src.db", salt="src_salt.bin")
+    source.add_credential("openai", "sk-secret", "api_key", alias="primary")
+    backup = source.export_backup()
+
+    target = _target_with_shared_key(tmp_path, source)
+    _seed_healthy_chain(target)
+
+    target.import_backup(backup, agent_id="pam")
+    target.import_backup(backup, agent_id="bob")
+
+    with sqlite3.connect(target.db_path) as conn:
+        rows = conn.execute(
+            "SELECT agent_id FROM access_logs WHERE action = 'restore' ORDER BY timestamp"
+        ).fetchall()
+    assert [row[0] for row in rows] == ["pam", "bob"]
+    assert _restore_event_count(target) == 2
+    assert AuditIntegrityService(target.db_path, target.key).verify().status == AuditIntegrityStatus.healthy
+
 
 
 def test_cli_restore_checkpoint_failure_reports_committed_not_blocked(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Complete the live backup-restore hardening for Issue #62.
- Wire typed `rotation-journal-v2` recovery into the live Vault rotate/reopen path for Issue #66.
- Preserve detached evidence verification, lease identity checks, audit-lock/transaction atomicity, and checkpoint-after-commit semantics.
- Scope deterministic protected restore event IDs by acting agent: same-agent retries remain idempotent, while distinct actors restoring identical content retain distinct protected attribution.

## What changed
- Revalidate restore lease linkage and broker identity inside the write transaction.
- Require healthy detached audit evidence for v2 restores before mutation.
- Hold the audit write lock across the health gate and restore transaction.
- Publish the protected audit event atomically with credentials and leases.
- Surface post-commit checkpoint publication failure as a distinct committed-restore error.
- Wire typed rotation journal recovery into rotate/reopen and preserve journal evidence through ambiguous crash states.
- Add regression coverage for TOCTOU, checkpoint retry, same-agent idempotency, and cross-agent attribution.

## Verification
- Focused restore/rotation suite: 113 passed.
- Full core + Secret Source plugin suite: 1,191 passed.
- Ruff: clean.
- mypy: clean across 64 source files.
- Package build: `hermes_vault-0.24.0.tar.gz` and `hermes_vault-0.24.0-py3-none-any.whl`.
- Disposable live smoke: rotation/reopen readable; audit healthy after rotation; two identical restores recorded protected actors `pam` and `bob`; audit healthy after restore.

Closes #62
Closes #66
